### PR TITLE
fix(infra): workflows stuck with default settings

### DIFF
--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -23,7 +23,7 @@ resources:
 
 autoscaling:
   enabled: true
-  minReplicas: 2
+  minReplicas: 4
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80


### PR DESCRIPTION
### Issues Closed

- PARA-12535

### Brief Summary

Changed minimum `worker-workflows` to 4.

### Detailed Summary

The default deployment settings result in only 2 `worker-workflows` pods. These are then consumed by system queues with low compute requirements. So they don't have to scale up for load. All new workflow steps then stall since there is no worker capacity. This increases minimum to 4 so there is spare capacity by default.

### Changes

- changed `minReplicas` to 4