### PR TITLE
fix(redis): set default cluster flag correctly

### DIFF
--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -50,7 +50,7 @@
 | <a name="input_cloudflare_tunnel_zone_id"></a> [cloudflare\_tunnel\_zone\_id](#input\_cloudflare\_tunnel\_zone\_id) | Zone ID for Cloudflare domain | `string` | `""` | no |
 | <a name="input_disable_cloudtrail"></a> [disable\_cloudtrail](#input\_disable\_cloudtrail) | Used to specify that Cloudtrail is disabled. | `bool` | `true` | no |
 | <a name="input_disable_deletion_protection"></a> [disable\_deletion\_protection](#input\_disable\_deletion\_protection) | Used to disable deletion protection on RDS and S3 resources. | `bool` | `false` | no |
-| <a name="input_eks_admin_arns"></a> [eks\_admin\_arns](#input\_eks\_admin\_arns) | Array of ARNs for IAM users or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard. | `list(string)` | `null` | no |
+| <a name="input_eks_admin_arns"></a> [eks\_admin\_arns](#input\_eks\_admin\_arns) | Array of ARNs for IAM users or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard. | `list(string)` | `[]` | no |
 | <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `30` | no |
 | <a name="input_eks_min_node_count"></a> [eks\_min\_node\_count](#input\_eks\_min\_node\_count) | The minimum number of nodes to run in the Kubernetes cluster. | `number` | `4` | no |
 | <a name="input_eks_ondemand_node_instance_type"></a> [eks\_ondemand\_node\_instance\_type](#input\_eks\_ondemand\_node\_instance\_type) | The compute instance type to use for Kubernetes nodes. | `string` | `"t3a.large,t3.large"` | no |

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -330,7 +330,7 @@ locals {
   ]
 
   default_redis_cluster = try(
-    local.helm_vars.global.env["REDIS_CLSUTER"],
+    local.helm_vars.global.env["REDIS_CLUSTER"],
     local.infra_vars.redis.value.cache.cluster,
     "false"
   )
@@ -343,8 +343,8 @@ locals {
 
   default_redis_url = try(
     local.helm_vars.global.env["REDIS_URL"],
-    "redis://${local.helm_vars.global.env["REDIS_HOST"]}:${local.helm_vars.global.env["REDIS_PORT"]}",
-    "redis://${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
+    "${local.helm_vars.global.env["REDIS_HOST"]}:${local.helm_vars.global.env["REDIS_PORT"]}",
+    "${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
   )
 
   helm_values = merge(local.helm_vars, {
@@ -352,11 +352,11 @@ locals {
       env = merge(local.helm_vars.global.env, {
         for key, value in merge({
           // default values, can be overridden by `values.yaml -> global.env`
-          NODE_ENV              = "production"
-          PLATFORM_ENV          = "enterprise"
-          BRANCH                = "master"
-          SENDGRID_API_KEY      = "SG.xxx"
-          EMAIL_FROM_ADDRESS    = "not-a-real@email.com"
+          NODE_ENV           = "production"
+          PLATFORM_ENV       = "enterprise"
+          BRANCH             = "main"
+          SENDGRID_API_KEY   = "SG.xxx"
+          EMAIL_FROM_ADDRESS = "not-a-real@email.com"
 
           ACCOUNT_PUBLIC_URL   = try(local.microservices.account.public_url, null)
           CERBERUS_PUBLIC_URL  = try(local.microservices.cerberus.public_url, null)
@@ -425,16 +425,16 @@ locals {
 
             CACHE_REDIS_CLUSTER_ENABLED    = try(local.infra_vars.redis.value.cache.cluster, local.default_redis_cluster)
             CACHE_REDIS_TLS_ENABLED        = try(local.infra_vars.redis.value.cache.ssl, local.default_redis_ssl)
-            CACHE_REDIS_URL                = try("redis://${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}", local.default_redis_url)
+            CACHE_REDIS_URL                = try("${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}", local.default_redis_url)
             QUEUE_REDIS_CLUSTER_ENABLED    = try(local.infra_vars.redis.value.queue.cluster, local.default_redis_cluster)
             QUEUE_REDIS_TLS_ENABLED        = try(local.infra_vars.redis.value.queue.ssl, local.default_redis_ssl)
-            QUEUE_REDIS_URL                = try("redis://${local.infra_vars.redis.value.queue.host}:${local.infra_vars.redis.value.queue.port}", local.default_redis_url)
+            QUEUE_REDIS_URL                = try("${local.infra_vars.redis.value.queue.host}:${local.infra_vars.redis.value.queue.port}", local.default_redis_url)
             SYSTEM_REDIS_CLUSTER_ENABLED   = try(local.infra_vars.redis.value.system.cluster, local.default_redis_cluster)
             SYSTEM_REDIS_TLS_ENABLED       = try(local.infra_vars.redis.value.system.ssl, local.default_redis_ssl)
-            SYSTEM_REDIS_URL               = try("redis://${local.infra_vars.redis.value.system.host}:${local.infra_vars.redis.value.system.port}", local.default_redis_url)
+            SYSTEM_REDIS_URL               = try("${local.infra_vars.redis.value.system.host}:${local.infra_vars.redis.value.system.port}", local.default_redis_url)
             WORKFLOW_REDIS_CLUSTER_ENABLED = try(local.infra_vars.redis.value.workflow.cluster, local.default_redis_cluster)
             WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
-            WORKFLOW_REDIS_URL             = try("redis://${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}", local.default_redis_url)
+            WORKFLOW_REDIS_URL             = try("${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}", local.default_redis_url)
 
             MINIO_BROWSER           = "off"
             MINIO_INSTANCE_COUNT    = "1"

--- a/gcp/workspaces/paragon/variables.tf
+++ b/gcp/workspaces/paragon/variables.tf
@@ -397,7 +397,7 @@ locals {
   ]
 
   default_redis_cluster = try(
-    local.helm_vars.global.env["REDIS_CLSUTER"],
+    local.helm_vars.global.env["REDIS_CLUSTER"],
     local.infra_vars.redis.value.cache.cluster,
     "false"
   )
@@ -410,8 +410,8 @@ locals {
 
   default_redis_url = try(
     local.helm_vars.global.env["REDIS_URL"],
-    "redis://${local.helm_vars.global.env["REDIS_HOST"]}:${local.helm_vars.global.env["REDIS_PORT"]}",
-    "redis://${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
+    "${local.helm_vars.global.env["REDIS_HOST"]}:${local.helm_vars.global.env["REDIS_PORT"]}",
+    "${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
   )
 
   helm_values = merge(local.helm_vars, {
@@ -419,11 +419,11 @@ locals {
       env = merge(local.helm_vars.global.env, {
         for key, value in merge({
           // default values, can be overridden by `values.yaml -> global.env`
-          NODE_ENV              = "production"
-          PLATFORM_ENV          = "enterprise"
-          BRANCH                = "master"
-          SENDGRID_API_KEY      = "SG.xxx"
-          EMAIL_FROM_ADDRESS    = "not-a-real@email.com"
+          NODE_ENV           = "production"
+          PLATFORM_ENV       = "enterprise"
+          BRANCH             = "main"
+          SENDGRID_API_KEY   = "SG.xxx"
+          EMAIL_FROM_ADDRESS = "not-a-real@email.com"
 
           ACCOUNT_PUBLIC_URL   = try(local.microservices.account.public_url, null)
           CERBERUS_PUBLIC_URL  = try(local.microservices.cerberus.public_url, null)
@@ -492,16 +492,16 @@ locals {
 
             CACHE_REDIS_CLUSTER_ENABLED    = try(local.infra_vars.redis.value.cache.cluster, local.default_redis_cluster)
             CACHE_REDIS_TLS_ENABLED        = try(local.infra_vars.redis.value.cache.ssl, local.default_redis_ssl)
-            CACHE_REDIS_URL                = try("redis://${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}", local.default_redis_url)
+            CACHE_REDIS_URL                = try("${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}", local.default_redis_url)
             QUEUE_REDIS_CLUSTER_ENABLED    = try(local.infra_vars.redis.value.queue.cluster, local.default_redis_cluster)
             QUEUE_REDIS_TLS_ENABLED        = try(local.infra_vars.redis.value.queue.ssl, local.default_redis_ssl)
-            QUEUE_REDIS_URL                = try("redis://${local.infra_vars.redis.value.queue.host}:${local.infra_vars.redis.value.queue.port}", local.default_redis_url)
+            QUEUE_REDIS_URL                = try("${local.infra_vars.redis.value.queue.host}:${local.infra_vars.redis.value.queue.port}", local.default_redis_url)
             SYSTEM_REDIS_CLUSTER_ENABLED   = try(local.infra_vars.redis.value.system.cluster, local.default_redis_cluster)
             SYSTEM_REDIS_TLS_ENABLED       = try(local.infra_vars.redis.value.system.ssl, local.default_redis_ssl)
-            SYSTEM_REDIS_URL               = try("redis://${local.infra_vars.redis.value.system.host}:${local.infra_vars.redis.value.system.port}", local.default_redis_url)
+            SYSTEM_REDIS_URL               = try("${local.infra_vars.redis.value.system.host}:${local.infra_vars.redis.value.system.port}", local.default_redis_url)
             WORKFLOW_REDIS_CLUSTER_ENABLED = try(local.infra_vars.redis.value.workflow.cluster, local.default_redis_cluster)
             WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
-            WORKFLOW_REDIS_URL             = try("redis://${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}", local.default_redis_url)
+            WORKFLOW_REDIS_URL             = try("${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}", local.default_redis_url)
 
             MINIO_BROWSER           = "off"
             MINIO_INSTANCE_COUNT    = "1"


### PR DESCRIPTION
### Issues Closed

- [PARA-12947](https://useparagon.atlassian.net/browse/PARA-12947)

### Brief Summary

Fixed redis cluster and TLS flag settings.

### Detailed Summary

The default values for redis cluster and TLS flag settings (e.g. `WORKFLOW_REDIS_CLUSTER_ENABLED` and `WORKFLOW_REDIS_TLS_ENABLED`) were using hardcoded values instead of falling back to values from the shared cluster. This resulted in pods having the cluster flag set incorrectly and restarting while trying to establish a connection in the health endpoint.

### Changes

- standardized redis env var defaults across cloud providers

### Unrelated Changes

- updated Terraform docs and linting

### Future Work

none

### Steps to Test

- deploy updates and verify that pods start cleanly without restarts

### QA Notes

none

### Deployment Notes

none

### Screenshots

Before
![image](https://github.com/user-attachments/assets/78a5aa1d-fe3e-4c2e-9167-89ce05b31193)

After
![image](https://github.com/user-attachments/assets/dc83e4c0-c7bf-43ac-9fea-e630eca55b87)


[PARA-12947]: https://useparagon.atlassian.net/browse/PARA-12947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ