### PR TITLE
Support GCP internal ingress schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,79 @@ After the infrastructure has been provisioned the output will be used as input t
 terraform output -json > ../paragon/.secure/infra-output.json
 ```
 
+This will produce an `infra-output.json` file that will generally follow the schema below. If the `infra` workspace is not being used to provision the infrastructure then a comparable JSON file will have to be created to be consumed by the `paragon` workspace. e.g.
+
+```json
+{
+  "cluster_name": {
+    "value": "<kubernetes-cluster-name>"
+  },
+  "logs_container": {
+    "value": "<logs-bucket-name>"
+  },
+  "minio": {
+    "value": {
+      "microservice_pass": "<service-password>",
+      "microservice_user": "<service-username>",
+      "private_bucket": "<private-bucket-name>",
+      "public_bucket": "<private-bucket-name>",
+      "root_password": "<iam-password>",
+      "root_user": "<iam-username>"
+    }
+  },
+  "postgres": {
+    "value": {
+      "cerberus": {
+        "database": "cerberus",
+        "host": "<host-endpoint-or-ip>",
+        "password": "<password>",
+        "port": "5432",
+        "user": "<password>"
+      },
+      "hermes": {
+        "database": "hermes",
+        "host": "<host-endpoint-or-ip>",
+        "password": "<password>",
+        "port": "5432",
+        "user": "<password>"
+      },
+      "zeus": {
+        "database": "zeus",
+        "host": "<host-endpoint-or-ip>",
+        "password": "<password>",
+        "port": "5432",
+        "user": "<password>"
+      }
+    }
+  },
+  "redis": {
+    "value": {
+      "cache": {
+        "cluster": true,
+        "host": "<host-endpoint-or-ip>",
+        "port": 6379,
+        "ssl": false
+      },
+      "queue": {
+        "cluster": false,
+        "host": "<host-endpoint-or-ip>",
+        "port": 6379,
+        "ssl": false
+      },
+      "system": {
+        "cluster": false,
+        "host": "<host-endpoint-or-ip>",
+        "port": 6379,
+        "ssl": false
+      }
+    }
+  },
+  "workspace": {
+    "value": "<resource-naming-prefix>"
+  }
+}
+```
+
 ### Paragon Deployment
 
 Once the infrastructure has been setup then standard Terraform commands can be used within the `<provider>/workspace/paragon` directory to provision the necessary resources. See the `paragon` README for your cloud provider more details and any required variables.
@@ -161,6 +234,12 @@ Each Paragon microservice requires variables that follow this format:
 2. **Create a `values.yaml` file**:
 
     Create a `values.yaml` file with the necessary configurations defined above or otherwise required by the charts.
+
+    The `paragon` Terraform workspace can be used to produce most of the `values.yaml` file even if not being used to apply it. This command will output the global yaml values.
+
+    ```bash
+    echo "yamlencode(yamldecode(nonsensitive(jsonencode(local.helm_values))))" | terraform console
+    ```
 
 3. **Deploy the Helm charts**:
 

--- a/aws/workspaces/paragon/alb/certificate.tf
+++ b/aws/workspaces/paragon/alb/certificate.tf
@@ -1,5 +1,5 @@
 module "acm_request_certificate" {
-  count   = var.acm_certificate_arn == null ? 1 : 0
+  count   = var.certificate == null ? 1 : 0
   source  = "cloudposse/acm-request-certificate/aws"
   version = "0.17.0"
 

--- a/aws/workspaces/paragon/alb/outputs.tf
+++ b/aws/workspaces/paragon/alb/outputs.tf
@@ -3,9 +3,9 @@ output "nameservers" {
   value       = aws_route53_zone.paragon.name_servers
 }
 
-output "acm_certificate_arn" {
+output "certificate" {
   description = "The ARN of the ACM certificate."
-  value       = var.acm_certificate_arn == null ? module.acm_request_certificate[0].arn : var.acm_certificate_arn
+  value       = var.certificate == null ? module.acm_request_certificate[0].arn : var.certificate
 }
 
 output "alb_arn" {

--- a/aws/workspaces/paragon/alb/variables.tf
+++ b/aws/workspaces/paragon/alb/variables.tf
@@ -8,7 +8,7 @@ variable "domain" {
   type        = string
 }
 
-variable "acm_certificate_arn" {
+variable "certificate" {
   description = "Optional ACM certificate ARN of an existing certificate to use with the load balancer."
   type        = string
 }

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -229,8 +229,8 @@ resource "helm_release" "paragon_on_prem" {
     for_each = var.public_microservices
 
     content {
-      name  = "${set.key}.ingress.acm_certificate_arn"
-      value = var.acm_certificate_arn
+      name  = "${set.key}.ingress.certificate"
+      value = var.certificate
     }
   }
 
@@ -374,8 +374,8 @@ resource "helm_release" "paragon_monitoring" {
     for_each = var.public_monitors
 
     content {
-      name  = "${set.key}.ingress.acm_certificate_arn"
-      value = var.acm_certificate_arn
+      name  = "${set.key}.ingress.certificate"
+      value = var.certificate
     }
   }
 

--- a/aws/workspaces/paragon/helm/variables.tf
+++ b/aws/workspaces/paragon/helm/variables.tf
@@ -62,7 +62,7 @@ variable "flipt_options" {
   sensitive   = true
 }
 
-variable "acm_certificate_arn" {
+variable "certificate" {
   description = "The ARN of domain certificate."
   type        = string
 }

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -1,7 +1,7 @@
 module "alb" {
   source = "./alb"
 
-  acm_certificate_arn      = var.acm_certificate_arn
+  certificate              = var.certificate
   cloudflare_dns_api_token = var.cloudflare_dns_api_token
   cloudflare_zone_id       = var.cloudflare_zone_id
   dns_provider             = var.dns_provider
@@ -16,7 +16,7 @@ module "alb" {
 module "helm" {
   source = "./helm"
 
-  acm_certificate_arn    = module.alb.acm_certificate_arn
+  certificate            = module.alb.certificate
   aws_region             = var.aws_region
   cluster_name           = local.cluster_name
   docker_email           = var.docker_email

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -29,7 +29,7 @@ variable "domain" {
   type        = string
 }
 
-variable "acm_certificate_arn" {
+variable "certificate" {
   description = "Optional ACM certificate ARN of an existing certificate to use with the load balancer."
   type        = string
   default     = null

--- a/charts/paragon-logging/charts/openobserve/templates/ingress.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- if eq .Values.global.env.HOST_ENV "AWS_K8" }}
   annotations:
     kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/group.name: {{ .Values.ingress.load_balancer_name | default "paragon" }}
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
     alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
@@ -39,10 +39,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-logging/charts/openobserve/values.yaml
+++ b/charts/paragon-logging/charts/openobserve/values.yaml
@@ -30,7 +30,7 @@ credsJson: ""
 
 ingress:
   enabled: false
-  # acm_certificate_arn: 'arn:aws:acm:<region>:<account>:certificate/<uuid>'
+  # certificate: 'arn:aws:acm:<region>:<account>:certificate/<uuid>'
   # className: ''
   # host: openobserve.<domain>.paragon.so
   # healthcheck_path: /healthz

--- a/charts/paragon-monitoring/charts/grafana/templates/ingress.yaml
+++ b/charts/paragon-monitoring/charts/grafana/templates/ingress.yaml
@@ -15,14 +15,14 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/group.name: "{{ .Values.ingress.load_balancer_name | default "paragon" }}"
     alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.load_balancer_name | default "paragon" }}
-    alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
     alb.ingress.kubernetes.io/success-codes: '200'
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -33,15 +33,18 @@ metadata:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
     {{- end }}
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
     service.beta.kubernetes.io/azure-load-balancer-type: "public"
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -51,10 +54,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-monitoring/charts/grafana/templates/ingress.yaml
+++ b/charts/paragon-monitoring/charts/grafana/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/group.name: "{{ .Values.ingress.load_balancer_name | default "paragon" }}"
     alb.ingress.kubernetes.io/load-balancer-name: {{ .Values.ingress.load_balancer_name | default "paragon" }}
-    alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
     alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
     alb.ingress.kubernetes.io/success-codes: '200'
@@ -33,7 +33,7 @@ metadata:
     kubernetes.io/ingress.class: nginx
     cert-manager.io/cluster-issuer: letsencrypt-prod
     {{- end }}
-    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
+    service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
     service.beta.kubernetes.io/azure-load-balancer-type: "public"
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
@@ -44,7 +44,7 @@ metadata:
     kubernetes.io/ingress.allow-http: "true"
     networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/paragon-monitoring/charts/grafana/values.yaml
+++ b/charts/paragon-monitoring/charts/grafana/values.yaml
@@ -63,7 +63,7 @@ securityContext:
   # runAsUser: 1000
 
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/account/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/account/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/account/values.yaml
+++ b/charts/paragon-onprem/charts/account/values.yaml
@@ -204,12 +204,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/cerberus/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/cerberus/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/cerberus/values.yaml
+++ b/charts/paragon-onprem/charts/cerberus/values.yaml
@@ -133,12 +133,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/connect/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/connect/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/connect/values.yaml
+++ b/charts/paragon-onprem/charts/connect/values.yaml
@@ -136,12 +136,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/dashboard/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/dashboard/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/dashboard/values.yaml
+++ b/charts/paragon-onprem/charts/dashboard/values.yaml
@@ -208,12 +208,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/hades/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/hades/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/hades/values.yaml
+++ b/charts/paragon-onprem/charts/hades/values.yaml
@@ -199,12 +199,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/hermes/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/hermes/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -189,12 +189,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/minio/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/minio/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -38,8 +38,11 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
     ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/minio/health/live" }}
   {{ end }}
@@ -51,10 +54,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/minio/templates/service.yaml
+++ b/charts/paragon-onprem/charts/minio/templates/service.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "minio.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
-  clusterIP: None
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/charts/paragon-onprem/charts/minio/values.yaml
+++ b/charts/paragon-onprem/charts/minio/values.yaml
@@ -72,12 +72,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/passport/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/passport/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/passport/values.yaml
+++ b/charts/paragon-onprem/charts/passport/values.yaml
@@ -128,12 +128,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/pheme/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/pheme/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/pheme/values.yaml
+++ b/charts/paragon-onprem/charts/pheme/values.yaml
@@ -191,12 +191,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/release/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/release/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -199,12 +199,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-actionkit/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -271,12 +271,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-actions/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -267,12 +267,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-credentials/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -267,12 +267,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-crons/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -266,12 +266,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-deployments/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -272,12 +272,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-proxy/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -275,12 +275,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-triggers/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -268,12 +268,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/worker-workflows/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -300,12 +300,8 @@ securityContext:
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# service:
-#   type: ClusterIP
-#   port: 80
-
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/charts/zeus/templates/ingress.yaml
+++ b/charts/paragon-onprem/charts/zeus/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     alb.ingress.kubernetes.io/healthy-threshold-count: '3'
     alb.ingress.kubernetes.io/unhealthy-threshold-count: '3'
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate_arn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificate }}
     alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=30
     {{- if hasKey .Values.ingress "ip_whitelist" }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.ingress.ip_whitelist }}
@@ -41,13 +41,13 @@ metadata:
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
   annotations:
     {{- if .Values.ingress.include_annotations }}
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
-    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    nginx.ingress.kubernetes.io/proxy-busy-buffers: 256k
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.loadBalancerName }}
+    ingress.gcp.kubernetes.io/pre-shared-cert: {{ .Values.ingress.certificate }}
+    kubernetes.io/ingress.allow-http: "true"
+    networking.gke.io/v1beta1.FrontendConfig: {{ .Values.ingress.frontendConfig }}
     {{- end }}
-    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/api/health" }}
+    ingress.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthcheck_path | default "/healthz" }}
   {{ end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -57,10 +57,7 @@ spec:
         - {{ .Values.ingress.host }}
       secretName: {{ .Values.tls_secret }}
   {{- else if eq .Values.global.env.HOST_ENV "GCP_K8" }}
-  tls:
-    - hosts:
-        - {{ .Values.ingress.host }}
-      secretName: {{ .Values.tls_secret }}
+  loadBalancerIP: {{ .Values.ingress.loadBalancerIP }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host }}

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -234,7 +234,7 @@ securityContext:
   # runAsUser: 1000
 
 ingress:
-  acm_certificate_arn: ''
+  certificate: ''
   enabled: true
   className: ''
   host: chart-example.local

--- a/charts/paragon-onprem/values.yaml
+++ b/charts/paragon-onprem/values.yaml
@@ -14,7 +14,7 @@ subchart:
   hermes:
     enabled: true
   minio:
-    enabled: true
+    enabled: false
   passport:
     enabled: true
   pheme:

--- a/gcp/workspaces/paragon/.terraform.lock.hcl
+++ b/gcp/workspaces/paragon/.terraform.lock.hcl
@@ -166,22 +166,3 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/time" {
-  version = "0.12.1"
-  hashes = [
-    "h1:JzYsPugN8Fb7C4NlfLoFu7BBPuRVT2/fCOdCaxshveI=",
-    "zh:090023137df8effe8804e81c65f636dadf8f9d35b79c3afff282d39367ba44b2",
-    "zh:26f1e458358ba55f6558613f1427dcfa6ae2be5119b722d0b3adb27cd001efea",
-    "zh:272ccc73a03384b72b964918c7afeb22c2e6be22460d92b150aaf28f29a7d511",
-    "zh:438b8c74f5ed62fe921bd1078abe628a6675e44912933100ea4fa26863e340e9",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:85c8bd8eefc4afc33445de2ee7fbf33a7807bc34eb3734b8eefa4e98e4cddf38",
-    "zh:98bbe309c9ff5b2352de6a047e0ec6c7e3764b4ed3dfd370839c4be2fbfff869",
-    "zh:9c7bf8c56da1b124e0e2f3210a1915e778bab2be924481af684695b52672891e",
-    "zh:d2200f7f6ab8ecb8373cda796b864ad4867f5c255cff9d3b032f666e4c78f625",
-    "zh:d8c7926feaddfdc08d5ebb41b03445166df8c125417b28d64712dccd9feef136",
-    "zh:e2412a192fc340c61b373d6c20c9d805d7d3dee6c720c34db23c2a8ff0abd71b",
-    "zh:e6ac6bba391afe728a099df344dbd6481425b06d61697522017b8f7a59957d44",
-  ]
-}

--- a/gcp/workspaces/paragon/README.md
+++ b/gcp/workspaces/paragon/README.md
@@ -50,7 +50,7 @@ No resources.
 | <a name="input_helm_yaml_path"></a> [helm\_yaml\_path](#input\_helm\_yaml\_path) | Path to helm values.yaml file. | `string` | `".secure/values.yaml"` | no |
 | <a name="input_infra_json"></a> [infra\_json](#input\_infra\_json) | JSON string of `infra` workspace variables to use instead of `infra_json_path` | `string` | `null` | no |
 | <a name="input_infra_json_path"></a> [infra\_json\_path](#input\_infra\_json\_path) | Path to `infra` workspace output JSON file. | `string` | `".secure/infra-output.json"` | no |
-| <a name="input_ingress_scheme"></a> [ingress\_scheme](#input\_ingress\_scheme) | Whether the load balancer is 'internet-facing' (public) or 'internal' (private) | `string` | `"internet-facing"` | no |
+| <a name="input_ingress_scheme"></a> [ingress\_scheme](#input\_ingress\_scheme) | Whether the load balancer is 'external' (public) or 'internal' (private) | `string` | `"external"` | no |
 | <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | The version of Kubernetes to run in the cluster. | `string` | `"1.31"` | no |
 | <a name="input_monitor_version"></a> [monitor\_version](#input\_monitor\_version) | The version of the Paragon monitors to install. | `string` | `null` | no |
 | <a name="input_monitors_enabled"></a> [monitors\_enabled](#input\_monitors\_enabled) | Specifies that monitors are enabled. | `bool` | `false` | no |
@@ -68,6 +68,7 @@ No resources.
 |------|-------------|
 | <a name="output_grafana_admin_email"></a> [grafana\_admin\_email](#output\_grafana\_admin\_email) | Grafana admin login email. |
 | <a name="output_grafana_admin_password"></a> [grafana\_admin\_password](#output\_grafana\_admin\_password) | Grafana admin login password. |
+| <a name="output_load_balancer"></a> [load\_balancer](#output\_load\_balancer) | Location of the load balancer |
 | <a name="output_pgadmin_admin_email"></a> [pgadmin\_admin\_email](#output\_pgadmin\_admin\_email) | PGAdmin admin login email. |
 | <a name="output_pgadmin_admin_password"></a> [pgadmin\_admin\_password](#output\_pgadmin\_admin\_password) | PGAdmin admin login password. |
 | <a name="output_uptime_webhook"></a> [uptime\_webhook](#output\_uptime\_webhook) | Uptime webhook URL |

--- a/gcp/workspaces/paragon/dns/dns.tf
+++ b/gcp/workspaces/paragon/dns/dns.tf
@@ -1,17 +1,18 @@
 data "cloudflare_zone" "zone" {
+  count   = var.enabled ? 1 : 0
   zone_id = var.cloudflare_zone_id
 }
 
 locals {
-  is_ip = can(regex("^\\d+\\.\\d+\\.\\d+\\.\\d+$", var.ingress_loadbalancer))
+  is_ip    = can(regex("^\\d+\\.\\d+\\.\\d+\\.\\d+$", var.ingress_loadbalancer))
+  zone     = var.enabled ? data.cloudflare_zone.zone[0].name : ""
+  wildcard = var.domain == local.zone ? "*" : "*.${replace(var.domain, ".${local.zone}", "")}"
 }
 
-resource "cloudflare_record" "cname" {
-  for_each = var.public_services
+resource "cloudflare_record" "dns" {
+  count = var.enabled ? 1 : 0
 
-  # strip protocol and domain from URL to get subdomain
-  name = replace(replace(each.value.public_url, "https://", ""), ".${data.cloudflare_zone.zone.name}", "")
-
+  name    = local.wildcard
   content = var.ingress_loadbalancer
   ttl     = 600
   type    = local.is_ip ? "A" : "CNAME"

--- a/gcp/workspaces/paragon/dns/variables.tf
+++ b/gcp/workspaces/paragon/dns/variables.tf
@@ -1,3 +1,9 @@
+variable "enabled" {
+  description = "Enable DNS module"
+  type        = bool
+  default     = true
+}
+
 variable "cloudflare_api_token" {
   description = "Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Zone `DNS`"
   type        = string
@@ -17,12 +23,4 @@ variable "domain" {
 variable "ingress_loadbalancer" {
   description = "The Ingress Load Balancer for our Microservices"
   type        = string
-}
-
-variable "public_services" {
-  description = "The services exposed to the public internet."
-  type = map(object({
-    port       = number
-    public_url = string
-  }))
 }

--- a/gcp/workspaces/paragon/helm/outputs.tf
+++ b/gcp/workspaces/paragon/helm/outputs.tf
@@ -1,5 +1,5 @@
 output "load_balancer" {
-  value = google_compute_address.loadbalancer.address
+  value = google_compute_global_address.loadbalancer.address
 }
 
 output "openobserve_email" {

--- a/gcp/workspaces/paragon/helm/variables.tf
+++ b/gcp/workspaces/paragon/helm/variables.tf
@@ -33,6 +33,11 @@ variable "docker_email" {
   type        = string
 }
 
+variable "domain" {
+  description = "The domain used for the application. Used to generate an SSL certificate and associates CNAMEs."
+  type        = string
+}
+
 variable "openobserve_email" {
   description = "OpenObserve admin login email."
   type        = string
@@ -106,8 +111,16 @@ variable "public_monitors" {
   }))
 }
 
+variable "public_services" {
+  description = "The services exposed to the public internet."
+  type = map(object({
+    port       = number
+    public_url = string
+  }))
+}
+
 variable "ingress_scheme" {
-  description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
+  description = "Whether the load balancer is 'external' (public) or 'internal' (private)"
   type        = string
 }
 

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -6,6 +6,7 @@ module "helm" {
   docker_password        = var.docker_password
   docker_registry_server = var.docker_registry_server
   docker_username        = var.docker_username
+  domain                 = var.domain
   flipt_options          = local.flipt_options
   helm_values            = local.helm_values
   ingress_scheme         = var.ingress_scheme
@@ -19,6 +20,7 @@ module "helm" {
   openobserve_password   = var.openobserve_password
   public_microservices   = local.public_microservices
   public_monitors        = local.public_monitors
+  public_services        = local.public_services
   region                 = var.region
   workspace              = local.workspace
 }
@@ -45,9 +47,9 @@ module "uptime" {
 module "dns" {
   source = "./dns"
 
+  enabled              = local.dns_enabled
   cloudflare_api_token = var.cloudflare_api_token
   cloudflare_zone_id   = var.cloudflare_zone_id
   domain               = var.domain
   ingress_loadbalancer = module.helm.load_balancer
-  public_services      = local.public_services
 }

--- a/gcp/workspaces/paragon/outputs.tf
+++ b/gcp/workspaces/paragon/outputs.tf
@@ -27,3 +27,8 @@ output "uptime_webhook" {
   value       = module.uptime.webhook
   sensitive   = true
 }
+
+output "load_balancer" {
+  description = "Location of the load balancer"
+  value       = module.helm.load_balancer
+}

--- a/gcp/workspaces/paragon/variables.tf
+++ b/gcp/workspaces/paragon/variables.tf
@@ -118,9 +118,9 @@ variable "excluded_microservices" {
 }
 
 variable "ingress_scheme" {
-  description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
+  description = "Whether the load balancer is 'external' (public) or 'internal' (private)"
   type        = string
-  default     = "internet-facing"
+  default     = "external"
 }
 
 variable "k8s_version" {
@@ -217,6 +217,8 @@ locals {
     organization = var.organization
     creator      = "terraform"
   }
+
+  dns_enabled = var.ingress_scheme != "internal" && var.cloudflare_api_token != null && var.cloudflare_zone_id != null
 
   infra_json_path = abspath(var.infra_json_path)
   infra_vars      = jsondecode(fileexists(local.infra_json_path) && var.infra_json == null ? file(local.infra_json_path) : var.infra_json)

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2025.2.20"
+version="2025.03.05"
 provider=${1:-aws}
 
 # allow calling from other directories


### PR DESCRIPTION
### Issues Closed

- PARA-12073

### Brief Summary

Changes GCP ingress to use GCE instead of Nginx to support switching beween internal and external access.

### Detailed Summary

Updated charts to change ingress attributes when deploying to GCP to use the native GCE load balancer. This provides better scalabilty without requiring compute resources on the cluster. It also switches from the LetsEncrypt certificate manager to the GCP managed certificates for the same reason. A public load balancer will be used `ingress_scheme=external` or a private one when `ingress_scheme=internal`.

A single ingress manifest is used in Terraform instead of the per service ones to minimize costs while also mitigating the need to increase GCP quotas for public IPs or URL Maps.

### Changes

- ingress chart changes
- GCP ingress and certificate Terraform changes

### Unrelated Changes

none

### Future Work

Update the Azure charts and Terraform to support the same functionality.

### Steps to Test

Deploy to GCP and ensure site is accessible and all resources created as expected.

### Screenshots

![image](https://github.com/user-attachments/assets/ddb10a0e-427e-4fa2-89a8-4d6cf4dafb17)

![image](https://github.com/user-attachments/assets/da812bb3-e1be-469c-9fdf-afb2bac3079a)

![image](https://github.com/user-attachments/assets/dbfb1d26-262a-4725-ad00-e2b6e28615ad)
