### PR TITLE
fix: set ingress ALB ARN for grafana

### DIFF
--- a/aws/workspaces/paragon/helm/data.tf
+++ b/aws/workspaces/paragon/helm/data.tf
@@ -5,3 +5,10 @@ data "aws_eks_cluster" "cluster" {
 data "aws_eks_cluster_auth" "cluster" {
   name = var.cluster_name
 }
+
+data "aws_lb" "load_balancer" {
+  name = var.workspace
+
+  # requires ingress for the controller and then logging/on-prem to deploy pods that trigger LB creation
+  depends_on = [helm_release.ingress, helm_release.paragon_logging, helm_release.paragon_on_prem]
+}

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -404,6 +404,11 @@ resource "helm_release" "paragon_monitoring" {
     value = var.k8s_version
   }
 
+  set {
+    name  = "global.env.MONITOR_GRAFANA_ALB_ARN"
+    value = data.aws_lb.load_balancer.arn_suffix
+  }
+
   depends_on = [
     helm_release.ingress,
     helm_release.paragon_on_prem,

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2025.2.20"
+version="2025.3.12"
 provider=${1:-aws}
 
 # allow calling from other directories


### PR DESCRIPTION
### Issues Closed

- PARA-13274

### Brief Summary

Set ingress ALB ARN for Grafana AWS ALB dashboards.

### Changes

- set `MONITOR_GRAFANA_ALB_ARN` env var

### Steps to Test

- apply changes and verify that AWS ALB dashboard displays data

### Screenshots

![image](https://github.com/user-attachments/assets/0efaac70-be30-4054-9ee5-aa04590fb0c8)