### PR TITLE
fix(charts): updated chart defaults

### DIFF
--- a/charts/paragon-logging/charts/fluent-bit/Chart.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/Chart.yaml
@@ -3,4 +3,4 @@ name: fluent-bit
 description: Fast and lightweight log processor and forwarder or Linux, OSX and BSD
 type: application
 version: __PARAGON_VERSION__
-appVersion: 3.0.7
+appVersion: 3.2.10

--- a/charts/paragon-logging/charts/fluent-bit/values.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/values.yaml
@@ -7,12 +7,10 @@ kind: DaemonSet
 replicaCount: 1
 
 image:
-  repository: cr.fluentbit.io/fluent/fluent-bit
-  # Overrides the image tag whose default is {{ .Chart.AppVersion }}
-  # Set to "-" to not use the default value
-  tag:
-  digest:
+  repository: fluent/fluent-bit
   pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: '3.2.10'
 
 testFramework:
   enabled: false
@@ -198,13 +196,13 @@ readinessProbe:
     path: /api/v1/health
     port: http
 
-resources: {}
-#   limits:
-#     cpu: 100m
-#     memory: 128Mi
-#   requests:
-#     cpu: 100m
-#     memory: 128Mi
+resources:
+  limits:
+    cpu: 0.5
+    memory: 256Mi
+  requests:
+    cpu: 0.1
+    memory: 64Mi
 
 ## only available if kind is Deployment
 ingress:
@@ -304,7 +302,7 @@ minReadySeconds:
 ##
 terminationGracePeriodSeconds:
 
-priorityClassName: ""
+priorityClassName: "system-node-critical"
 
 envKeys:
   - ZO_ROOT_USER_EMAIL
@@ -393,6 +391,8 @@ config:
         Tag kube.*
         Mem_Buf_Limit 20MB
         Skip_Long_Lines On
+        Buffer_Chunk_Size 64KB
+        Buffer_Max_Size 64KB
 
     [INPUT]
         Name systemd
@@ -409,6 +409,7 @@ config:
         Keep_Log Off
         K8S-Logging.Parser On
         K8S-Logging.Exclude On
+        Buffer_Size 512KB
 
     [FILTER]
         Name    grep
@@ -416,6 +417,11 @@ config:
         Logical_Op or
         Exclude $kubernetes['labels']['app.kubernetes.io/name'] fluent-bit
         Exclude $kubernetes['labels']['app.kubernetes.io/name'] openobserve
+
+    [FILTER]
+        Name modify
+        Match kube.*
+        Remove req_query_*
 
   ## https://docs.fluentbit.io/manual/pipeline/outputs
   outputs: |

--- a/charts/paragon-logging/charts/openobserve/Chart.yaml
+++ b/charts/paragon-logging/charts/openobserve/Chart.yaml
@@ -3,4 +3,4 @@ name: openobserve
 description: OpenObserve to aggregate and visualize log data
 type: application
 version: __PARAGON_VERSION__
-appVersion: "v0.13.1"
+appVersion: "v0.14.5"

--- a/charts/paragon-logging/charts/openobserve/values.yaml
+++ b/charts/paragon-logging/charts/openobserve/values.yaml
@@ -2,13 +2,13 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: public.ecr.aws/zinclabs/openobserve
   pullPolicy: IfNotPresent
-  tag: v0.13.1
-  # tag: v0.13.1-debug
+  tag: v0.14.5
+  # tag: v0.14.5-debug
 
 service:
   type: ClusterIP
@@ -16,11 +16,11 @@ service:
 
 resources:
   limits:
-    cpu: 2048m
+    cpu: 2
     memory: 2048Mi
   requests:
-    cpu: 256m
-    memory: 10Mi
+    cpu: 0.5
+    memory: 512Mi
 
 nameOverride: ''
 fullnameOverride: 'openobserve'

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -25,8 +25,8 @@ autoscaling:
   enabled: true
   minReplicas: 2
   maxReplicas: 10
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  targetCPUUtilizationPercentage: 40
+  targetMemoryUtilizationPercentage: 40
 
 secretName: "paragon-secrets"
 

--- a/charts/paragon-onprem/charts/pheme/values.yaml
+++ b/charts/paragon-onprem/charts/pheme/values.yaml
@@ -25,8 +25,8 @@ autoscaling:
   enabled: true
   minReplicas: 2
   maxReplicas: 2
-  targetCPUUtilizationPercentage: 70
-  targetMemoryUtilizationPercentage: 70
+  targetCPUUtilizationPercentage: 40
+  targetMemoryUtilizationPercentage: 40
 
 secretName: "paragon-secrets"
 

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -24,7 +24,7 @@ resources:
 
 autoscaling:
   enabled: true
-  minReplicas: 2
+  minReplicas: 4
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -23,7 +23,7 @@ resources:
 
 autoscaling:
   enabled: true
-  minReplicas: 2
+  minReplicas: 4
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -16,9 +16,11 @@ service:
 
 resources:
   limits:
+    cpu: 0.5
     memory: 1024Mi
   requests:
     cpu: 0.25
+    memory: 1024Mi
 
 autoscaling:
   enabled: true


### PR DESCRIPTION
### Issues Closed

- PARA-12865
- PARA-13235
- PARA-13368
- PARA-13477
- PARA-13484

### Brief Summary

Updated Helm chart default values to address various issues.

### Detailed Summary

PARA-12865 - filtered out `req_query_*` fields from OpenObserve to prevent indexing tens of thousands of potential query string parameters. This was causing major performance issues when trying to query all fields.

PARA-13235 - increased the default minimum number of `worker-triggers` and `worker-workflows` pods from 2 to 4.

PARA-13368 - set `priorityClassName` on `fluent-bit` to ensure logging pods are always scheduled. 

PARA-13477 - updated default `resources` and `autoscaling` settings for improved stability

PARA-13484 - upgraded `fluent-bit` image and configured buffer sizes to avoid 139 exit codes (`SIGSEGV`)

### Changes

- updated Helm chart `Charts.yaml` and `values.yaml`

### Unrelated Changes

none