### PR TITLE
Add support for local YAML-based feature flags

### DIFF
--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -10,6 +10,25 @@ locals {
         ]
       }
     }
+    persistence = var.feature_flags_content != null ? {
+      enabled = true
+    } : {}
+    extraVolumes = var.feature_flags_content != null ? [
+      {
+        name = "feature-flags-content"
+        configMap = {
+          name = kubernetes_config_map.feature_flag_content[0].metadata[0].name
+        }
+      }
+    ] : []
+    extraVolumeMounts = var.feature_flags_content != null ? [
+      {
+        name      = "feature-flags-content"
+        mountPath = "/var/opt/flipt/production/features.yml"
+        subPath   = "features.yml"
+        readOnly  = true
+      }
+    ] : []
   })
 
   global_values = yamlencode(merge(
@@ -82,6 +101,19 @@ resource "kubernetes_namespace" "paragon" {
     annotations = {
       name = "paragon"
     }
+  }
+}
+
+resource "kubernetes_config_map" "feature_flag_content" {
+  count = var.feature_flags_content != null ? 1 : 0
+
+  metadata {
+    name      = "feature-flags-content"
+    namespace = kubernetes_namespace.paragon.id
+  }
+
+  data = {
+    "features.yml" = var.feature_flags_content
   }
 }
 
@@ -258,7 +290,8 @@ resource "helm_release" "paragon_on_prem" {
     helm_release.ingress,
     kubernetes_secret.docker_login,
     kubernetes_secret.paragon_secrets,
-    kubernetes_storage_class_v1.gp3_encrypted
+    kubernetes_storage_class_v1.gp3_encrypted,
+    kubernetes_config_map.feature_flag_content
   ]
 }
 

--- a/aws/workspaces/paragon/helm/variables.tf
+++ b/aws/workspaces/paragon/helm/variables.tf
@@ -56,6 +56,12 @@ variable "helm_values" {
   sensitive   = true
 }
 
+variable "feature_flags_content" {
+  description = "Optional YAML content for feature flags when not using a git repository."
+  type        = string
+  default     = null
+}
+
 variable "flipt_options" {
   description = "Map of flipt configuration variables"
   type        = map(any)

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -23,6 +23,7 @@ module "helm" {
   docker_password        = var.docker_password
   docker_registry_server = var.docker_registry_server
   docker_username        = var.docker_username
+  feature_flags_content  = local.feature_flags_content
   flipt_options          = local.flipt_options
   helm_values            = local.helm_values
   ingress_scheme         = var.ingress_scheme

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -74,6 +74,12 @@ variable "excluded_microservices" {
   default     = []
 }
 
+variable "feature_flags" {
+  description = "Optional base64 encoded feature flags YAML content."
+  type        = string
+  default     = null
+}
+
 variable "ingress_scheme" {
   description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
   type        = string
@@ -564,17 +570,22 @@ locals {
 
   monitor_version = var.monitor_version != null ? var.monitor_version : try(local.helm_values.global.env["VERSION"], "latest")
 
+  feature_flags_content = var.feature_flags != null ? base64decode(var.feature_flags) : null
+
   flipt_options = {
     for key, value in merge(
       # user overrides
       local.helm_vars.global.env,
       {
         FLIPT_CACHE_ENABLED             = "true"
+        FLIPT_LOG_GRPC_LEVEL            = "warn"
+        FLIPT_LOG_LEVEL                 = "warn"
         FLIPT_STORAGE_GIT_POLL_INTERVAL = "30s"
         FLIPT_STORAGE_GIT_REF           = "main"
-        FLIPT_STORAGE_GIT_REPOSITORY    = "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_GIT_REPOSITORY    = local.feature_flags_content != null ? null : "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_LOCAL_PATH        = local.feature_flags_content != null ? "/var/opt/flipt" : null
         FLIPT_STORAGE_READ_ONLY         = "true"
-        FLIPT_STORAGE_TYPE              = "git"
+        FLIPT_STORAGE_TYPE              = local.feature_flags_content != null ? "local" : "git"
     }) :
     key => value
     if key != null && startswith(key, "FLIPT_") && value != null && value != ""

--- a/azure/workspaces/paragon/helm/helm.tf
+++ b/azure/workspaces/paragon/helm/helm.tf
@@ -62,6 +62,25 @@ locals {
             value = v
           }
         ]
+        persistence = var.feature_flags_content != null ? {
+          enabled = true
+        } : {}
+        extraVolumes = var.feature_flags_content != null ? [
+          {
+            name = "feature-flags-content"
+            configMap = {
+              name = kubernetes_config_map.feature_flag_content[0].metadata[0].name
+            }
+          }
+        ] : []
+        extraVolumeMounts = var.feature_flags_content != null ? [
+          {
+            name      = "feature-flags-content"
+            mountPath = "/var/opt/flipt/production/features.yml"
+            subPath   = "features.yml"
+            readOnly  = true
+          }
+        ] : []
       }
     }
   })
@@ -97,6 +116,19 @@ resource "kubernetes_namespace" "paragon" {
     annotations = {
       name = "paragon"
     }
+  }
+}
+
+resource "kubernetes_config_map" "feature_flag_content" {
+  count = var.feature_flags_content != null ? 1 : 0
+
+  metadata {
+    name      = "feature-flags-content"
+    namespace = kubernetes_namespace.paragon.id
+  }
+
+  data = {
+    "features.yml" = var.feature_flags_content
   }
 }
 
@@ -165,7 +197,8 @@ resource "helm_release" "paragon_on_prem" {
     helm_release.ingress,
     kubernetes_secret.docker_login,
     kubernetes_secret.paragon_secrets,
-    kubernetes_secret.microservices
+    kubernetes_secret.microservices,
+    kubernetes_config_map.feature_flag_content
   ]
 }
 

--- a/azure/workspaces/paragon/helm/variables.tf
+++ b/azure/workspaces/paragon/helm/variables.tf
@@ -55,6 +55,12 @@ variable "helm_values" {
   sensitive   = true
 }
 
+variable "feature_flags_content" {
+  description = "Optional YAML content for feature flags when not using a git repository."
+  type        = string
+  default     = null
+}
+
 variable "flipt_options" {
   description = "Map of flipt configuration variables"
   type        = map(any)

--- a/azure/workspaces/paragon/modules.tf
+++ b/azure/workspaces/paragon/modules.tf
@@ -6,6 +6,7 @@ module "helm" {
   docker_password        = var.docker_password
   docker_registry_server = var.docker_registry_server
   docker_username        = var.docker_username
+  feature_flags_content  = local.feature_flags_content
   flipt_options          = local.flipt_options
   helm_values            = local.helm_values
   ingress_scheme         = var.ingress_scheme

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -73,6 +73,12 @@ variable "excluded_microservices" {
   default     = []
 }
 
+variable "feature_flags" {
+  description = "Optional base64 encoded feature flags YAML content."
+  type        = string
+  default     = null
+}
+
 variable "ingress_scheme" {
   description = "Whether the load balancer is 'internet-facing' (public) or 'internal' (private)"
   type        = string
@@ -541,17 +547,22 @@ locals {
 
   monitor_version = var.monitor_version != null ? var.monitor_version : try(local.helm_values.global.env["VERSION"], "latest")
 
+  feature_flags_content = var.feature_flags != null ? base64decode(var.feature_flags) : null
+
   flipt_options = {
     for key, value in merge(
       # user overrides
       local.helm_vars.global.env,
       {
         FLIPT_CACHE_ENABLED             = "true"
+        FLIPT_LOG_GRPC_LEVEL            = "warn"
+        FLIPT_LOG_LEVEL                 = "warn"
         FLIPT_STORAGE_GIT_POLL_INTERVAL = "30s"
         FLIPT_STORAGE_GIT_REF           = "main"
-        FLIPT_STORAGE_GIT_REPOSITORY    = "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_GIT_REPOSITORY    = local.feature_flags_content != null ? null : "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_LOCAL_PATH        = local.feature_flags_content != null ? "/var/opt/flipt" : null
         FLIPT_STORAGE_READ_ONLY         = "true"
-        FLIPT_STORAGE_TYPE              = "git"
+        FLIPT_STORAGE_TYPE              = local.feature_flags_content != null ? "local" : "git"
     }) :
     key => value
     if key != null && startswith(key, "FLIPT_") && value != null && value != ""

--- a/gcp/workspaces/paragon/helm/helm.tf
+++ b/gcp/workspaces/paragon/helm/helm.tf
@@ -72,6 +72,25 @@ locals {
             value = v
           }
         ]
+        persistence = var.feature_flags_content != null ? {
+          enabled = true
+        } : {}
+        extraVolumes = var.feature_flags_content != null ? [
+          {
+            name = "feature-flags-content"
+            configMap = {
+              name = kubernetes_config_map.feature_flag_content[0].metadata[0].name
+            }
+          }
+        ] : []
+        extraVolumeMounts = var.feature_flags_content != null ? [
+          {
+            name      = "feature-flags-content"
+            mountPath = "/var/opt/flipt/production/features.yml"
+            subPath   = "features.yml"
+            readOnly  = true
+          }
+        ] : []
       }
     }
   })
@@ -107,6 +126,19 @@ resource "kubernetes_namespace" "paragon" {
     annotations = {
       name = "paragon"
     }
+  }
+}
+
+resource "kubernetes_config_map" "feature_flag_content" {
+  count = var.feature_flags_content != null ? 1 : 0
+
+  metadata {
+    name      = "feature-flags-content"
+    namespace = kubernetes_namespace.paragon.id
+  }
+
+  data = {
+    "features.yml" = var.feature_flags_content
   }
 }
 
@@ -173,7 +205,8 @@ resource "helm_release" "paragon_on_prem" {
 
   depends_on = [
     kubernetes_secret.docker_login,
-    kubernetes_secret.paragon_secrets
+    kubernetes_secret.paragon_secrets,
+    kubernetes_config_map.feature_flag_content
   ]
 }
 

--- a/gcp/workspaces/paragon/helm/variables.tf
+++ b/gcp/workspaces/paragon/helm/variables.tf
@@ -61,6 +61,12 @@ variable "helm_values" {
   sensitive   = true
 }
 
+variable "feature_flags_content" {
+  description = "Optional YAML content for feature flags when not using a git repository."
+  type        = string
+  default     = null
+}
+
 variable "flipt_options" {
   description = "Map of flipt configuration variables"
   type        = map(any)

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -7,6 +7,7 @@ module "helm" {
   docker_registry_server = var.docker_registry_server
   docker_username        = var.docker_username
   domain                 = var.domain
+  feature_flags_content  = local.feature_flags_content
   flipt_options          = local.flipt_options
   helm_values            = local.helm_values
   ingress_scheme         = var.ingress_scheme

--- a/gcp/workspaces/paragon/variables.tf
+++ b/gcp/workspaces/paragon/variables.tf
@@ -117,6 +117,12 @@ variable "excluded_microservices" {
   default     = []
 }
 
+variable "feature_flags" {
+  description = "Optional base64 encoded feature flags YAML content."
+  type        = string
+  default     = null
+}
+
 variable "ingress_scheme" {
   description = "Whether the load balancer is 'external' (public) or 'internal' (private)"
   type        = string
@@ -611,17 +617,22 @@ locals {
 
   monitor_version = var.monitor_version != null ? var.monitor_version : try(local.helm_values.global.env["VERSION"], "latest")
 
+  feature_flags_content = var.feature_flags != null ? base64decode(var.feature_flags) : null
+
   flipt_options = {
     for key, value in merge(
       # user overrides
       local.helm_vars.global.env,
       {
         FLIPT_CACHE_ENABLED             = "true"
+        FLIPT_LOG_GRPC_LEVEL            = "warn"
+        FLIPT_LOG_LEVEL                 = "warn"
         FLIPT_STORAGE_GIT_POLL_INTERVAL = "30s"
         FLIPT_STORAGE_GIT_REF           = "main"
-        FLIPT_STORAGE_GIT_REPOSITORY    = "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_GIT_REPOSITORY    = local.feature_flags_content != null ? null : "https://github.com/useparagon/feature-flags.git"
+        FLIPT_STORAGE_LOCAL_PATH        = local.feature_flags_content != null ? "/var/opt/flipt" : null
         FLIPT_STORAGE_READ_ONLY         = "true"
-        FLIPT_STORAGE_TYPE              = "git"
+        FLIPT_STORAGE_TYPE              = local.feature_flags_content != null ? "local" : "git"
     }) :
     key => value
     if key != null && startswith(key, "FLIPT_") && value != null && value != ""


### PR DESCRIPTION
Introduced the ability to use locally defined feature flags via YAML instead of the default Git-based configuration. This includes adding support for optional feature flag variables, a `ConfigMap` resource, and corresponding volume mounts in Helm configurations across AWS, Azure, and GCP deployments