### PR TITLE
fix: avoid image pull throttling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ main.tf
 
 # only keep the top level charts
 **/paragon/charts
+
+# ignore IDE files
+.idea

--- a/charts/paragon-logging/charts/fluent-bit/values.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/values.yaml
@@ -21,7 +21,9 @@ testFramework:
     tag: latest
     digest:
 
-imagePullSecrets: []
+imagePullSecrets:
+  - name: docker-cfg
+
 nameOverride: "fluent-bit"
 fullnameOverride: "fluent-bit"
 
@@ -200,8 +202,8 @@ resources:
     cpu: 0.5
     memory: 256Mi
   requests:
-    cpu: 0.1
-    memory: 64Mi
+    cpu: 0.2
+    memory: 100Mi
 
 ## only available if kind is Deployment
 ingress:
@@ -386,10 +388,10 @@ config:
         Path /var/log/containers/*.log
         multiline.parser docker, cri
         Tag kube.*
-        Mem_Buf_Limit 20MB
+        Mem_Buf_Limit 50MB
         Skip_Long_Lines On
-        Buffer_Chunk_Size 64KB
-        Buffer_Max_Size 64KB
+        Buffer_Chunk_Size 128KB
+        Buffer_Max_Size 128KB
 
     [INPUT]
         Name systemd
@@ -406,7 +408,7 @@ config:
         Keep_Log Off
         K8S-Logging.Parser On
         K8S-Logging.Exclude On
-        Buffer_Size 512KB
+        Buffer_Size 1MB
 
     [FILTER]
         Name    grep
@@ -428,11 +430,12 @@ config:
         Host openobserve
         Port 5080
         Index paragon
-        Retry_Limit False
+        Retry_Limit 10
         Path /api/default
         Suppress_Type_Name On
         HTTP_User {{ .Values.secrets.ZO_ROOT_USER_EMAIL }}
         HTTP_Passwd {{ .Values.secrets.ZO_ROOT_USER_PASSWORD }}
+        Buffer_Size 1MB
 
   ## https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/upstream-servers
   ## This configuration is deprecated, please use `extraFiles` instead.

--- a/charts/paragon-onprem/charts/flipt/values.yaml
+++ b/charts/paragon-onprem/charts/flipt/values.yaml
@@ -7,7 +7,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
+imagePullSecrets:
+  - name: docker-cfg
+  
 nameOverride: ""
 fullnameOverride: "flipt"
 
@@ -91,13 +93,12 @@ ingress:
   #      - chart-example.local
 
 resources:
-  {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi
 
 autoscaling:
   enabled: true

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -19,7 +19,7 @@ resources:
     cpu: 0.5
     memory: 1024Mi
   requests:
-    cpu: 0.25
+    cpu: 0.5
     memory: 1024Mi
 
 autoscaling:

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2025.5.1"
+version="2025.5.9"
 provider=${1:-aws}
 
 # allow calling from other directories


### PR DESCRIPTION
### Issues Closed

- PARA-13663

### Brief Summary

Updated public images to use docker creds to avoid pull limits. Increased logging buffers.

### Detailed Summary

Large deployments (50+ k8s nodes) could run into crash loops trying to pull public images (`fluent-bit` and `flipt`) from Docker Hub anonymously. Adding the `imagePullSecrets` login that is used for the private images avoids this.

`fluent-bit` was also running into cases when logs were potentially lost due to buffer limits. So these were increased.

Increased `zeus` request CPU to match limit since spikes in CPU were causing HPA to autoscale too aggressively.

### Changes

- helm chart changes

### Unrelated Changes

- added `.idea` to `.gitignore`

### Steps to Test

- deploy updated charts and verify all services start cleanly and scale appropriately paying special attention to fluent-bit