### PR TITLE
fix: correct flipt_values nesting

### DIFF
--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -9,26 +9,26 @@ locals {
           }
         ]
       }
-    }
-    persistence = var.feature_flags_content != null ? {
-      enabled = true
-    } : {}
-    extraVolumes = var.feature_flags_content != null ? [
-      {
-        name = "feature-flags-content"
-        configMap = {
-          name = kubernetes_config_map.feature_flag_content[0].metadata[0].name
+      persistence = var.feature_flags_content != null ? {
+        enabled = true
+      } : {}
+      extraVolumes = var.feature_flags_content != null ? [
+        {
+          name = "feature-flags-content"
+          configMap = {
+            name = kubernetes_config_map.feature_flag_content[0].metadata[0].name
+          }
         }
-      }
-    ] : []
-    extraVolumeMounts = var.feature_flags_content != null ? [
-      {
-        name      = "feature-flags-content"
-        mountPath = "/var/opt/flipt/production/features.yml"
-        subPath   = "features.yml"
-        readOnly  = true
-      }
-    ] : []
+      ] : []
+      extraVolumeMounts = var.feature_flags_content != null ? [
+        {
+          name      = "feature-flags-content"
+          mountPath = "/var/opt/flipt/production/features.yml"
+          subPath   = "features.yml"
+          readOnly  = true
+        }
+      ] : []
+    }
   })
 
   global_values = yamlencode(merge(


### PR DESCRIPTION
### Issues Closed

- PARA-13788

### Brief Summary

fix flipt options indentation in helm chart

### Detailed Summary

Fixed the indentation of Flipt configuration options in the Helm chart to ensure proper YAML structure. The previous indentation was causing issues with the feature flags configuration.

### Changes

- Fixed indentation of `persistence`, `extraVolumes`, and `extraVolumeMounts` configurations in `aws/workspaces/paragon/helm/helm.tf`
- Properly nested Flipt configuration options under the `flipt` key

### Unrelated Changes

None

### Future Work

Consider adding validation for YAML structure in the Helm chart to catch similar issues earlier.

### Steps to Test

1. Deploy the updated Helm chart
2. Verify that Flipt feature flags are properly loaded
3. Confirm that the feature flags configuration is accessible at `/var/opt/flipt/production/features.yml`

### QA Notes

No special QA considerations needed - this is a configuration fix only.