### PR TITLE
Add health-checker microservice support to uptime module

### DIFF
--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -56,7 +56,8 @@ module "monitors" {
 module "uptime" {
   source = "./uptime"
 
-  uptime_api_token = var.uptime_api_token
-  uptime_company   = coalesce(var.uptime_company, var.organization)
-  microservices    = local.public_microservices
+  uptime_api_token            = var.uptime_api_token
+  uptime_company              = coalesce(var.uptime_company, var.organization)
+  microservices               = local.public_microservices
+  health-checker-microservice = local.all_microservices.health-checker
 }

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -58,6 +58,5 @@ module "uptime" {
 
   uptime_api_token            = var.uptime_api_token
   uptime_company              = coalesce(var.uptime_company, var.organization)
-  microservices               = local.public_microservices
-  health-checker-microservice = local.all_microservices.health-checker
+  health_checker_microservice = local.all_microservices.health-checker
 }

--- a/aws/workspaces/paragon/uptime/monitors.tf
+++ b/aws/workspaces/paragon/uptime/monitors.tf
@@ -17,9 +17,7 @@ data "betteruptime_policy" "escalation" {
 }
 
 resource "betteruptime_monitor" "monitor" {
-  for_each = local.enabled ? var.microservices : {}
-
-  pronounceable_name = "Enterprise ${var.uptime_company} - Microservice ${each.key}"
+  pronounceable_name = "Enterprise ${var.uptime_company}"
 
   check_frequency       = 30  # seconds
   confirmation_period   = 120 # seconds
@@ -34,7 +32,7 @@ resource "betteruptime_monitor" "monitor" {
   request_timeout       = 15  # seconds
   ssl_expiration        = 14  # days
   team_wait             = 180 # seconds
-  url                   = "${each.value.public_url}${each.value.healthcheck_path}"
+  url                   = var.health-checker-microservice.public_url
 
   call  = true
   email = true

--- a/aws/workspaces/paragon/uptime/monitors.tf
+++ b/aws/workspaces/paragon/uptime/monitors.tf
@@ -32,7 +32,7 @@ resource "betteruptime_monitor" "monitor" {
   request_timeout       = 15  # seconds
   ssl_expiration        = 14  # days
   team_wait             = 180 # seconds
-  url                   = var.health-checker-microservice.public_url
+  url                   = var.health_checker_microservice.public_url
 
   call  = true
   email = true

--- a/aws/workspaces/paragon/uptime/variables.tf
+++ b/aws/workspaces/paragon/uptime/variables.tf
@@ -21,12 +21,7 @@ variable "uptime_regions" {
   default     = ["as", "au", "eu", "us"]
 }
 
-variable "microservices" {
-  description = "The microservices to create monitors for."
-  type        = map(any)
-}
-
-variable "health-checker-microservice" {
+variable "health_checker_microservice" {
   description = "The information about the health-checker microservice"
   type        = map(any)
 }

--- a/aws/workspaces/paragon/uptime/variables.tf
+++ b/aws/workspaces/paragon/uptime/variables.tf
@@ -26,6 +26,11 @@ variable "microservices" {
   type        = map(any)
 }
 
+variable "health-checker-microservice" {
+  description = "The information about the health-checker microservice"
+  type        = map(any)
+}
+
 locals {
   enabled = var.uptime_api_token != null
 }

--- a/azure/workspaces/paragon/modules.tf
+++ b/azure/workspaces/paragon/modules.tf
@@ -38,9 +38,10 @@ module "monitors" {
 module "uptime" {
   source = "./uptime"
 
-  uptime_api_token = var.uptime_api_token
-  uptime_company   = coalesce(var.uptime_company, var.organization)
-  microservices    = var.ingress_scheme == "internal" ? {} : local.public_microservices
+  uptime_api_token            = var.uptime_api_token
+  uptime_company              = coalesce(var.uptime_company, var.organization)
+  microservices               = var.ingress_scheme == "internal" ? {} : local.public_microservices
+  health-checker-microservice = local.all_microservices.health-checker
 }
 
 module "dns" {

--- a/azure/workspaces/paragon/modules.tf
+++ b/azure/workspaces/paragon/modules.tf
@@ -40,8 +40,7 @@ module "uptime" {
 
   uptime_api_token            = var.uptime_api_token
   uptime_company              = coalesce(var.uptime_company, var.organization)
-  microservices               = var.ingress_scheme == "internal" ? {} : local.public_microservices
-  health-checker-microservice = local.all_microservices.health-checker
+  health_checker_microservice = local.all_microservices.health-checker
 }
 
 module "dns" {

--- a/azure/workspaces/paragon/uptime/monitors.tf
+++ b/azure/workspaces/paragon/uptime/monitors.tf
@@ -17,9 +17,7 @@ data "betteruptime_policy" "escalation" {
 }
 
 resource "betteruptime_monitor" "monitor" {
-  for_each = local.enabled ? var.microservices : {}
-
-  pronounceable_name = "Enterprise ${var.uptime_company} - Microservice ${each.key}"
+  pronounceable_name = "Enterprise ${var.uptime_company}"
 
   check_frequency       = 30  # seconds
   confirmation_period   = 120 # seconds
@@ -34,7 +32,7 @@ resource "betteruptime_monitor" "monitor" {
   request_timeout       = 15  # seconds
   ssl_expiration        = 14  # days
   team_wait             = 180 # seconds
-  url                   = "${each.value.public_url}${each.value.healthcheck_path}"
+  url                   = var.health-checker-microservice.public_url
 
   call  = true
   email = true

--- a/azure/workspaces/paragon/uptime/monitors.tf
+++ b/azure/workspaces/paragon/uptime/monitors.tf
@@ -32,7 +32,7 @@ resource "betteruptime_monitor" "monitor" {
   request_timeout       = 15  # seconds
   ssl_expiration        = 14  # days
   team_wait             = 180 # seconds
-  url                   = var.health-checker-microservice.public_url
+  url                   = var.health_checker_microservice.public_url
 
   call  = true
   email = true

--- a/azure/workspaces/paragon/uptime/variables.tf
+++ b/azure/workspaces/paragon/uptime/variables.tf
@@ -21,12 +21,7 @@ variable "uptime_regions" {
   default     = ["as", "au", "eu", "us"]
 }
 
-variable "microservices" {
-  description = "The microservices to create monitors for."
-  type        = map(any)
-}
-
-variable "health-checker-microservice" {
+variable "health_checker_microservice" {
   description = "The information about the health-checker microservice"
   type        = map(any)
 }

--- a/azure/workspaces/paragon/uptime/variables.tf
+++ b/azure/workspaces/paragon/uptime/variables.tf
@@ -26,6 +26,11 @@ variable "microservices" {
   type        = map(any)
 }
 
+variable "health-checker-microservice" {
+  description = "The information about the health-checker microservice"
+  type        = map(any)
+}
+
 locals {
   enabled = var.uptime_api_token != null
 }

--- a/charts/paragon-onprem/Chart.yaml
+++ b/charts/paragon-onprem/Chart.yaml
@@ -30,6 +30,10 @@ dependencies:
     repository: file://charts/hades
     version: __PARAGON_VERSION__
     condition: subchart.hades.enabled
+  - name: health-checker
+    repository: file://charts/health-checker
+    version: __PARAGON_VERSION__
+    condition: subchart.health-checker.enabled
   - name: hermes
     repository: file://charts/hermes
     version: __PARAGON_VERSION__

--- a/charts/paragon-onprem/values.yaml
+++ b/charts/paragon-onprem/values.yaml
@@ -13,6 +13,8 @@ subchart:
     enabled: true
   hades:
     enabled: true
+  health-checker:
+    enabled: true
   hermes:
     enabled: true
   minio:

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -40,9 +40,10 @@ module "monitors" {
 module "uptime" {
   source = "./uptime"
 
-  uptime_api_token = var.uptime_api_token
-  uptime_company   = coalesce(var.uptime_company, var.organization)
-  microservices    = local.public_microservices
+  uptime_api_token            = var.uptime_api_token
+  uptime_company              = coalesce(var.uptime_company, var.organization)
+  microservices               = local.public_microservices
+  health-checker-microservice = local.all_microservices.health-checker
 }
 
 module "dns" {

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -42,8 +42,7 @@ module "uptime" {
 
   uptime_api_token            = var.uptime_api_token
   uptime_company              = coalesce(var.uptime_company, var.organization)
-  microservices               = local.public_microservices
-  health-checker-microservice = local.all_microservices.health-checker
+  health_checker_microservice = local.all_microservices.health-checker
 }
 
 module "dns" {

--- a/gcp/workspaces/paragon/uptime/monitors.tf
+++ b/gcp/workspaces/paragon/uptime/monitors.tf
@@ -17,9 +17,7 @@ data "betteruptime_policy" "escalation" {
 }
 
 resource "betteruptime_monitor" "monitor" {
-  for_each = local.enabled ? var.microservices : {}
-
-  pronounceable_name = "Enterprise ${var.uptime_company} - Microservice ${each.key}"
+  pronounceable_name = "Enterprise ${var.uptime_company}"
 
   check_frequency       = 30  # seconds
   confirmation_period   = 120 # seconds
@@ -34,7 +32,7 @@ resource "betteruptime_monitor" "monitor" {
   request_timeout       = 15  # seconds
   ssl_expiration        = 14  # days
   team_wait             = 180 # seconds
-  url                   = "${each.value.public_url}${each.value.healthcheck_path}"
+  url                   = var.health-checker-microservice.public_url
 
   call  = true
   email = true

--- a/gcp/workspaces/paragon/uptime/monitors.tf
+++ b/gcp/workspaces/paragon/uptime/monitors.tf
@@ -32,7 +32,7 @@ resource "betteruptime_monitor" "monitor" {
   request_timeout       = 15  # seconds
   ssl_expiration        = 14  # days
   team_wait             = 180 # seconds
-  url                   = var.health-checker-microservice.public_url
+  url                   = var.health_checker_microservice.public_url
 
   call  = true
   email = true

--- a/gcp/workspaces/paragon/uptime/variables.tf
+++ b/gcp/workspaces/paragon/uptime/variables.tf
@@ -21,12 +21,7 @@ variable "uptime_regions" {
   default     = ["as", "au", "eu", "us"]
 }
 
-variable "microservices" {
-  description = "The microservices to create monitors for."
-  type        = map(any)
-}
-
-variable "health-checker-microservice" {
+variable "health_checker_microservice" {
   description = "The information about the health-checker microservice"
   type        = map(any)
 }

--- a/gcp/workspaces/paragon/uptime/variables.tf
+++ b/gcp/workspaces/paragon/uptime/variables.tf
@@ -26,6 +26,11 @@ variable "microservices" {
   type        = map(any)
 }
 
+variable "health-checker-microservice" {
+  description = "The information about the health-checker microservice"
+  type        = map(any)
+}
+
 locals {
   enabled = var.uptime_api_token != null
 }


### PR DESCRIPTION


### Issues Closed

- [PARA-13876](https://useparagon.atlassian.net/browse/PARA-13876)

### Brief Summary

Add health-checker microservice to uptime module

### Detailed Summary

Introduced a new variable and updates configurations to handle the health-checker microservice across Azure, GCP, and AWS.
Simplified monitor naming and replaced dynamic URLs with a direct reference to the health-checker public URL.

### Changes

- Added a direct reference to health-checker's status URL to BetterUptime

### Unrelated Changes

Updated Helm charts to include health-checker as a subchart.

### Steps to Test

Deploy a new enterprise env, make sure ealth-checker is running and Better Uptime is correctly using it's `/status` endpoint

[PARA-13876]: https://useparagon.atlassian.net/browse/PARA-13876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ