### PR TITLE
Make Azure CloudFlare usage optional and fix TLS secrets

### DIFF
--- a/azure/workspaces/paragon/README.md
+++ b/azure/workspaces/paragon/README.md
@@ -62,6 +62,7 @@ No resources.
 |------|-------------|
 | <a name="output_grafana_admin_email"></a> [grafana\_admin\_email](#output\_grafana\_admin\_email) | Grafana admin login email. |
 | <a name="output_grafana_admin_password"></a> [grafana\_admin\_password](#output\_grafana\_admin\_password) | Grafana admin login password. |
+| <a name="output_load_balancer"></a> [load\_balancer](#output\_load\_balancer) | Location of the load balancer |
 | <a name="output_pgadmin_admin_email"></a> [pgadmin\_admin\_email](#output\_pgadmin\_admin\_email) | PGAdmin admin login email. |
 | <a name="output_pgadmin_admin_password"></a> [pgadmin\_admin\_password](#output\_pgadmin\_admin\_password) | PGAdmin admin login password. |
 | <a name="output_uptime_webhook"></a> [uptime\_webhook](#output\_uptime\_webhook) | Uptime webhook URL |

--- a/azure/workspaces/paragon/dns/dns.tf
+++ b/azure/workspaces/paragon/dns/dns.tf
@@ -1,4 +1,6 @@
 data "cloudflare_zone" "zone" {
+  count = var.enabled ? 1 : 0
+
   zone_id = var.cloudflare_zone_id
 }
 
@@ -7,10 +9,10 @@ locals {
 }
 
 resource "cloudflare_record" "cname" {
-  for_each = var.public_services
+  for_each = var.enabled ? var.public_services : {}
 
   # strip protocol and domain from URL to get subdomain
-  name = replace(replace(each.value.public_url, "https://", ""), ".${data.cloudflare_zone.zone.name}", "")
+  name = replace(replace(each.value.public_url, "https://", ""), ".${data.cloudflare_zone.zone[0].name}", "")
 
   content = var.ingress_loadbalancer
   ttl     = 600

--- a/azure/workspaces/paragon/dns/provider.tf
+++ b/azure/workspaces/paragon/dns/provider.tf
@@ -8,5 +8,5 @@ terraform {
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  api_token = var.enabled ? var.cloudflare_api_token : "placeholder_0apiTokencloudflareonprem100"
 }

--- a/azure/workspaces/paragon/dns/variables.tf
+++ b/azure/workspaces/paragon/dns/variables.tf
@@ -1,3 +1,9 @@
+variable "enabled" {
+  description = "Enable DNS module"
+  type        = bool
+  default     = true
+}
+
 variable "cloudflare_api_token" {
   description = "Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Zone `DNS`"
   type        = string

--- a/azure/workspaces/paragon/helm/helm.tf
+++ b/azure/workspaces/paragon/helm/helm.tf
@@ -200,7 +200,6 @@ resource "helm_release" "paragon_on_prem" {
     helm_release.ingress,
     kubernetes_secret.docker_login,
     kubernetes_secret.paragon_secrets,
-    kubernetes_secret.microservices,
     kubernetes_config_map.feature_flag_content
   ]
 }
@@ -254,8 +253,7 @@ resource "helm_release" "paragon_logging" {
 
   depends_on = [
     helm_release.ingress,
-    kubernetes_secret.docker_login,
-    kubernetes_secret.microservices
+    kubernetes_secret.docker_login
   ]
 }
 
@@ -284,7 +282,6 @@ resource "helm_release" "paragon_monitoring" {
   depends_on = [
     helm_release.ingress,
     helm_release.paragon_on_prem,
-    kubernetes_secret.docker_login,
-    kubernetes_secret.microservices
+    kubernetes_secret.docker_login
   ]
 }

--- a/azure/workspaces/paragon/helm/ingress.tf
+++ b/azure/workspaces/paragon/helm/ingress.tf
@@ -20,22 +20,6 @@ resource "azurerm_key_vault_access_policy" "aks_access_to_kv" {
   ]
 }
 
-resource "kubernetes_secret" "microservices" {
-  for_each = var.microservices
-
-  metadata {
-    name      = "${each.key}-secret"
-    namespace = kubernetes_namespace.paragon.id
-  }
-
-  lifecycle {
-    ignore_changes = [
-      metadata[0].annotations,
-      metadata[0].labels
-    ]
-  }
-}
-
 resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   namespace  = kubernetes_namespace.paragon.id

--- a/azure/workspaces/paragon/modules.tf
+++ b/azure/workspaces/paragon/modules.tf
@@ -46,6 +46,7 @@ module "uptime" {
 module "dns" {
   source = "./dns"
 
+  enabled              = local.dns_enabled
   cloudflare_api_token = var.cloudflare_api_token
   cloudflare_zone_id   = var.cloudflare_zone_id
   domain               = var.domain

--- a/azure/workspaces/paragon/outputs.tf
+++ b/azure/workspaces/paragon/outputs.tf
@@ -27,3 +27,8 @@ output "uptime_webhook" {
   value       = module.uptime.webhook
   sensitive   = true
 }
+
+output "load_balancer" {
+  description = "Location of the load balancer"
+  value       = module.helm.load_balancer
+}

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -157,6 +157,8 @@ locals {
   hash      = substr(sha256(var.azure_subscription_id), 0, 8)
   workspace = nonsensitive("paragon-${var.organization}-${local.hash}")
 
+  dns_enabled = var.ingress_scheme != "internal" && var.cloudflare_api_token != null && var.cloudflare_zone_id != null
+
   infra_json_path = abspath(var.infra_json_path)
   infra_vars      = jsondecode(fileexists(local.infra_json_path) && var.infra_json == null ? file(local.infra_json_path) : var.infra_json)
 
@@ -535,8 +537,6 @@ locals {
         MONITOR_GRAFANA_SECURITY_ADMIN_USER     = var.monitors_enabled ? module.monitors[0].grafana_admin_email : null
         MONITOR_GRAFANA_SERVER_DOMAIN           = try(local.monitors["grafana"].public_url, null)
         MONITOR_GRAFANA_UPTIME_WEBHOOK_URL      = module.uptime.webhook
-        HEALTH_CHECKER_HOST                     = "http://health-checker"
-        HEALTH_CHECKER_PORT                     = try(local.monitors["health-checker"].port, null)
         MONITOR_KUBE_STATE_METRICS_HOST         = "http://kube-state-metrics"
         MONITOR_KUBE_STATE_METRICS_PORT         = try(local.monitors["kube-state-metrics"].port, null)
         MONITOR_PGADMIN_EMAIL                   = var.monitors_enabled ? module.monitors[0].pgadmin_admin_email : null

--- a/gcp/workspaces/paragon/README.md
+++ b/gcp/workspaces/paragon/README.md
@@ -3,11 +3,7 @@
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.16.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.16.0 |
+No requirements.
 
 ## Providers
 

--- a/gcp/workspaces/paragon/dns/provider.tf
+++ b/gcp/workspaces/paragon/dns/provider.tf
@@ -8,5 +8,5 @@ terraform {
 }
 
 provider "cloudflare" {
-  api_token = var.cloudflare_api_token
+  api_token = var.enabled ? var.cloudflare_api_token : "placeholder_0apiTokencloudflareonprem100"
 }

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2025.5.13"
+version="2025.5.29"
 provider=${1:-aws}
 
 # allow calling from other directories


### PR DESCRIPTION
### Issues Closed

- PARA-13878

### Brief Summary

Enable/disable DNS module, remove microservices secret, update outputs.

### Detailed Summary

- Added an `enabled` flag to the DNS Terraform module for Azure and GCP, allowing DNS resources to be conditionally created.
- Updated Cloudflare provider configuration to use a placeholder token when DNS is disabled.
- Removed the `microservices` Kubernetes secret and its dependencies from Helm charts.
- Added a new `load_balancer` output to Azure workspace.
- Updated documentation and variable usage to reflect these changes.
- Bumped chart version in `prepare.sh`.

### Changes

- Added `enabled` variable to `azure/workspaces/paragon/dns/variables.tf` and related logic in `dns.tf`, `provider.tf`.
- Updated `modules.tf` and `variables.tf` to use new DNS enablement logic.
- Removed `kubernetes_secret.microservices` from Helm charts and dependencies.
- Added `load_balancer` output to `outputs.tf` and documentation.
- Updated `prepare.sh` version.
- Synced similar changes in GCP workspace.

### Unrelated Changes

- No unrelated changes outside the scope of the DNS module and Helm chart refactor.

### Future Work

- Consider making DNS enablement logic more generic for other cloud providers.
- Further modularize Helm chart dependencies.

### Steps to Test

1. Deploy the Azure and GCP workspaces with and without DNS enabled.
2. Verify that DNS resources are only created when enabled.
3. Confirm that Helm releases work without the `microservices` secret.
4. Check that the new `load_balancer` output is present and correct.

### QA Notes

- Ensure that disabling DNS does not break other resources.
- Validate that all outputs and secrets are as expected after deployment.

### Deployment Notes

- No config updates required unless you want to enable/disable DNS.
- Make sure to use the updated `prepare.sh` script for deployments.

### Screenshots

_N/A (infra/Helm changes only)_