### PR TITLE
aws > managed sync > configurable autoscaling

### DIFF
--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -66,6 +66,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_managed_sync_enabled"></a> [managed\_sync\_enabled](#input\_managed\_sync\_enabled) | Whether to enable managed sync. | `bool` | `false` | no |
 | <a name="input_master_guardduty_account_id"></a> [master\_guardduty\_account\_id](#input\_master\_guardduty\_account\_id) | Optional AWS account id to delegate GuardDuty control to. | `string` | `null` | no |
 | <a name="input_mfa_enabled"></a> [mfa\_enabled](#input\_mfa\_enabled) | Whether to require MFA for certain configurations (e.g. cloudtrail s3 bucket deletion) | `bool` | `false` | no |
+| <a name="input_msk_autoscaling_enabled"></a> [msk\_autoscaling\_enabled](#input\_msk\_autoscaling\_enabled) | Whether to enable autoscaling for the MSK cluster. | `bool` | `true` | no |
 | <a name="input_msk_instance_type"></a> [msk\_instance\_type](#input\_msk\_instance\_type) | The instance type for the MSK cluster. | `string` | `"kafka.t3.small"` | no |
 | <a name="input_msk_kafka_num_broker_nodes"></a> [msk\_kafka\_num\_broker\_nodes](#input\_msk\_kafka\_num\_broker\_nodes) | The number of broker nodes for the MSK cluster. | `number` | `2` | no |
 | <a name="input_msk_kafka_version"></a> [msk\_kafka\_version](#input\_msk\_kafka\_version) | The Kafka version for the MSK cluster. | `string` | `"3.6.0"` | no |

--- a/aws/workspaces/infra/kafka/msk.tf
+++ b/aws/workspaces/infra/kafka/msk.tf
@@ -109,6 +109,8 @@ PROPERTIES
 }
 
 resource "aws_appautoscaling_target" "kafka" {
+  count = var.msk_autoscaling_enabled ? 1 : 0
+
   max_capacity       = 3000
   min_capacity       = 1
   resource_id        = aws_msk_cluster.kafka.arn
@@ -117,11 +119,13 @@ resource "aws_appautoscaling_target" "kafka" {
 }
 
 resource "aws_appautoscaling_policy" "kafka" {
+  count = var.msk_autoscaling_enabled ? 1 : 0
+
   name               = "${aws_msk_cluster.kafka.cluster_name}-msk-scaling"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_msk_cluster.kafka.arn
-  scalable_dimension = aws_appautoscaling_target.kafka.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.kafka.service_namespace
+  scalable_dimension = aws_appautoscaling_target.kafka[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.kafka[0].service_namespace
 
   target_tracking_scaling_policy_configuration {
     disable_scale_in = false

--- a/aws/workspaces/infra/kafka/variables.tf
+++ b/aws/workspaces/infra/kafka/variables.tf
@@ -31,3 +31,8 @@ variable "msk_kafka_num_broker_nodes" {
   description = "The number of broker nodes for the MSK cluster."
   type        = number
 }
+
+variable "msk_autoscaling_enabled" {
+  description = "Whether to enable autoscaling for the MSK cluster."
+  type        = bool
+}

--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -69,6 +69,7 @@ module "kafka" {
 
   workspace                  = local.workspace
   force_destroy              = var.disable_deletion_protection
+  msk_autoscaling_enabled    = var.msk_autoscaling_enabled
   msk_kafka_version          = var.msk_kafka_version
   msk_instance_type          = var.msk_instance_type
   msk_kafka_num_broker_nodes = var.msk_kafka_num_broker_nodes

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -249,6 +249,12 @@ variable "msk_kafka_num_broker_nodes" {
   default     = 2
 }
 
+variable "msk_autoscaling_enabled" {
+  description = "Whether to enable autoscaling for the MSK cluster."
+  type        = bool
+  default     = true
+}
+
 variable "msk_instance_type" {
   description = "The instance type for the MSK cluster."
   type        = string


### PR DESCRIPTION
### Brief Summary

aws > infra > kafka > variable to configure if autoscaling enabled

### Detailed Summary

We're having trouble getting the `iam:CreateServiceLinkedRole` permission correctly configured with a customer, which is causing errors in the `infra` workspace when applying Terraform when Managed Sync is enabled. However, it's not needed to deploy Managed Sync.

This PR adds a configuration variable `msk_autoscaling_enabled` for AWS to disable autoscaling for Kafka.

### Changes

- added `msk_autoscaling_enabled` configuration to determine whether or not autoscaling is enabled for Kafka