### PR TITLE
fix(bastion): point to new cdn for helm package

### DIFF
--- a/aws/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
+++ b/aws/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
@@ -53,8 +53,8 @@ eksctl version
 
 # install helm
 writeLog "installing helm"
-curl -fsSL https://baltocdn.com/helm/signing.asc | sudo apt-key add -
-echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/helm.gpg
+echo "deb [signed-by=/etc/apt/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
 sudo apt-get update -y
 sudo apt-get install -y helm
 


### PR DESCRIPTION
### Issues Closed

- PARA-15554

### Brief Summary

Updated location for Helm package download.

### Detailed Summary

The CDN that had been hosting the Helm package that gets installed during the bastion setup is no longer hosting it. It has now been updated to use the new location from the official Helm [installation instructions](https://helm.sh/docs/intro/install/#through-package-managers).

### Changes

- updated bastion setup

### Unrelated Changes

none

### Future Work

_how can this be improved?_

### Steps to Test

- verify that `helm` executable is found after the bastion starts
