### PR TITLE
feat(15906): scrape flipt metrics with prometheus

### DIFF
--- a/charts/paragon-onprem/charts/flipt/values.yaml
+++ b/charts/paragon-onprem/charts/flipt/values.yaml
@@ -26,7 +26,11 @@ test:
   # Can pin the version of busybox to a specific version
   # tag: '1.36.1'
 
-podAnnotations: {}
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/scheme: "http"
+  prometheus.io/path: "/metrics"
+  prometheus.io/port: "8080" # or 9000
 podLabels: {}
 
 deploymentAnnotations: {}


### PR DESCRIPTION
### Issues Closed

- PARA-15906

### Brief Summary

Added flipt labels for prometheus scrapping

### Steps to Test

1. Get into on-prem prometheus
2. Check prometheus targets (`k8s_pod_discovery`) and confirm if flipt (port 9000) is there
3. Query `*flipt*` metrics to confirm there are metrics being scrapped.
