### PR TITLE
feat/PARA-18753/add-5xx-alerts-for-alb

### DIFF
--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -393,6 +393,11 @@ resource "helm_release" "paragon_monitoring" {
     value = data.aws_lb.load_balancer.arn_suffix
   }
 
+  set {
+    name  = "grafana.secrets.MONITOR_GRAFANA_ALB_ARN"
+    value = data.aws_lb.load_balancer.arn_suffix
+  }
+
   depends_on = [
     helm_release.ingress,
     helm_release.paragon_on_prem,

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -389,11 +389,6 @@ resource "helm_release" "paragon_monitoring" {
   }
 
   set {
-    name  = "global.env.MONITOR_GRAFANA_ALB_ARN"
-    value = data.aws_lb.load_balancer.arn_suffix
-  }
-
-  set {
     name  = "grafana.secrets.MONITOR_GRAFANA_ALB_ARN"
     value = data.aws_lb.load_balancer.arn_suffix
   }


### PR DESCRIPTION
### Issues Closed

- PARA-18753

### Brief Summary

inject grafana alb arn into grafana pod via chart secret on eks

### Detailed Summary

Grafana’s Helm chart treats MONITOR_GRAFANA_ALB_ARN as a secret key (because of the _ARN suffix in the env classification). On EKS, values passed only through global.env do not populate the Kubernetes secret that _env.yaml reads for secretKeys, so the Grafana pod never received the ALB ARN and CloudWatch ALB queries could not scope to the correct load balancer.

This change adds a grafana.secrets.MONITOR_GRAFANA_ALB_ARN Helm set (same value as the existing global.env.MONITOR_GRAFANA_ALB_ARN from data.aws_lb.load_balancer.arn_suffix). That populates the chart-specific secret (paragon-secrets-grafana) so the variable is available to the Grafana container without putting it in the shared paragon-secrets secret (which would introduce a circular dependency with the monitoring release).


### Changes

- Added set { name = "grafana.secrets.MONITOR_GRAFANA_ALB_ARN", value = data.aws_lb.load_balancer.arn_suffix } on the paragon_monitoring Helm release in .turbo/enterprise/aws/workspaces/paragon/helm/helm.tf
- Kept the existing global.env.MONITOR_GRAFANA_ALB_ARN set so behavior stays consistent with other env wiring

### Unrelated Changes

Noe

### Future Work

None required for this fix. Optional: align MONITOR_GRAFANA_AWS_ACCOUNT_ID for EKS if any dashboards or datasources expect it.

### Steps to Test

1. Deploy or upgrade the monitoring stack in a non-prod EKS workspace that uses this Helm module.
2. kubectl exec into the Grafana pod and confirm MONITOR_GRAFANA_ALB_ARN is present in the environment (value should match the ALB ARN suffix for that workspace).
3. In Grafana, open the AWS ALB dashboard and confirm ALB / target-group CloudWatch series load for that environment.

### QA Notes

Infrastructure-only change; no customer-facing UI. Validates that Grafana can query ALB metrics on EKS after deploy.

### Deployment Notes

- Apply with the usual Terraform/Helm flow for paragon_monitoring.
- Companion to the main paragon monorepo PR for PARA-18753 (Grafana alert/dashboard definitions). Deploy order: enterprise infra change can ship before or with Grafana image/config rollout, but both are needed for end-to-end ALB alerting on EKS.

### Screenshots

None