### PR TITLE
Central deployment of infra workspace

### DIFF
--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -9,6 +9,8 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.70 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
 
 ## Providers
 
@@ -42,9 +44,9 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_app_bucket_expiration"></a> [app\_bucket\_expiration](#input\_app\_bucket\_expiration) | The number of days to retain S3 app data before deleting | `number` | `90` | no |
 | <a name="input_auditlogs_lock_enabled"></a> [auditlogs\_lock\_enabled](#input\_auditlogs\_lock\_enabled) | Whether to enable S3 Object Lock for the audit logs bucket. | `bool` | `false` | no |
 | <a name="input_auditlogs_retention_days"></a> [auditlogs\_retention\_days](#input\_auditlogs\_retention\_days) | The number of days to retain audit logs before deletion. | `number` | `365` | no |
-| <a name="input_aws_access_key_id"></a> [aws\_access\_key\_id](#input\_aws\_access\_key\_id) | AWS Access Key for AWS account to provision resources on. | `string` | n/a | yes |
+| <a name="input_aws_access_key_id"></a> [aws\_access\_key\_id](#input\_aws\_access\_key\_id) | AWS Access Key for AWS account to provision resources on. | `string` | `null` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region resources are created in. | `string` | n/a | yes |
-| <a name="input_aws_secret_access_key"></a> [aws\_secret\_access\_key](#input\_aws\_secret\_access\_key) | AWS Secret Access Key for AWS account to provision resources on. | `string` | n/a | yes |
+| <a name="input_aws_secret_access_key"></a> [aws\_secret\_access\_key](#input\_aws\_secret\_access\_key) | AWS Secret Access Key for AWS account to provision resources on. | `string` | `null` | no |
 | <a name="input_aws_session_token"></a> [aws\_session\_token](#input\_aws\_session\_token) | AWS session token. | `string` | `null` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Number of AZs to cover in a given region. | `number` | `2` | no |
 | <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Account `Cloudflare Tunnel`, `Access: Organizations, Identity Providers, and Groups`, `Access: Apps and Policies` and Zone `DNS` | `string` | `"dummy-cloudflare-tokens-must-be-40-chars"` | no |
@@ -57,15 +59,15 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_disable_cloudtrail"></a> [disable\_cloudtrail](#input\_disable\_cloudtrail) | Used to specify that Cloudtrail is disabled. | `bool` | `true` | no |
 | <a name="input_disable_deletion_protection"></a> [disable\_deletion\_protection](#input\_disable\_deletion\_protection) | Used to disable deletion protection on RDS and S3 resources. | `bool` | `false` | no |
 | <a name="input_eks_admin_arns"></a> [eks\_admin\_arns](#input\_eks\_admin\_arns) | Array of ARNs for IAM users or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard. | `list(string)` | `[]` | no |
-| <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `30` | no |
-| <a name="input_eks_min_node_count"></a> [eks\_min\_node\_count](#input\_eks\_min\_node\_count) | The minimum number of nodes to run in the Kubernetes cluster. | `number` | `4` | no |
+| <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `40` | no |
+| <a name="input_eks_min_node_count"></a> [eks\_min\_node\_count](#input\_eks\_min\_node\_count) | The minimum number of nodes to run in the Kubernetes cluster. | `number` | `2` | no |
 | <a name="input_eks_ondemand_node_instance_type"></a> [eks\_ondemand\_node\_instance\_type](#input\_eks\_ondemand\_node\_instance\_type) | The compute instance type to use for Kubernetes nodes. | `string` | `"m6a.xlarge"` | no |
 | <a name="input_eks_spot_instance_percent"></a> [eks\_spot\_instance\_percent](#input\_eks\_spot\_instance\_percent) | The percentage of spot instances to use for Kubernetes nodes. | `number` | `75` | no |
 | <a name="input_eks_spot_node_instance_type"></a> [eks\_spot\_node\_instance\_type](#input\_eks\_spot\_node\_instance\_type) | The compute instance type to use for Kubernetes spot nodes. | `string` | `"t3a.xlarge,t3.xlarge,m5a.xlarge,m5.xlarge,m6a.xlarge,m6i.xlarge,m7a.xlarge,m7i.xlarge,r5a.xlarge,m4.xlarge"` | no |
 | <a name="input_elasticache_multi_az"></a> [elasticache\_multi\_az](#input\_elasticache\_multi\_az) | Whether or not to enable multi-AZ in each ElastiCache instance. | `bool` | `true` | no |
 | <a name="input_elasticache_multiple_instances"></a> [elasticache\_multiple\_instances](#input\_elasticache\_multiple\_instances) | Whether or not to create multiple ElastiCache instances. Used for higher volume installations. | `bool` | `true` | no |
 | <a name="input_elasticache_node_type"></a> [elasticache\_node\_type](#input\_elasticache\_node\_type) | The ElastiCache node type used for Redis. | `string` | `"cache.r6g.large"` | no |
-| <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | The version of Kubernetes to run in the cluster. | `string` | `"1.33"` | no |
+| <a name="input_k8s_version"></a> [k8s\_version](#input\_k8s\_version) | The version of Kubernetes to run in the cluster. | `string` | `"1.34"` | no |
 | <a name="input_managed_sync_enabled"></a> [managed\_sync\_enabled](#input\_managed\_sync\_enabled) | Whether to enable managed sync. | `bool` | `false` | no |
 | <a name="input_master_guardduty_account_id"></a> [master\_guardduty\_account\_id](#input\_master\_guardduty\_account\_id) | Optional AWS account id to delegate GuardDuty control to. | `string` | `null` | no |
 | <a name="input_mfa_enabled"></a> [mfa\_enabled](#input\_mfa\_enabled) | Whether to require MFA for certain configurations (e.g. cloudtrail s3 bucket deletion) | `bool` | `false` | no |
@@ -80,7 +82,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_rds_instance_class"></a> [rds\_instance\_class](#input\_rds\_instance\_class) | The RDS instance class type used for Postgres. | `string` | `"db.t4g.small"` | no |
 | <a name="input_rds_multi_az"></a> [rds\_multi\_az](#input\_rds\_multi\_az) | Whether or not to enable multi-AZ in each RDS instance. | `bool` | `true` | no |
 | <a name="input_rds_multiple_instances"></a> [rds\_multiple\_instances](#input\_rds\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
-| <a name="input_rds_postgres_version"></a> [rds\_postgres\_version](#input\_rds\_postgres\_version) | Postgres version for the database. | `string` | `"14"` | no |
+| <a name="input_rds_postgres_version"></a> [rds\_postgres\_version](#input\_rds\_postgres\_version) | Postgres version for the database. | `string` | `"16"` | no |
 | <a name="input_rds_restore_from_snapshot"></a> [rds\_restore\_from\_snapshot](#input\_rds\_restore\_from\_snapshot) | Specifies that RDS instances should be restored from a snapshot. | `bool` | `false` | no |
 | <a name="input_ssh_whitelist"></a> [ssh\_whitelist](#input\_ssh\_whitelist) | An optional list of IP addresses to whitelist ssh access. | `string` | `""` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for the VPC. | `string` | `"10.0.0.0/16"` | no |

--- a/aws/workspaces/infra/cluster/security.tf
+++ b/aws/workspaces/infra/cluster/security.tf
@@ -17,7 +17,7 @@ resource "aws_iam_role" "eks_cluster_admin" {
 
 resource "aws_iam_policy" "eks_cluster_admin" {
   name   = "${var.workspace}-eks-admin"
-  policy = file("./templates/eks/eks-admin-policy.json")
+  policy = file("${path.module}/../templates/eks/eks-admin-policy.json")
 
   tags = {
     Name = "${var.workspace}-eks-admin"
@@ -50,7 +50,7 @@ resource "aws_iam_role" "node_role" {
 resource "aws_iam_policy" "eks_worker_policy" {
   name        = "${var.workspace}-eks-worker-policy"
   description = "Worker policy for the ALB Ingress."
-  policy      = file("./templates/eks/eks-worker-policy.json")
+  policy      = file("${path.module}/../templates/eks/eks-worker-policy.json")
 
   tags = {
     Name = "${var.workspace}-eks-worker-policy"

--- a/aws/workspaces/infra/main.tf.example
+++ b/aws/workspaces/infra/main.tf.example
@@ -1,10 +1,20 @@
 terraform {
-  required_version = ">= 1.7.0"
+  # backend "remote" {
+  #   hostname     = "app.terraform.io"
+  #   organization = "paragon-cloud"
 
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.70"
-    }
+  #   workspaces {
+  #     name = "paragon-aws-infra"
+  #   }
+  # }
+}
+
+provider "aws" {
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
+  token      = var.aws_session_token
+  region     = var.aws_region
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/aws/workspaces/infra/providers.tf
+++ b/aws/workspaces/infra/providers.tf
@@ -6,5 +6,13 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.70"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
   }
 }

--- a/aws/workspaces/infra/providers.tf
+++ b/aws/workspaces/infra/providers.tf
@@ -1,10 +1,10 @@
-provider "aws" {
-  access_key = var.aws_access_key_id
-  secret_key = var.aws_secret_access_key
-  token      = var.aws_session_token
-  region     = var.aws_region
+terraform {
+  required_version = ">= 1.7.0"
 
-  default_tags {
-    tags = local.default_tags
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
   }
 }

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -8,12 +8,14 @@ variable "aws_access_key_id" {
   description = "AWS Access Key for AWS account to provision resources on."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "aws_secret_access_key" {
   description = "AWS Secret Access Key for AWS account to provision resources on."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "aws_session_token" {
@@ -58,7 +60,7 @@ variable "rds_instance_class" {
 variable "rds_postgres_version" {
   description = "Postgres version for the database."
   type        = string
-  default     = "14"
+  default     = "16"
 }
 
 variable "rds_multiple_instances" {
@@ -108,7 +110,7 @@ variable "elasticache_multi_az" {
 variable "k8s_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "eks_ondemand_node_instance_type" {
@@ -136,13 +138,13 @@ variable "eks_spot_instance_percent" {
 variable "eks_min_node_count" {
   description = "The minimum number of nodes to run in the Kubernetes cluster."
   type        = number
-  default     = 4
+  default     = 2
 }
 
 variable "eks_max_node_count" {
   description = "The maximum number of nodes to run in the Kubernetes cluster."
   type        = number
-  default     = 30
+  default     = 40
 }
 
 variable "eks_admin_arns" {

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -36,18 +36,21 @@ variable "az_count" {
   description = "Number of AZs to cover in a given region."
   type        = number
   default     = 2
+  nullable    = false
 }
 
 variable "vpc_cidr" {
   description = "CIDR for the VPC."
   type        = string
   default     = "10.0.0.0/16"
+  nullable    = false
 }
 
 variable "vpc_cidr_newbits" {
   description = "Newbits used for calculating subnets."
   type        = number
   default     = 3
+  nullable    = false
 }
 
 # rds
@@ -55,36 +58,42 @@ variable "rds_instance_class" {
   description = "The RDS instance class type used for Postgres."
   type        = string
   default     = "db.t4g.small"
+  nullable    = false
 }
 
 variable "rds_postgres_version" {
   description = "Postgres version for the database."
   type        = string
   default     = "16"
+  nullable    = false
 }
 
 variable "rds_multiple_instances" {
   description = "Whether or not to create multiple Postgres instances. Used for higher volume installations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "rds_multi_az" {
   description = "Whether or not to enable multi-AZ in each RDS instance."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "rds_restore_from_snapshot" {
   description = "Specifies that RDS instances should be restored from a snapshot."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "rds_final_snapshot_enabled" {
   description = "Specifies that RDS instances should perform a final snapshot before being deleted."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 # elasticache
@@ -92,18 +101,21 @@ variable "elasticache_node_type" {
   description = "The ElastiCache node type used for Redis."
   type        = string
   default     = "cache.r6g.large"
+  nullable    = false
 }
 
 variable "elasticache_multiple_instances" {
   description = "Whether or not to create multiple ElastiCache instances. Used for higher volume installations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "elasticache_multi_az" {
   description = "Whether or not to enable multi-AZ in each ElastiCache instance."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 # eks
@@ -111,24 +123,28 @@ variable "k8s_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
   default     = "1.34"
+  nullable    = false
 }
 
 variable "eks_ondemand_node_instance_type" {
   description = "The compute instance type to use for Kubernetes nodes."
   type        = string
   default     = "m6a.xlarge"
+  nullable    = false
 }
 
 variable "eks_spot_node_instance_type" {
   description = "The compute instance type to use for Kubernetes spot nodes."
   type        = string
   default     = "t3a.xlarge,t3.xlarge,m5a.xlarge,m5.xlarge,m6a.xlarge,m6i.xlarge,m7a.xlarge,m7i.xlarge,r5a.xlarge,m4.xlarge"
+  nullable    = false
 }
 
 variable "eks_spot_instance_percent" {
   description = "The percentage of spot instances to use for Kubernetes nodes."
   type        = number
   default     = 75
+  nullable    = false
   validation {
     condition     = var.eks_spot_instance_percent >= 0 && var.eks_spot_instance_percent <= 100
     error_message = "Value must be between 0 - 100."
@@ -139,24 +155,28 @@ variable "eks_min_node_count" {
   description = "The minimum number of nodes to run in the Kubernetes cluster."
   type        = number
   default     = 2
+  nullable    = false
 }
 
 variable "eks_max_node_count" {
   description = "The maximum number of nodes to run in the Kubernetes cluster."
   type        = number
   default     = 40
+  nullable    = false
 }
 
 variable "eks_admin_arns" {
   description = "Array of ARNs for IAM users or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard."
   type        = list(string)
   default     = []
+  nullable    = false
 }
 
 variable "create_autoscaling_linked_role" {
   description = "Whether or not to create an IAM role for autoscaling."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 # security
@@ -170,42 +190,49 @@ variable "mfa_enabled" {
   description = "Whether to require MFA for certain configurations (e.g. cloudtrail s3 bucket deletion)"
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "ssh_whitelist" {
   description = "An optional list of IP addresses to whitelist ssh access."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "disable_cloudtrail" {
   description = "Used to specify that Cloudtrail is disabled."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "disable_deletion_protection" {
   description = "Used to disable deletion protection on RDS and S3 resources."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "app_bucket_expiration" {
   description = "The number of days to retain S3 app data before deleting"
   type        = number
   default     = 90
+  nullable    = false
 }
 
 variable "auditlogs_retention_days" {
   description = "The number of days to retain audit logs before deletion."
   type        = number
   default     = 365
+  nullable    = false
 }
 
 variable "auditlogs_lock_enabled" {
   description = "Whether to enable S3 Object Lock for the audit logs bucket."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 # cloudflare
@@ -214,18 +241,21 @@ variable "cloudflare_api_token" {
   type        = string
   sensitive   = true
   default     = "dummy-cloudflare-tokens-must-be-40-chars"
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_enabled" {
   description = "Flag whether to enable Cloudflare Zero Trust tunnel for bastion"
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_subdomain" {
   description = "Subdomain under the Cloudflare Zone to create the tunnel"
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_zone_id" {
@@ -233,6 +263,7 @@ variable "cloudflare_tunnel_zone_id" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_account_id" {
@@ -240,6 +271,7 @@ variable "cloudflare_tunnel_account_id" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_email_domain" {
@@ -247,6 +279,7 @@ variable "cloudflare_tunnel_email_domain" {
   type        = string
   sensitive   = true
   default     = "useparagon.com"
+  nullable    = false
 }
 
 variable "migrated_workspace" {
@@ -259,12 +292,14 @@ variable "migrated_passwords" {
   description = "Override credentials to preserve complexity conventions when migrating from legacy workspaces"
   type        = map(string)
   default     = {}
+  nullable    = false
 }
 
 variable "managed_sync_enabled" {
   description = "Whether to enable managed sync."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "msk_kafka_version" {
@@ -272,25 +307,29 @@ variable "msk_kafka_version" {
   type        = string
   // NOTE: to use a small instance type like `kafka.t3.small`, we need to use an older version that uses zookeeper
   // we're default to an older version to keep costs low, but we can override this if we use a supported larger instance type
-  default = "3.6.0"
+  default  = "3.6.0"
+  nullable = false
 }
 
 variable "msk_kafka_num_broker_nodes" {
   description = "The number of broker nodes for the MSK cluster."
   type        = number
   default     = 2
+  nullable    = false
 }
 
 variable "msk_autoscaling_enabled" {
   description = "Whether to enable autoscaling for the MSK cluster."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "msk_instance_type" {
   description = "The instance type for the MSK cluster."
   type        = string
   default     = "kafka.t3.small"
+  nullable    = false
 }
 
 locals {

--- a/aws/workspaces/paragon/main.tf.example
+++ b/aws/workspaces/paragon/main.tf.example
@@ -1,22 +1,20 @@
 terraform {
-  required_version = ">= 1.7.0"
+  # backend "remote" {
+  #   hostname     = "app.terraform.io"
+  #   organization = "paragon-cloud"
 
-  required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = "~> 5.70"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.0"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
-    }
-    hoop = {
-      source  = "hoophq/hoop"
-      version = ">= 0.0.19"
-    }
+  #   workspaces {
+  #     name = "paragon-aws-helm"
+  #   }
+  # }
+}
+
+provider "aws" {
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
+  token      = var.aws_session_token
+  region     = var.aws_region
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/aws/workspaces/paragon/providers.tf
+++ b/aws/workspaces/paragon/providers.tf
@@ -1,10 +1,23 @@
-provider "aws" {
-  access_key = var.aws_access_key_id
-  secret_key = var.aws_secret_access_key
-  token      = var.aws_session_token
-  region     = var.aws_region
-  default_tags {
-    tags = local.default_tags
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.70"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    hoop = {
+      source  = "hoophq/hoop"
+      version = ">= 0.0.19"
+    }
   }
 }
 

--- a/azure/scripts/setup-roles.sh
+++ b/azure/scripts/setup-roles.sh
@@ -1,41 +1,47 @@
 #!/bin/bash
 
-# Script to assign roles to a service principal or user within an Azure subscription using `az cli`.
-# This script documents the minimum required permissions to run the Azure infra and paragon Terraform workspaces.
+# Assign subscription-scoped Azure RBAC for the principal that runs Paragon enterprise
+# Terraform (e.g. Spacelift Azure integration app) and for operational diagnostics.
+#
+# Provisioning: Contributor + User Access Administrator cover ARM for AKS, Postgres,
+# Redis, storage, networking, VMSS, etc., plus Key Vault RBAC / role assignments.
+#
+# Kubernetes API: Contributor does NOT grant access to the Kubernetes control plane when
+# using Azure RBAC for Kubernetes. "Azure Kubernetes Service Cluster User Role" allows
+# obtaining a kubeconfig and read-oriented kubectl (e.g. inspect cert-manager Certificates,
+# ingress, events) subject to Kubernetes RBAC inside the cluster.
+#
+# Key Vault data plane: To read secret/certificate *values* (not just manage the vault
+# resource), also assign a data-plane role at the vault scope (e.g. Key Vault Administrator
+# or Key Vault Secrets User) — subscription roles alone are not enough for secret content.
 
-# Define variables
 SUBSCRIPTION_ID="your-azure-subscription-id"
 PRINCIPAL_ID="your-service-principal-object-id-or-user-object-id"
 
-# List of roles to assign at subscription level
-# Note: Contributor role is sufficient for most operations, but we document specific roles
-# for better security and compliance with least privilege principle.
-
 ROLES=(
-  # Contributor role - provides full access to manage all resources except grant access to others
-  # This is the minimum role needed for Terraform to create and manage Azure resources
+  # Full resource management except IAM grants (Terraform apply/destroy)
   "Contributor"
-  # Needed to switch Key Vaults to RBAC and create role assignments
+  # Key Vault permission model (RBAC) and Azure resource role assignments
   "User Access Administrator"
+  # kubectl / Kubernetes API via Azure RBAC (cluster inspection, certs, events, logs)
+  "Azure Kubernetes Service Cluster User Role"
 )
 
-# Alternative: If you want to use more granular permissions instead of Contributor,
-# you would need the following roles (but Contributor is simpler and sufficient):
+# Optional: tighter scope than Contributor (more roles to maintain):
 #
 # GRANULAR_ROLES=(
-#   "Network Contributor"              # For Virtual Networks, Subnets, NSGs, Private Endpoints
-#   "DNS Zone Contributor"             # For Private DNS Zones
-#   "PostgreSQL Flexible Server Contributor"  # For PostgreSQL Flexible Servers
-#   "Redis Cache Contributor"          # For Redis Caches
-#   "Storage Account Contributor"      # For Storage Accounts
-#   "Kubernetes Cluster Contributor"   # For AKS Clusters
-#   "Virtual Machine Contributor"      # For VM Scale Sets (bastion)
-#   "Key Vault Contributor"            # For Key Vaults (management plane)
-#   "Key Vault Administrator"          # For Key Vault data-plane access (RBAC)
-#   "User Access Administrator"        # For role assignments (RBAC)
+#   "Network Contributor"
+#   "DNS Zone Contributor"
+#   "PostgreSQL Flexible Server Contributor"
+#   "Redis Cache Contributor"
+#   "Storage Account Contributor"
+#   "Kubernetes Cluster Contributor"
+#   "Virtual Machine Contributor"
+#   "Key Vault Contributor"
+#   "Key Vault Administrator"
+#   "User Access Administrator"
 # )
 
-# Assign Contributor role at subscription level
 for ROLE in "${ROLES[@]}"; do
   echo "Assigning role '$ROLE' to principal $PRINCIPAL_ID..."
   az role assignment create \
@@ -45,23 +51,12 @@ for ROLE in "${ROLES[@]}"; do
 done
 
 echo ""
-echo "Role assignment complete!"
+echo "Role assignment complete."
 echo ""
-echo "Note: The Contributor role provides the following permissions needed for Terraform:"
-echo "  - Create and manage Resource Groups"
-echo "  - Create and manage Virtual Networks, Subnets, and Network Security Groups"
-echo "  - Create and manage Private DNS Zones and Private Endpoints"
-echo "  - Create and manage PostgreSQL Flexible Servers"
-echo "  - Create and manage Redis Caches"
-echo "  - Create and manage Storage Accounts and Containers"
-echo "  - Create and manage AKS Clusters and Node Pools"
-echo "  - Create and manage Virtual Machine Scale Sets"
-echo "  - Create and manage Key Vaults"
-echo "  - Create and manage Key Vault role assignments (via User Access Administrator)"
-echo "  - Create and manage Public IPs"
+echo "Contributor: ARM for resource groups, VNet/NSG/DNS, private endpoints, Postgres,"
+echo "  Redis, storage, AKS node pools, VMSS (bastion), public IPs, etc."
+echo "User Access Administrator: Key Vault RBAC transitions and Azure RBAC assignments."
+echo "AKS Cluster User: Kubernetes API access for diagnostics (e.g. cert-manager, ingress)."
 echo ""
-echo "For Key Vault RBAC (permission model change + role assignments),"
-echo "Terraform also needs User Access Administrator at subscription or resource group scope."
-echo ""
-echo "If you want the Terraform principal to manage Key Vault secrets/certs/keys,"
-echo "assign Key Vault Administrator at the vault scope."
+echo "For Key Vault secret/certificate *contents*, assign a Key Vault data-plane role at"
+echo "the vault scope (e.g. Key Vault Administrator)."

--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -2,9 +2,11 @@
 
 ## Azure credentials
 
-Terraform uses the Azure client ID, secret, subscription, and tenant from variables (e.g. `vars.auto.tfvars`) or from environment variables: `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID`.
+**Terraform** (this workspace or a parent stack) can authenticate with optional variables `azure_client_id`, `azure_client_secret`, `azure_tenant_id` when this repo is the root, or with `ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_SUBSCRIPTION_ID`, `ARM_TENANT_ID` / Azure CLI when those are omitted. When this path is used as a **child module**, the parent stack owns provider auth and typically passes only `azure_subscription_id`.
 
-To update credentials when the app registration secret expires:
+**Bastion VMs** do not use that principal. The bastion **always** uses its **VMSS system-assigned managed identity** (`az login --identity` in cloud-init); Terraform grants that identity `Azure Kubernetes Service Cluster Admin Role` on the AKS cluster. This is independent of whether Terraform runs as a service principal or OIDC.
+
+To update credentials when the **Terraform** app registration secret expires:
 
 1. In **Azure Portal** go to **Microsoft Entra ID** → **App registrations** → select the app (use the client ID to find it).
 2. Open **Certificates & secrets** → **New client secret** → add a description and expiry → **Add**.

--- a/azure/workspaces/infra/bastion/server.tf
+++ b/azure/workspaces/infra/bastion/server.tf
@@ -30,15 +30,17 @@ resource "azurerm_linux_virtual_machine_scale_set" "bastion" {
     }
   }
 
+  # Bastion runtime auth to Azure/AKS is always this identity (not the Terraform principal).
+  identity {
+    type = "SystemAssigned"
+  }
+
   custom_data = base64encode(templatefile("${path.module}/../templates/bastion/bastion-startup.tpl.sh", {
     account_id      = var.cloudflare_tunnel_account_id,
-    client_id       = var.azure_client_id,
-    client_secret   = var.azure_client_secret,
     cluster_name    = var.cluster_name,
     cluster_version = local.k8s_version_major_minor,
     resource_group  = var.resource_group.name
     subscription_id = var.azure_subscription_id,
-    tenant_id       = var.azure_tenant_id,
     tunnel_id       = local.tunnel_id,
     tunnel_name     = local.tunnel_domain,
     tunnel_secret   = local.tunnel_secret,
@@ -75,4 +77,11 @@ resource "azurerm_linux_virtual_machine_scale_set" "bastion" {
   upgrade_mode = "Automatic"
 
   tags = merge(var.tags, { Name = local.bastion_name })
+}
+
+# Allow the bastion VMSS managed identity to fetch kubeconfig and use kubectl against AKS.
+resource "azurerm_role_assignment" "bastion_aks_cluster_admin" {
+  scope                = var.cluster_id
+  role_definition_name = "Azure Kubernetes Service Cluster Admin Role"
+  principal_id         = azurerm_linux_virtual_machine_scale_set.bastion.identity[0].principal_id
 }

--- a/azure/workspaces/infra/bastion/server.tf
+++ b/azure/workspaces/infra/bastion/server.tf
@@ -10,6 +10,17 @@ resource "tls_private_key" "bastion" {
   rsa_bits  = 4096
 }
 
+# User-assigned identity so role assignments can use a top-level principal_id. Referencing
+# azurerm_linux_virtual_machine_scale_set.*.identity[0].principal_id breaks validation in
+# some root-module graphs (nested computed; see hashicorp/terraform-provider-azurerm#21545).
+resource "azurerm_user_assigned_identity" "bastion" {
+  name                = "${local.bastion_name}-uai"
+  location            = var.resource_group.location
+  resource_group_name = var.resource_group.name
+
+  tags = var.tags
+}
+
 resource "azurerm_linux_virtual_machine_scale_set" "bastion" {
   name                = local.bastion_name
   location            = var.resource_group.location
@@ -32,18 +43,20 @@ resource "azurerm_linux_virtual_machine_scale_set" "bastion" {
 
   # Bastion runtime auth to Azure/AKS is always this identity (not the Terraform principal).
   identity {
-    type = "SystemAssigned"
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.bastion.id]
   }
 
   custom_data = base64encode(templatefile("${path.module}/../templates/bastion/bastion-startup.tpl.sh", {
-    account_id      = var.cloudflare_tunnel_account_id,
-    cluster_name    = var.cluster_name,
-    cluster_version = local.k8s_version_major_minor,
-    resource_group  = var.resource_group.name
-    subscription_id = var.azure_subscription_id,
-    tunnel_id       = local.tunnel_id,
-    tunnel_name     = local.tunnel_domain,
-    tunnel_secret   = local.tunnel_secret,
+    account_id                 = var.cloudflare_tunnel_account_id,
+    cluster_name               = var.cluster_name,
+    cluster_version            = local.k8s_version_major_minor,
+    managed_identity_client_id = azurerm_user_assigned_identity.bastion.client_id,
+    resource_group             = var.resource_group.name,
+    subscription_id            = var.azure_subscription_id,
+    tunnel_id                  = local.tunnel_id,
+    tunnel_name                = local.tunnel_domain,
+    tunnel_secret              = local.tunnel_secret,
   }))
 
   admin_ssh_key {
@@ -83,5 +96,5 @@ resource "azurerm_linux_virtual_machine_scale_set" "bastion" {
 resource "azurerm_role_assignment" "bastion_aks_cluster_admin" {
   scope                = var.cluster_id
   role_definition_name = "Azure Kubernetes Service Cluster Admin Role"
-  principal_id         = azurerm_linux_virtual_machine_scale_set.bastion.identity[0].principal_id
+  principal_id         = azurerm_user_assigned_identity.bastion.principal_id
 }

--- a/azure/workspaces/infra/bastion/variables.tf
+++ b/azure/workspaces/infra/bastion/variables.tf
@@ -1,26 +1,12 @@
-# credentials
-variable "azure_client_id" {
-  description = "Azure client ID"
-  type        = string
-  sensitive   = true
-}
-
-variable "azure_client_secret" {
-  description = "Azure client secret"
-  type        = string
-  sensitive   = true
-}
-
 variable "azure_subscription_id" {
-  description = "Azure subscription ID"
+  description = "Azure subscription ID (used for az account set on the bastion)"
   type        = string
   sensitive   = true
 }
 
-variable "azure_tenant_id" {
-  description = "Azure tenant ID"
+variable "cluster_id" {
+  description = "Resource ID of the AKS cluster (for RBAC: bastion managed identity → cluster admin)"
   type        = string
-  sensitive   = true
 }
 
 variable "resource_group" {

--- a/azure/workspaces/infra/cluster/outputs.tf
+++ b/azure/workspaces/infra/cluster/outputs.tf
@@ -1,5 +1,6 @@
 output "kubernetes" {
   value = {
+    id                     = azurerm_kubernetes_cluster.cluster.id
     name                   = azurerm_kubernetes_cluster.cluster.name
     host                   = azurerm_kubernetes_cluster.cluster.kube_config.0.host
     client_certificate     = azurerm_kubernetes_cluster.cluster.kube_config.0.client_certificate

--- a/azure/workspaces/infra/main.tf.example
+++ b/azure/workspaces/infra/main.tf.example
@@ -1,15 +1,24 @@
 terraform {
-  required_version = ">= 1.7.0"
+  # backend "remote" {
+  #   hostname     = "app.terraform.io"
+  #   organization = "paragon-cloud"
 
-  required_providers {
-    azurerm = {
-      source = "hashicorp/azurerm"
-      version = "~> 4.0"
-    }
+  #   workspaces {
+  #     name = "paragon-azure-infra"
+  #   }
+  # }
+}
 
-    azuread = {
-      source = "hashicorp/azuread"
-      version = "~> 3.0"
-    }
-  }
+provider "azurerm" {
+  subscription_id = var.azure_subscription_id
+  tenant_id       = var.azure_tenant_id
+  client_id       = var.azure_client_id
+  client_secret   = var.azure_client_secret
+  features {}
+}
+
+provider "azuread" {
+  client_id     = var.azure_client_id
+  client_secret = var.azure_client_secret
+  tenant_id     = var.azure_tenant_id
 }

--- a/azure/workspaces/infra/modules.tf
+++ b/azure/workspaces/infra/modules.tf
@@ -10,10 +10,8 @@ module "network" {
 module "bastion" {
   source = "./bastion"
 
-  azure_client_id       = var.azure_client_id
-  azure_client_secret   = var.azure_client_secret
   azure_subscription_id = var.azure_subscription_id
-  azure_tenant_id       = var.azure_tenant_id
+  cluster_id            = module.cluster.kubernetes.id
 
   bastion_vm_size                = var.bastion_vm_size
   cloudflare_api_token           = var.cloudflare_api_token

--- a/azure/workspaces/infra/outputs.tf
+++ b/azure/workspaces/infra/outputs.tf
@@ -33,13 +33,14 @@ output "auditlogs_bucket" {
 output "minio" {
   description = "MinIO server connection info."
   value = {
-    public_bucket       = module.storage.blob.public_container
-    private_bucket      = module.storage.blob.private_container
-    managed_sync_bucket = module.storage.blob.managed_sync_container
-    microservice_user   = module.storage.blob.minio_microservice_user
-    microservice_pass   = module.storage.blob.minio_microservice_pass
-    root_user           = module.storage.blob.name
-    root_password       = module.storage.blob.access_key
+    public_bucket               = module.storage.blob.public_container
+    public_storage_account_name = module.storage.blob.public_storage_account_name
+    private_bucket              = module.storage.blob.private_container
+    managed_sync_bucket         = module.storage.blob.managed_sync_container
+    microservice_user           = module.storage.blob.minio_microservice_user
+    microservice_pass           = module.storage.blob.minio_microservice_pass
+    root_user                   = module.storage.blob.name
+    root_password               = module.storage.blob.access_key
   }
   sensitive = true
 }

--- a/azure/workspaces/infra/providers.tf
+++ b/azure/workspaces/infra/providers.tf
@@ -1,13 +1,15 @@
-provider "azurerm" {
-  subscription_id = var.azure_subscription_id
-  tenant_id       = var.azure_tenant_id
-  client_id       = var.azure_client_id
-  client_secret   = var.azure_client_secret
-  features {}
-}
+terraform {
+  required_version = ">= 1.7.0"
 
-provider "azuread" {
-  client_id     = var.azure_client_id
-  client_secret = var.azure_client_secret
-  tenant_id     = var.azure_tenant_id
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 3.0"
+    }
+  }
 }

--- a/azure/workspaces/infra/storage/blob.tf
+++ b/azure/workspaces/infra/storage/blob.tf
@@ -6,9 +6,20 @@ resource "random_string" "storage_hash" {
   special = false
 }
 
+resource "random_string" "cdn_public_hash" {
+  length  = 8
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
+}
+
 locals {
+  clean_prefix = substr(replace(var.workspace, "/[^a-z0-9]/", ""), 0, 16)
   # storage accounts must be globally unique and only up to 24 lower case alphanumeric characters
-  storage_account_name = "${substr(replace(var.workspace, "/[^a-z0-9]/", ""), 0, 16)}${random_string.storage_hash.result}"
+  storage_account_name = "${local.clean_prefix}${random_string.storage_hash.result}"
+  # Premium BlockBlob cannot host public containers; anonymous CDN uses a separate Standard account.
+  cdn_storage_account_name = "${substr(local.clean_prefix, 0, 13)}cd${random_string.cdn_public_hash.result}"
 }
 
 resource "azurerm_storage_account" "blob" {
@@ -23,6 +34,18 @@ resource "azurerm_storage_account" "blob" {
   tags                            = merge(var.tags, { Name = local.storage_account_name })
 }
 
+resource "azurerm_storage_account" "cdn_public" {
+  name                = local.cdn_storage_account_name
+  resource_group_name = var.resource_group.name
+  location            = var.resource_group.location
+
+  account_kind                    = "StorageV2"
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = true
+  tags                            = merge(var.tags, { Name = local.cdn_storage_account_name })
+}
+
 resource "azurerm_storage_container" "app" {
   name                  = "${var.workspace}-app"
   container_access_type = "private"
@@ -32,7 +55,7 @@ resource "azurerm_storage_container" "app" {
 resource "azurerm_storage_container" "cdn" {
   name                  = "${var.workspace}-cdn"
   container_access_type = "container"
-  storage_account_id    = azurerm_storage_account.blob.id
+  storage_account_id    = azurerm_storage_account.cdn_public.id
 }
 
 resource "azurerm_storage_container" "logs" {
@@ -64,6 +87,15 @@ resource "azurerm_storage_container_immutability_policy" "auditlogs" {
 
 resource "azurerm_storage_account_network_rules" "storage" {
   storage_account_id = azurerm_storage_account.blob.id
+
+  bypass                     = ["Metrics"]
+  default_action             = "Allow"
+  ip_rules                   = []
+  virtual_network_subnet_ids = var.virtual_network_subnet_ids
+}
+
+resource "azurerm_storage_account_network_rules" "cdn_public" {
+  storage_account_id = azurerm_storage_account.cdn_public.id
 
   bypass                     = ["Metrics"]
   default_action             = "Allow"

--- a/azure/workspaces/infra/storage/outputs.tf
+++ b/azure/workspaces/infra/storage/outputs.tf
@@ -1,14 +1,15 @@
 output "blob" {
   value = {
-    name                    = local.storage_account_name
-    access_key              = azurerm_storage_account.blob.primary_access_key
-    private_container       = azurerm_storage_container.app.name
-    public_container        = azurerm_storage_container.cdn.name
-    logs_container          = azurerm_storage_container.logs.name
-    managed_sync_container  = var.managed_sync_enabled ? azurerm_storage_container.managed_sync[0].name : null
-    auditlogs_container     = azurerm_storage_container.auditlogs.name
-    minio_microservice_user = random_string.minio_microservice_user.result
-    minio_microservice_pass = random_password.minio_microservice_pass.result
+    name                        = local.storage_account_name
+    access_key                  = azurerm_storage_account.blob.primary_access_key
+    private_container           = azurerm_storage_container.app.name
+    public_container            = azurerm_storage_container.cdn.name
+    public_storage_account_name = azurerm_storage_account.cdn_public.name
+    logs_container              = azurerm_storage_container.logs.name
+    managed_sync_container      = var.managed_sync_enabled ? azurerm_storage_container.managed_sync[0].name : null
+    auditlogs_container         = azurerm_storage_container.auditlogs.name
+    minio_microservice_user     = random_string.minio_microservice_user.result
+    minio_microservice_pass     = random_password.minio_microservice_pass.result
   }
   sensitive = true
 }

--- a/azure/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
+++ b/azure/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
@@ -163,7 +163,7 @@ chmod 644 /home/ubuntu/.bash_aliases
 
 # configure az, aks and kubectl
 writeLog "configuring k8s tools as ubuntu"
-sudo -u ubuntu az login --service-principal -u ${client_id} -p ${client_secret} --tenant ${tenant_id}
+sudo -u ubuntu az login --identity
 sudo -u ubuntu az account set --subscription ${subscription_id}
 sudo -u ubuntu az aks get-credentials --overwrite-existing --resource-group ${resource_group} --name ${cluster_name}
 sudo -u ubuntu kubectl config set-context --current --namespace=paragon

--- a/azure/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
+++ b/azure/workspaces/infra/templates/bastion/bastion-startup.tpl.sh
@@ -163,7 +163,8 @@ chmod 644 /home/ubuntu/.bash_aliases
 
 # configure az, aks and kubectl
 writeLog "configuring k8s tools as ubuntu"
-sudo -u ubuntu az login --identity
+# User-assigned identity: pass client id so az picks the right principal (required when only UAIs exist).
+sudo -u ubuntu az login --identity --username "${managed_identity_client_id}"
 sudo -u ubuntu az account set --subscription ${subscription_id}
 sudo -u ubuntu az aks get-credentials --overwrite-existing --resource-group ${resource_group} --name ${cluster_name}
 sudo -u ubuntu kubectl config set-context --current --namespace=paragon

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -38,36 +38,42 @@ variable "environment" {
   description = "Type of environment being deployed to."
   type        = string
   default     = "enterprise"
+  nullable    = false
 }
 
 variable "ssh_whitelist" {
   description = "An optional list of IP addresses to whitelist SSH access."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "bastion_vm_size" {
   description = "VM size for the bastion scale set (e.g. Standard_B1s). Must be available in the target region."
   type        = string
   default     = "Standard_B1s"
+  nullable    = false
 }
 
 variable "vpc_cidr" {
   description = "CIDR for the virtual network. A `/16` (65,536 IPs) or larger is recommended."
   type        = string
   default     = "10.0.0.0/16"
+  nullable    = false
 }
 
 variable "auditlogs_retention_days" {
   description = "The number of days to retain audit logs before deletion."
   type        = number
   default     = 365
+  nullable    = false
 }
 
 variable "auditlogs_lock_enabled" {
   description = "Whether to lock the audit logs container immutability policy."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 # cloudflare
@@ -76,18 +82,21 @@ variable "cloudflare_api_token" {
   type        = string
   sensitive   = true
   default     = "dummy-cloudflare-tokens-must-be-40-chars"
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_enabled" {
   description = "Flag whether to enable Cloudflare Zero Trust tunnel for bastion"
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_subdomain" {
   description = "Subdomain under the Cloudflare Zone to create the tunnel"
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_zone_id" {
@@ -95,6 +104,7 @@ variable "cloudflare_tunnel_zone_id" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_account_id" {
@@ -102,6 +112,7 @@ variable "cloudflare_tunnel_account_id" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_email_domain" {
@@ -109,6 +120,7 @@ variable "cloudflare_tunnel_email_domain" {
   type        = string
   sensitive   = true
   default     = "useparagon.com"
+  nullable    = false
 }
 
 # postgres
@@ -116,30 +128,35 @@ variable "postgres_redundant" {
   description = "Whether zone redundant HA should be enabled"
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "postgres_sku_name" {
   description = "PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`)"
   type        = string
   default     = "GP_Standard_D2ds_v5"
+  nullable    = false
 }
 
 variable "postgres_base_sku_name" {
   description = "Default PostgreSQL SKU name for instances that don't use the main postgres_sku_name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`)"
   type        = string
   default     = "B_Standard_B2s"
+  nullable    = false
 }
 
 variable "postgres_version" {
   description = "PostgreSQL version (14, 15 or 16)"
   type        = string
   default     = "14"
+  nullable    = false
 }
 
 variable "postgres_multiple_instances" {
   description = "Whether or not to create multiple Postgres instances. Used for higher volume installations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 # redis
@@ -147,6 +164,7 @@ variable "redis_capacity" {
   description = "Used to configure the capacity of the Redis cache."
   type        = number
   default     = 1
+  nullable    = false
   validation {
     condition     = contains([0, 1, 2, 3, 4, 5, 6], var.redis_capacity)
     error_message = "The capacity for the redis instance. It must be between 0 - 6 (inclusive)."
@@ -157,6 +175,7 @@ variable "redis_base_capacity" {
   description = "Default capacity of the Redis cache for instances that don't use the main redis_capacity."
   type        = number
   default     = 1
+  nullable    = false
   validation {
     condition     = contains([0, 1, 2, 3, 4, 5, 6], var.redis_base_capacity)
     error_message = "The capacity for the redis instance. It must be between 0 - 6 (inclusive)."
@@ -167,6 +186,7 @@ variable "redis_sku_name" {
   description = "The SKU Name of the Redis cache (`Basic`, `Standard` or `Premium`)."
   type        = string
   default     = "Premium"
+  nullable    = false
   validation {
     condition     = contains(["Basic", "Standard", "Premium"], var.redis_sku_name)
     error_message = "The sku_name for the redis instance. It must be `Basic`, `Standard`, or `Premium`."
@@ -177,6 +197,7 @@ variable "redis_base_sku_name" {
   description = "Default SKU Name of the Redis cache (`Basic`, `Standard` or `Premium`) for instances that don't use the main redis_sku_name."
   type        = string
   default     = "Standard"
+  nullable    = false
   validation {
     condition     = contains(["Basic", "Standard", "Premium"], var.redis_base_sku_name)
     error_message = "The sku_name for the redis instance. It must be `Basic`, `Standard`, or `Premium`."
@@ -187,12 +208,14 @@ variable "redis_ssl_only" {
   description = "Flag whether only SSL connections are allowed."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "redis_multiple_instances" {
   description = "Whether or not to create multiple Redis instances."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 # aks
@@ -200,24 +223,28 @@ variable "k8s_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
   default     = "1.33"
+  nullable    = false
 }
 
 variable "k8s_min_node_count" {
   description = "Minimum number of node Kubernetes can scale down to."
   type        = number
   default     = 3
+  nullable    = false
 }
 
 variable "k8s_max_node_count" {
   description = "Maximum number of node Kubernetes can scale up to."
   type        = number
   default     = 20
+  nullable    = false
 }
 
 variable "k8s_spot_instance_percent" {
   description = "The percentage of spot instances to use for Kubernetes nodes."
   type        = number
   default     = 75
+  nullable    = false
   validation {
     condition     = var.k8s_spot_instance_percent >= 0 && var.k8s_spot_instance_percent <= 100
     error_message = "Value must be between 0 - 100."
@@ -228,24 +255,28 @@ variable "k8s_default_node_pool_vm_size" {
   description = "VM size for the AKS default (system) node pool. Must be available in the target region (e.g. Standard_B2s_v2 in japaneast)."
   type        = string
   default     = "Standard_B2s"
+  nullable    = false
 }
 
 variable "k8s_ondemand_node_instance_type" {
   description = "The compute instance type to use for Kubernetes on demand nodes."
   type        = string
   default     = "Standard_B2ms"
+  nullable    = false
 }
 
 variable "k8s_spot_node_instance_type" {
   description = "The compute instance type to use for Kubernetes spot nodes."
   type        = string
   default     = "Standard_B2ms"
+  nullable    = false
 }
 
 variable "k8s_sku_tier" {
   description = "The SKU Tier of the AKS cluster (`Free`, `Standard` or `Premium`)."
   type        = string
   default     = "Premium"
+  nullable    = false
   validation {
     condition     = contains(["Free", "Standard", "Premium"], var.k8s_sku_tier)
     error_message = "The sku_tier for the AKS cluster. It must be `Free`, `Standard`, or `Premium`."
@@ -256,12 +287,14 @@ variable "managed_sync_enabled" {
   description = "Whether to enable managed sync."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "eventhub_namespace_sku" {
   description = "The SKU name for the Event Hubs namespace (Basic, Standard, Premium)."
   type        = string
   default     = "Standard"
+  nullable    = false
   validation {
     condition     = contains(["Basic", "Standard", "Premium"], var.eventhub_namespace_sku)
     error_message = "The sku_name must be `Basic`, `Standard`, or `Premium`."
@@ -272,6 +305,7 @@ variable "eventhub_capacity" {
   description = "The capacity units for the Event Hubs namespace (1-20 for Standard, 1-8 for Premium)."
   type        = number
   default     = 1
+  nullable    = false
   validation {
     condition     = var.eventhub_capacity >= 1 && var.eventhub_capacity <= 20
     error_message = "The capacity must be between 1 and 20."
@@ -282,12 +316,14 @@ variable "eventhub_auto_inflate_enabled" {
   description = "Whether to enable auto-inflate for the Event Hubs namespace."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "eventhub_maximum_throughput_units" {
   description = "The maximum throughput units for auto-inflate (only applicable when auto_inflate_enabled is true)."
   type        = number
   default     = 20
+  nullable    = false
 }
 
 locals {

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -1,25 +1,34 @@
-# credentials
-variable "azure_client_id" {
-  description = "Azure client ID"
-  type        = string
-  sensitive   = true
-}
-
-variable "azure_client_secret" {
-  description = "Azure client secret"
-  type        = string
-  sensitive   = true
-}
-
 variable "azure_subscription_id" {
   description = "Azure subscription ID"
   type        = string
   sensitive   = true
 }
 
+# Optional service principal for the azurerm / azuread providers when this workspace is
+# the Terraform root. Leave null (omit in tfvars) to use ARM_* / Azure CLI / OIDC.
+# When this path is used as a child module, omit these so the parent workspace owns
+# provider auth (same env-based chain).
 variable "azure_tenant_id" {
-  description = "Azure tenant ID"
+  description = "Azure AD tenant ID for provider auth. Optional if using ARM_TENANT_ID / CLI."
   type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "azure_client_id" {
+  description = "Azure AD application (client) ID for provider auth. Optional if using ARM_CLIENT_ID / CLI."
+  type        = string
+  default     = null
+  nullable    = true
+  sensitive   = true
+}
+
+variable "azure_client_secret" {
+  description = "Azure AD client secret for provider auth. Optional if using ARM_CLIENT_SECRET / CLI."
+  type        = string
+  default     = null
+  nullable    = true
   sensitive   = true
 }
 

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -70,7 +70,7 @@ locals {
     )
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
-      local.storage_type == "AZURE" ? "https://${var.infra_values.minio.value.root_user}.blob.core.windows.net" : null,
+      local.storage_type == "AZURE" ? "https://${try(var.infra_values.minio.value.public_storage_account_name, var.infra_values.minio.value.root_user)}.blob.core.windows.net" : null,
       try(var.microservices.minio.public_url, null), null
     )
   }

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -754,7 +754,7 @@ locals {
 
         CLOUD_STORAGE_PUBLIC_URL = coalesce(
           try(local.helm_vars.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
-          local.cloud_storage_type == "AZURE" ? "https://${local.infra_vars.minio.value.root_user}.blob.core.windows.net" : null,
+          local.cloud_storage_type == "AZURE" ? "https://${try(local.infra_vars.minio.value.public_storage_account_name, local.infra_vars.minio.value.root_user)}.blob.core.windows.net" : null,
           try(local.microservices.minio.public_url, null), null
         )
         # TODO: In the future, we should use a private link to access the storage account so traffic stays within the VPC. This affects costs and performance.

--- a/gcp/scripts/gcp-roles.sh
+++ b/gcp/scripts/gcp-roles.sh
@@ -4,10 +4,11 @@
 # operates Paragon enterprise GCP infra (GKE, Cloud SQL, Memorystore, GCS, GMK, IAM, etc.).
 #
 # Diagnostic additions vs a minimal set for provisioning:
-# - roles/servicenetworking.networksAdmin — private service connection / VPC peering (Cloud SQL)
-# - roles/managedkafka.admin — Google Managed Kafka (managed sync)
-# - roles/logging.viewer — read Cloud Logging for troubleshooting (logWriter is write-only)
 # - roles/cloudtrace.user — read Cloud Trace (console + API)
+# - roles/logging.viewer — read Cloud Logging for troubleshooting (logWriter is write-only)
+# - roles/managedkafka.admin — Google Managed Kafka (managed sync)
+# - roles/servicenetworking.networksAdmin — private service connection / VPC peering (Cloud SQL)
+# - roles/serviceusage.serviceUsageAdmin — enable/disable APIs (required for Terraform apply)
 # - roles/serviceusage.serviceUsageViewer — list enabled APIs / quota visibility for support
 
 PROJECT_ID="your-gcp-project-id"
@@ -15,6 +16,7 @@ SERVICE_ACCOUNT="your-service-account@something.iam.gserviceaccount.com"
 
 ROLES=(
   "roles/cloudsql.admin"
+  "roles/cloudtrace.user"
   "roles/compute.admin"
   "roles/container.admin"
   "roles/dns.admin"
@@ -23,16 +25,16 @@ ROLES=(
   "roles/iam.serviceAccountUser"
   "roles/logging.logWriter"
   "roles/logging.viewer"
+  "roles/managedkafka.admin"
   "roles/monitoring.metricWriter"
   "roles/monitoring.viewer"
   "roles/redis.admin"
   "roles/resourcemanager.projectIamAdmin"
   "roles/servicenetworking.networksAdmin"
+  "roles/serviceusage.serviceUsageAdmin"
+  "roles/serviceusage.serviceUsageViewer"
   "roles/stackdriver.resourceMetadata.writer"
   "roles/storage.admin"
-  "roles/managedkafka.admin"
-  "roles/cloudtrace.user"
-  "roles/serviceusage.serviceUsageViewer"
 )
 
 for ROLE in "${ROLES[@]}"; do

--- a/gcp/scripts/gcp-roles.sh
+++ b/gcp/scripts/gcp-roles.sh
@@ -1,34 +1,42 @@
 #!/bin/bash
 
-# Script to assign roles to a service account within a GCP project using `gcloud`.
+# Project-level IAM for the Terraform / automation service account that provisions and
+# operates Paragon enterprise GCP infra (GKE, Cloud SQL, Memorystore, GCS, GMK, IAM, etc.).
+#
+# Diagnostic additions vs a minimal set for provisioning:
+# - roles/servicenetworking.networksAdmin — private service connection / VPC peering (Cloud SQL)
+# - roles/managedkafka.admin — Google Managed Kafka (managed sync)
+# - roles/logging.viewer — read Cloud Logging for troubleshooting (logWriter is write-only)
+# - roles/cloudtrace.user — read Cloud Trace (console + API)
+# - roles/serviceusage.serviceUsageViewer — list enabled APIs / quota visibility for support
 
-# Define the project ID and service account email
 PROJECT_ID="your-gcp-project-id"
 SERVICE_ACCOUNT="your-service-account@something.iam.gserviceaccount.com"
 
-# List of roles to assign
 ROLES=(
-   "roles/cloudsql.admin"
-   "roles/compute.admin"
-   "roles/container.admin"
-   "roles/container.clusterAdmin"
-   "roles/container.developer"
-   "roles/dns.admin"
-   "roles/iam.serviceAccountAdmin"
-   "roles/iam.serviceAccountKeyAdmin"
-   "roles/iam.serviceAccountUser"
-   "roles/logging.logWriter"
-   "roles/monitoring.metricWriter"
-   "roles/monitoring.viewer"
-   "roles/redis.admin"
-   "roles/resourcemanager.projectIamAdmin"
-   "roles/stackdriver.resourceMetadata.writer"
-   "roles/storage.admin"
+  "roles/cloudsql.admin"
+  "roles/compute.admin"
+  "roles/container.admin"
+  "roles/dns.admin"
+  "roles/iam.serviceAccountAdmin"
+  "roles/iam.serviceAccountKeyAdmin"
+  "roles/iam.serviceAccountUser"
+  "roles/logging.logWriter"
+  "roles/logging.viewer"
+  "roles/monitoring.metricWriter"
+  "roles/monitoring.viewer"
+  "roles/redis.admin"
+  "roles/resourcemanager.projectIamAdmin"
+  "roles/servicenetworking.networksAdmin"
+  "roles/stackdriver.resourceMetadata.writer"
+  "roles/storage.admin"
+  "roles/managedkafka.admin"
+  "roles/cloudtrace.user"
+  "roles/serviceusage.serviceUsageViewer"
 )
 
-# Loop through each role and assign it to the service account
 for ROLE in "${ROLES[@]}"; do
-  gcloud projects add-iam-policy-binding $PROJECT_ID \
-    --member="serviceAccount:$SERVICE_ACCOUNT" \
+  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SERVICE_ACCOUNT}" \
     --role="$ROLE"
 done

--- a/gcp/workspaces/infra/main.tf.example
+++ b/gcp/workspaces/infra/main.tf.example
@@ -1,14 +1,26 @@
 terraform {
-  required_version = ">= 1.7.0"
+  # backend "remote" {
+  #   hostname     = "app.terraform.io"
+  #   organization = "paragon-cloud"
 
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 7.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 7.0"
-    }
-  }
+  #   workspaces {
+  #     name = "paragon-gcp-infra"
+  #   }
+  # }
+}
+
+provider "google" {
+  credentials    = var.gcp_assume_role ? null : local.gcp_creds
+  default_labels = local.default_labels
+  project        = local.gcp_project_id
+  region         = var.region
+  zone           = var.region_zone
+}
+
+provider "google-beta" {
+  credentials    = var.gcp_assume_role ? null : local.gcp_creds
+  default_labels = local.default_labels
+  project        = local.gcp_project_id
+  region         = var.region
+  zone           = var.region_zone
 }

--- a/gcp/workspaces/infra/modules.tf
+++ b/gcp/workspaces/infra/modules.tf
@@ -99,8 +99,8 @@ module "bastion" {
   cloudflare_tunnel_subdomain    = var.cloudflare_tunnel_subdomain
   cloudflare_tunnel_zone_id      = var.cloudflare_tunnel_zone_id
 
-  cluster_name   = module.cluster.kubernetes.name
-  gcp_project_id = local.gcp_project_id
+  cluster_name    = module.cluster.kubernetes.name
+  gcp_project_id  = local.gcp_project_id
   network         = module.network.network
   k8s_version     = var.k8s_version
   private_subnet  = module.network.private_subnet

--- a/gcp/workspaces/infra/providers.tf
+++ b/gcp/workspaces/infra/providers.tf
@@ -1,15 +1,14 @@
-provider "google" {
-  credentials    = var.gcp_assume_role ? null : local.gcp_creds
-  default_labels = local.default_labels
-  project        = local.gcp_project_id
-  region         = var.region
-  zone           = var.region_zone
-}
+terraform {
+  required_version = ">= 1.7.0"
 
-provider "google-beta" {
-  credentials    = var.gcp_assume_role ? null : local.gcp_creds
-  default_labels = local.default_labels
-  project        = local.gcp_project_id
-  region         = var.region
-  zone           = var.region_zone
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.0"
+    }
+  }
 }

--- a/gcp/workspaces/infra/variables.tf
+++ b/gcp/workspaces/infra/variables.tf
@@ -50,6 +50,7 @@ variable "gcp_assume_role" {
   description = "Whether to assume a role for the service account instead of using JSON credentials."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 # account
@@ -67,12 +68,14 @@ variable "environment" {
   description = "Type of environment being deployed to."
   type        = string
   default     = "enterprise"
+  nullable    = false
 }
 
 variable "vpc_cidr" {
   description = "CIDR for the virtual network. A `/16` (65,536 IPs) or larger is recommended."
   type        = string
   default     = "10.0.0.0/16"
+  nullable    = false
 }
 
 variable "region" {
@@ -96,18 +99,21 @@ variable "cloudflare_api_token" {
   type        = string
   sensitive   = true
   default     = "dummy-cloudflare-tokens-must-be-40-chars"
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_enabled" {
   description = "Flag whether to enable Cloudflare Zero Trust tunnel for bastion"
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_subdomain" {
   description = "Subdomain under the Cloudflare Zone to create the tunnel"
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_zone_id" {
@@ -115,6 +121,7 @@ variable "cloudflare_tunnel_zone_id" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_account_id" {
@@ -122,6 +129,7 @@ variable "cloudflare_tunnel_account_id" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 variable "cloudflare_tunnel_email_domain" {
@@ -129,6 +137,7 @@ variable "cloudflare_tunnel_email_domain" {
   type        = string
   sensitive   = true
   default     = "useparagon.com"
+  nullable    = false
 }
 
 # optional network restrictions
@@ -136,24 +145,28 @@ variable "ssh_whitelist" {
   description = "An optional list of IP addresses to whitelist ssh access."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 variable "disable_deletion_protection" {
   description = "Used to disable deletion protection on database and storage resources."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "auditlogs_retention_days" {
   description = "The number of days to retain audit logs before deletion."
   type        = number
   default     = 365
+  nullable    = false
 }
 
 variable "auditlogs_lock_enabled" {
   description = "Whether to lock the GCS audit logs bucket retention policy."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 # postgres
@@ -161,6 +174,7 @@ variable "postgres_tier" {
   description = "The instance type to use for Postgres."
   type        = string
   default     = "db-custom-2-7680"
+  nullable    = false
   # https://cloud.google.com/sql/docs/mysql/instance-settings#:~:text=see%20Instance%20Locations.-,Machine,-Type
 }
 
@@ -168,6 +182,7 @@ variable "postgres_multiple_instances" {
   description = "Whether or not to create multiple Postgres instances. Used for higher volume installations."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 # redis
@@ -175,12 +190,14 @@ variable "redis_multiple_instances" {
   description = "Whether or not to create multiple Redis instances."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "redis_memory_size" {
   description = "The size of the Redis instance (in GB)."
   type        = number
   default     = 2
+  nullable    = false
 }
 
 # managed sync (GMK = Google Managed Kafka)
@@ -188,42 +205,49 @@ variable "managed_sync_enabled" {
   description = "Whether to enable managed sync (GMK cluster, managed_sync bucket, postgres and redis instances)."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "gmk_kafka_version" {
   description = "Kafka version for the Google Managed Kafka cluster (version offered by the service)."
   type        = string
   default     = "3.7.1"
+  nullable    = false
 }
 
 variable "gmk_vcpu_count" {
   description = "Number of vCPUs for the GMK cluster (minimum 3 in GCP)."
   type        = number
   default     = 3
+  nullable    = false
 }
 
 variable "gmk_memory_gib" {
   description = "Memory in GiB for the GMK cluster (1-8 GiB per vCPU)."
   type        = number
   default     = 6
+  nullable    = false
 }
 
 variable "gmk_disk_size_gib" {
   description = "Disk size in GiB per broker for the GMK cluster."
   type        = number
   default     = 100
+  nullable    = false
 }
 
 variable "gmk_auto_rebalance" {
   description = "Whether to enable automatic partition rebalancing across brokers (can add load)."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "gmk_sasl_mechanism" {
   description = "SASL mechanism: plain (module creates SA key and outputs in kafka.cluster_password) or oauthbearer (Workload Identity)."
   type        = string
   default     = "plain"
+  nullable    = false
 
   validation {
     condition     = contains(["oauthbearer", "plain"], var.gmk_sasl_mechanism)
@@ -235,6 +259,7 @@ variable "gmk_sasl_plain_key_file_path" {
   description = "Optional path to your own Kafka SA key JSON for SASL/PLAIN. When empty, the module creates the key and outputs it in kafka.cluster_password."
   type        = string
   default     = ""
+  nullable    = false
 }
 
 # kubernetes
@@ -242,24 +267,28 @@ variable "k8s_version" {
   description = "The version of Kubernetes to run in the cluster."
   type        = string
   default     = "1.33"
+  nullable    = false
 }
 
 variable "k8s_min_node_count" {
   description = "Minimum number of node Kubernetes can scale down to."
   type        = number
   default     = 2
+  nullable    = false
 }
 
 variable "k8s_max_node_count" {
   description = "Maximum number of node Kubernetes can scale up to."
   type        = number
   default     = 20
+  nullable    = false
 }
 
 variable "k8s_spot_instance_percent" {
   description = "The percentage of spot instances to use for Kubernetes nodes."
   type        = number
   default     = 80
+  nullable    = false
   validation {
     condition     = var.k8s_spot_instance_percent >= 0 && var.k8s_spot_instance_percent <= 100
     error_message = "Value must be between 0 - 100."
@@ -270,18 +299,21 @@ variable "k8s_ondemand_node_instance_type" {
   description = "The compute instance type to use for Kubernetes on demand nodes."
   type        = string
   default     = "e2-standard-4"
+  nullable    = false
 }
 
 variable "k8s_spot_node_instance_type" {
   description = "The compute instance type to use for Kubernetes spot nodes."
   type        = string
   default     = "e2-standard-4"
+  nullable    = false
 }
 
 variable "k8s_disable_public_endpoint" {
   description = "Used to disable public endpoint on GKE cluster."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "k8s_master_authorized_networks" {
@@ -290,13 +322,15 @@ variable "k8s_master_authorized_networks" {
     cidr_block   = string
     display_name = optional(string, "")
   }))
-  default = []
+  default  = []
+  nullable = false
 }
 
 variable "use_storage_account_key" {
   description = "Whether to use the storage service account privatekey for the storage service account."
   type        = bool
   default     = false
+  nullable    = false
 }
 
 variable "tfc_agent_token" {
@@ -304,6 +338,7 @@ variable "tfc_agent_token" {
   type        = string
   sensitive   = true
   default     = ""
+  nullable    = false
 }
 
 locals {

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.03.25"
+version="2026.03.30"
 
 # defaults
 provider="aws"

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.03.19"
+version="2026.03.25"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-19454

### Brief Summary

harden enterprise infra for modular stacks and optional cloud auth

### Detailed Summary

Refactors AWS, Azure, and GCP infra workspaces so they work cleanly when consumed as Terraform modules from thin stacks (optional/nullable provider credentials, relative file loading, provider version pins). Azure changes improve bastion identity, CDN-related storage, and blob configuration; GCP and Azure role scripts list the permissions Terraform needs. Documentation and examples (`main.tf.example`, READMEs) are updated to match.

### Changes

- **Azure:** `bastion/server.tf`, `bastion/variables.tf`, `bastion-startup.tpl.sh`; `storage/blob.tf` and storage outputs; `modules.tf`, `providers.tf`, `variables.tf`, `outputs.tf`, `main.tf.example`, `README.md`; `setup-roles.sh` adjustments
- **GCP:** `gcp-roles.sh`, `gcp/workspaces/infra` variables, providers, modules, `main.tf.example`
- **AWS:** `cluster/security.tf`, `infra` providers, variables, `main.tf.example`; `paragon/main.tf.example`, `providers.tf`
- **Cross-cutting:** nullable/optional credential variables to avoid duplicating defaults; Helm/Kubernetes provider constraints where needed; `prepare.sh` path fix; `paragon` workspace small fixes (`secrets.tf`, `variables.tf`)

### Unrelated Changes

N/A

### Future Work

- Keep provider pins aligned with enterprise-deployments stack lock files when bumping

### Steps to Test

1. From affected workspaces (e.g. `azure/workspaces/infra`, `gcp/workspaces/infra`, `aws/workspaces/infra`): `terraform init -backend=false && terraform validate && terraform fmt -check`
2. Run role scripts in dry review or a test subscription/project to confirm listed roles match apply requirements
3. If using as a module, run `terraform plan` from a thin stack that sources these modules

### QA Notes

Behavior changes are mostly Terraform/provider wiring and IAM/storage; no application UI.

### Deployment Notes

After merge, thin stacks should pin the new enterprise ref and run `terraform plan` in Spacelift or locally. Azure/GCP role grants may need updates if plans show permission gaps; re-run `setup-roles.sh` / `gcp-roles.sh` as documented.

### Screenshots

N/A