### PR TITLE
docs: ArgoCD deployment evaluation for replacing Terraform Helm provider

### DIFF
--- a/docs/argocd-evaluation.md
+++ b/docs/argocd-evaluation.md
@@ -2,9 +2,30 @@
 
 ## Executive Summary
 
-This document evaluates replacing the Terraform Helm provider (used in each cloud provider's `paragon` workspace) with ArgoCD for managing Helm chart deployments. The goal is to eliminate the need for Terraform to access the Kubernetes API, enable GitOps-based upgrades and rollbacks, and simplify multi-customer deployment management.
+This document evaluates replacing the Terraform Helm provider (used in each cloud provider's `paragon` workspace) with ArgoCD for managing Helm chart deployments across 40 customer clusters (primarily AWS). The goal is to eliminate the need for Terraform to access the Kubernetes API, enable daily GitOps-based upgrades (up from monthly), provide rollback and drift detection, and stay on Spacelift Starter.
 
-**Recommendation:** ArgoCD can replace the `paragon` workspace's Helm release management and deliver meaningful improvements across all evaluation criteria. The `infra` workspace remains unchanged — it provisions cloud infrastructure (VPC, databases, K8s cluster, storage) and does not require K8s API access. The `paragon` workspace can be decomposed: some resources stay in Terraform (ALB certificates, DNS, uptime monitors, Grafana IAM), while all Helm releases and in-cluster resources move to ArgoCD.
+**Recommendation:** Adopt ArgoCD with External Secrets Operator (ESO). The entire `paragon` workspace can be eliminated by moving cloud-API-only resources (ALB, DNS, uptime, monitors, Hoop API connections) into the `infra` workspace and moving all Helm releases / K8s resources to ArgoCD. The `infra` workspace's Helm/Kubernetes provider dependency (cluster-autoscaler module) can also be removed by switching to the EKS-managed Karpenter addon. ArgoCD itself can be bootstrapped via an EKS addon (the ArgoCD EKS add-on from the AWS marketplace) or a single `helm_release` during initial cluster provisioning.
+
+This results in a single Terraform workspace (`infra`) that only calls cloud provider APIs — no K8s API access, no private runners, Spacelift Starter is sufficient.
+
+---
+
+## Context from Follow-up Questions
+
+| Question | Answer | Impact |
+|----------|--------|--------|
+| Active customer clusters | **40** | ApplicationSet is worthwhile; migration must be phased |
+| Secret management | **None today; prefer cloud-native (AWS Secrets Manager)** | External Secrets Operator is the right path |
+| `managed_sync_enabled` | **Subset of customers** | Can defer managed-sync migration; `helm-config` complexity affects fewer clusters |
+| Dominant cloud provider | **AWS** | Prioritize AWS implementation; Azure/GCP follow |
+| Upgrade frequency | **Monthly → target daily** | GitOps automation is high priority |
+| Customer config organization | **Per-customer Spacelift stacks in `enterprise-deployments` repo** | Config stays in that repo; ArgoCD reads from it |
+| Managed enterprise uses same approach? | **Yes** | ArgoCD benefits managed offering equally |
+| Compliance requirements | **Auditable, minimal centralized connections** | Per-cluster ArgoCD is the right model |
+| Hoop deployed everywhere? | **Yes** | Must handle Hoop in every migration |
+| Slack notifications | **Yes** | ArgoCD Notifications controller with Slack integration |
+| `update-charts.yaml` trigger | **Automatic; want it to also set chart versions, remove `prepare.sh`, host charts externally** | Aligns perfectly with ArgoCD + versioned Helm chart registry |
+| Terraform state backend | **S3** | State migration via `terraform state rm` is straightforward |
 
 ---
 
@@ -13,74 +34,82 @@ This document evaluates replacing the Terraform Helm provider (used in each clou
 ### How it works today
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│ Terraform Runner (Spacelift / local)                                │
-│                                                                     │
-│  infra workspace ──► VPC, K8s cluster, Postgres, Redis, S3/GCS/Blob│
-│       │                                                             │
-│       ▼ outputs (infra-output.json)                                 │
-│                                                                     │
-│  paragon workspace ──► K8s API ──► helm_release resources           │
-│       │                    ▲        (paragon-onprem, logging,       │
-│       │                    │         monitoring, managed-sync,       │
-│       │                    │         ingress, metrics-server, hoop)  │
-│       │                    │                                        │
-│       │              Requires direct network                        │
-│       │              access to K8s API                              │
-│       │              (public endpoint or VPC runner)                │
-│       │                                                             │
-│       └──► kubernetes_secret, kubernetes_namespace,                  │
-│            kubernetes_config_map, kubernetes_storage_class           │
-└─────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ Spacelift (Starter) + enterprise-deployments repo                    │
+│                                                                      │
+│  infra workspace ──► cloud APIs ──► VPC, EKS, Postgres, Redis, S3   │
+│       │              + K8s API  ──► cluster-autoscaler (helm_release)│
+│       │                                                              │
+│       ▼ outputs (infra-output.json)                                  │
+│                                                                      │
+│  paragon workspace ──► K8s API ──► helm_release resources            │
+│       │                    ▲        (paragon-onprem, logging,        │
+│       │                    │         monitoring, managed-sync,        │
+│       │                    │         ingress, metrics-server, hoop)   │
+│       │                    │                                         │
+│       │              Requires direct network access                   │
+│       │              to K8s API (public endpoint or VPC runner)       │
+│       │                                                              │
+│       └──► ALB/DNS, uptime monitors, Grafana IAM, Hoop connections   │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Pain points identified
 
 | Problem | Details |
 |---------|---------|
-| **Dual config locations** | Environment variables are defined in `.secure/values.yaml` (Helm values), merged/augmented in `variables.tf` locals (200+ env vars constructed from `infra_vars` + `helm_vars`), and cloud-specific values injected via `set`/`set_sensitive` in `helm.tf`. A single config change may require touching 2-3 files. |
-| **K8s API access requirement** | The `paragon` workspace's Helm and Kubernetes providers connect directly to the cluster API (EKS endpoint + auth token, AKS kubeconfig fields, GKE endpoint + OAuth token). This means the K8s API must be publicly accessible or the Terraform runner must be inside the VPC. |
-| **VPC runner cost** | Running Terraform inside the VPC requires Spacelift private workers (enterprise plan), self-hosted runners, or a public K8s API — all undesirable. |
-| **No GitOps / rollback** | Deployments are imperative (`terraform apply`). Rolling back means reverting state + re-applying. No automatic drift detection or self-healing. |
-| **Upgrade friction** | Upgrades require running `prepare.sh`, updating `VERSION` in values.yaml, then `terraform plan/apply` on both workspaces — a multi-step manual process. |
+| **Dual config locations** | Environment variables defined in `.secure/values.yaml`, merged/augmented in `variables.tf` locals (~200 env vars from `infra_vars` + `helm_vars`), and cloud-specific values injected via `set`/`set_sensitive` in `helm.tf`. A single config change may touch 2-3 files. |
+| **K8s API access from Spacelift** | Both `infra` (cluster-autoscaler) and `paragon` (all Helm releases) require K8s API access. The EKS endpoint must be public or the runner must be in-VPC. |
+| **VPC runner cost** | Private Spacelift workers require enterprise plan. Current workaround is public K8s API — a security concern. |
+| **No GitOps / rollback** | Deployments are imperative (`terraform apply`). Rolling back means reverting state + re-applying. No drift detection. |
+| **Upgrade friction at scale** | Monthly upgrades across 40 clusters require running `prepare.sh`, updating `VERSION`, then `terraform apply` per customer on both workspaces. Daily upgrades are impractical with this approach. |
+| **`prepare.sh` complexity** | Chart preparation involves extracting from git tags, computing SHA hashes, rsync-ing charts into provider directories, and sed-replacing version placeholders. This could be replaced by a proper Helm chart registry with versioned releases. |
 
 ---
 
 ## Proposed Architecture with ArgoCD
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│ Terraform Runner (Spacelift Starter — public API only)       │
-│                                                              │
-│  infra workspace ──► VPC, K8s cluster, Postgres, Redis, S3   │
-│       │              + ArgoCD Helm release (bootstrap)        │
-│       │              + ExternalSecrets operator (optional)    │
-│       │                                                      │
-│       ▼ outputs (infra-output.json)                          │
-│                                                              │
-│  paragon workspace (reduced) ──► Cloud-only resources:       │
-│       ALB certificates, DNS records, uptime monitors,        │
-│       Grafana IAM, Hoop API connections                      │
-│       (NO K8s API access needed)                             │
-└──────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ Spacelift (Starter) — public cloud APIs only                         │
+│                                                                      │
+│  infra workspace (single workspace) ──► cloud APIs only:             │
+│    • VPC, EKS, Postgres, Redis, S3                                   │
+│    • Karpenter (EKS addon, replaces cluster-autoscaler helm_release) │
+│    • ArgoCD bootstrap (EKS addon or one-time helm_release)           │
+│    • External Secrets Operator bootstrap                             │
+│    • ACM certificates, DNS records (moved from paragon)              │
+│    • Uptime monitors (moved from paragon)                            │
+│    • Grafana IAM (moved from paragon)                                │
+│    • Hoop API connections (moved from paragon)                       │
+│    • AWS Secrets Manager entries (infra outputs → secrets store)      │
+│                                                                      │
+│  paragon workspace ──► ELIMINATED                                    │
+└──────────────────────────────────────────────────────────────────────┘
 
-┌──────────────────────────────────────────────────────────────┐
-│ ArgoCD (runs inside the K8s cluster)                         │
-│                                                              │
-│  Watches this Git repo ──► Deploys Helm charts:              │
-│    • paragon-onprem (all microservices)                       │
-│    • paragon-logging (fluent-bit + openobserve)              │
-│    • paragon-monitoring (grafana, prometheus, exporters)      │
-│    • managed-sync (when enabled)                             │
-│    • bootstrap/ingress (ingress controller, cert-manager)    │
-│    • hoop agent                                              │
-│                                                              │
-│  Also manages:                                               │
-│    • Kubernetes Secrets (via ExternalSecrets or SealedSecrets)│
-│    • Namespace, ConfigMaps, StorageClass                     │
-│    • Drift detection + self-healing                          │
-│    • Automatic sync on Git push                              │
-└──────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ ArgoCD (runs inside each customer's EKS cluster)                     │
+│                                                                      │
+│  Watches versioned Helm chart repo + customer config repo:           │
+│    • paragon-onprem (all microservices)                               │
+│    • paragon-logging (fluent-bit + openobserve)                      │
+│    • paragon-monitoring (grafana, prometheus, exporters)              │
+│    • managed-sync (when enabled)                                     │
+│    • ingress controller (ALB controller / NGINX / GKE)               │
+│    • metrics-server, node-termination-handler                        │
+│    • hoop agent                                                      │
+│    • External Secrets Operator (self-managing)                       │
+│                                                                      │
+│  Secrets flow:                                                       │
+│    AWS Secrets Manager ──► ESO ──► K8s Secrets ──► Pods              │
+│                                                                      │
+│  Features:                                                           │
+│    • Automatic sync on Git push (daily releases)                     │
+│    • Drift detection + self-healing                                  │
+│    • One-click rollback                                              │
+│    • Slack notifications on sync events                              │
+│    • App-of-Apps pattern for ordered deployment                      │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -89,303 +118,487 @@ This document evaluates replacing the Terraform Helm provider (used in each clou
 
 ### 1. Can we eliminate the Terraform Helm provider entirely?
 
-**Yes, for the `paragon` workspace.** All `helm_release` resources in `{aws,azure,gcp}/workspaces/paragon/helm/` can be replaced by ArgoCD `Application` CRDs that point to the same charts in this repo.
+**Yes — from both workspaces.**
 
-**What moves to ArgoCD:**
-- `helm_release.paragon_on_prem` — the main microservices umbrella chart
-- `helm_release.paragon_logging` — fluent-bit + openobserve
-- `helm_release.paragon_monitoring` — grafana, prometheus, exporters
-- `helm_release.managed_sync` — managed sync chart (when enabled)
-- `helm_release.ingress` — AWS LB controller / NGINX ingress / GKE ingress
-- `helm_release.metricsserver` — metrics server (AWS)
-- `helm_release.cert_manager` — cert-manager (Azure)
-- `helm_release.hoopagent` — hoop agent
-- `kubernetes_namespace.paragon` — namespace creation
-- `kubernetes_secret.docker_login` — docker pull secret
-- `kubernetes_secret.paragon_secrets` — application secrets
-- `kubernetes_config_map.feature_flag_content` — feature flags
-- `kubernetes_storage_class_v1.gp3_encrypted` — storage class (AWS)
-- `module.aws_node_termination_handler` — spot termination handler
+**`paragon` workspace:** Eliminated entirely. All `helm_release` and `kubernetes_*` resources move to ArgoCD. Cloud-API-only resources move to the `infra` workspace.
 
-**What stays in Terraform (no K8s API needed):**
-- `module.alb` — ACM certificate creation/validation, DNS records (uses AWS API, not K8s)
-- `module.uptime` — BetterStack uptime monitors (uses BetterStack API)
-- `module.monitors` — IAM users for Grafana CloudWatch access (uses AWS API)
-- `module.hoop` (partially) — Hoop API connections (uses Hoop API); the `helm_release.hoopagent` moves to ArgoCD
+**`infra` workspace:** The only Helm provider usage is the `lablabs/eks-cluster-autoscaler` module which installs cluster-autoscaler via `helm_release`. This can be replaced by:
 
-**Caveat — the `infra` workspace:** The `infra/cluster/` module on AWS uses the Kubernetes/Helm provider for bootstrapping (e.g. installing the EBS CSI driver via the EKS module). This is a one-time cluster setup concern and stays in Terraform. It's a different workspace that runs during initial provisioning only.
+- **Karpenter as an EKS addon** (`aws_eks_addon` resource, same pattern as the existing EBS CSI driver, CoreDNS, kube-proxy, and vpc-cni addons in `cluster.tf`). Karpenter is the AWS-recommended successor to cluster-autoscaler and is available as a first-party EKS addon.
+- **Or:** Move cluster-autoscaler to ArgoCD along with the other charts (ArgoCD is bootstrapped first, then manages the autoscaler).
+
+Either approach eliminates the Helm and Kubernetes providers from the `infra` workspace entirely. The EBS CSI driver is already installed via `aws_eks_addon` — no Helm involved.
+
+**Result:** Zero `helm_release` resources remain in Terraform. The Helm and Kubernetes providers can be removed from `required_providers` across all workspaces.
 
 ### 2. Can we remove the need for private VPC Terraform execution?
 
-**Yes.** Today, the `paragon` workspace requires K8s API access because of the Helm and Kubernetes providers. With ArgoCD handling all in-cluster resources, the reduced `paragon` workspace only calls cloud provider APIs (AWS/Azure/GCP) and third-party APIs (BetterStack, Hoop) — none of which require VPC access.
+**Yes — completely.** With the changes above:
 
-The `infra` workspace already works without K8s API access for the bulk of its resources. The one exception is the cluster bootstrap step (EKS module Kubernetes provider), which typically runs once during initial setup and can use the public K8s endpoint temporarily.
+- `infra` workspace uses only: `aws` provider (EC2, EKS, RDS, ElastiCache, S3, IAM, KMS, Route53, ACM, Secrets Manager), `random`, `tls`, `betteruptime`, `hoop`, `cloudflare` — all public APIs
+- `paragon` workspace is eliminated
+- ArgoCD runs inside the cluster — no external runner
+
+Spacelift Starter with public runners is sufficient for all 40 clusters.
 
 ### 3. Does GitOps provide reliable, automated upgrades?
 
-**Yes.** Here's how the upgrade workflow would change:
+**Yes — and this is where the biggest operational win comes from at your scale.**
 
-| Step | Current (Terraform) | Proposed (ArgoCD) |
-|------|---------------------|-------------------|
-| 1 | Run `prepare.sh` to update charts and compute hashes | Same — `prepare.sh` or GitHub Actions workflow updates charts in-repo |
-| 2 | Update `VERSION` in `.secure/values.yaml` | Update `VERSION` in values file committed to Git (or in ArgoCD `Application` spec) |
-| 3 | Run `terraform plan` + `terraform apply` in paragon workspace | **Automatic** — ArgoCD detects Git changes and syncs |
-| 4 | Wait for Terraform to complete (~15-20 min timeout per release) | ArgoCD applies changes with configurable sync waves and health checks |
-| 5 | If failure: manually debug Terraform state | If failure: ArgoCD shows sync status, can auto-rollback |
+**Current upgrade workflow (per customer):**
+1. Run `prepare.sh -p aws -t <VERSION>` (extracts from git tag, hashes charts, rsync, sed-replaces versions)
+2. Update `VERSION` in `.secure/values.yaml`
+3. `terraform apply` in infra workspace
+4. `terraform apply` in paragon workspace
+5. Repeat 40 times for monthly releases
 
-**Key improvements:**
-- **No manual `terraform apply` step** — Git push triggers deployment
-- **Sync waves** ensure ordering (ingress → secrets → paragon-onprem → logging → monitoring)
-- **Health checks** prevent unhealthy deployments from progressing
-- **Automatic retry** on transient failures
-- **Existing `update-charts.yaml` GitHub Action** can be extended to commit version bumps, triggering automatic deployment
+**Proposed upgrade workflow:**
+1. CI publishes new chart versions to a Helm chart registry (OCI-based, e.g. ECR, GitHub Container Registry, or S3-hosted)
+2. `update-charts.yaml` GitHub Action updates chart version references in the `enterprise-deployments` repo (or this repo)
+3. ArgoCD detects the change and syncs automatically across all 40 clusters
+4. Slack notification confirms success/failure per cluster
+
+**Going from monthly to daily:** The current workflow is impractical for daily releases across 40 clusters. With ArgoCD, a single Git commit can trigger deployments to all clusters simultaneously, with per-cluster health checks and automatic rollback on failure.
+
+**Removing `prepare.sh`:** Your instinct to have the GitHub Action set chart versions directly and host charts externally is exactly right. With a proper Helm chart registry:
+- Charts are published with semantic versions as part of CI/CD
+- ArgoCD `Application` manifests reference charts by `repository` + `chart` + `targetRevision` (version constraint)
+- No more rsync-ing charts into provider directories, no SHA hash-based synthetic versions, no `__PARAGON_VERSION__` sed replacements
+- `prepare.sh` becomes unnecessary
 
 ### 4. Does this improve rollback and drift handling?
 
-**Significantly.**
+**Significantly — and this is critical for daily releases.**
 
 **Rollback:**
-- **Current:** Requires reverting Terraform state files, re-running `terraform apply`, and dealing with potential state drift. The Helm provider's `atomic = true` helps with individual release failures, but cross-release rollback is manual.
-- **With ArgoCD:** `argocd app rollback <app> <revision>` or clicking "Rollback" in the UI. ArgoCD maintains a history of all synced Git revisions. Rolling back to a previous revision re-deploys the exact chart + values from that commit.
+- **Current:** Revert Terraform state + re-apply. At 40 clusters, a bad monthly release is a multi-day incident.
+- **With ArgoCD:** `argocd app rollback <app> <revision>` per cluster, or automated via sync policy. ArgoCD maintains history of every synced Git revision. A bad daily release can be rolled back in minutes.
 
 **Drift detection:**
-- **Current:** None. If someone `kubectl edit`s a deployment or a Helm release is manually modified, Terraform has no idea until the next `plan` (which may be weeks later).
-- **With ArgoCD:** Continuous drift detection. ArgoCD compares live cluster state against the desired state in Git every 3 minutes (default). Drift is visible in the UI and can be auto-corrected (`selfHeal: true`).
+- **Current:** None. If someone `kubectl edit`s a resource, it goes undetected until the next `terraform plan`.
+- **With ArgoCD:** Continuous comparison of live state vs. Git (every 3 min default). Drift is visible in the ArgoCD UI and can be auto-corrected with `selfHeal: true`. Slack notifications on drift events.
 
 ### 5. Does this allow us to remain on Spacelift Starter?
 
-**Yes.** Spacelift Starter supports public Terraform operations. With ArgoCD handling all K8s-facing work:
-
-- `infra` workspace: provisions cloud infrastructure via cloud provider APIs (public) ✓
-- `paragon` workspace (reduced): manages cloud-only resources via cloud provider APIs (public) ✓
-- ArgoCD: runs inside the cluster, no external runner needed ✓
-
-No private workers, no VPC runners, no enterprise plan required.
+**Yes.** All Terraform operations become cloud-API-only. No K8s API access from Spacelift. No private workers needed. The `enterprise-deployments` repo Spacelift stacks continue to work — they just run a simpler, single `infra` workspace per customer.
 
 ### 6. Does GitOps simplify multi-customer application management?
 
-**Yes, substantially.**
+**Yes — especially given the `enterprise-deployments` repo structure.**
 
-**Current model per customer:**
-1. Clone/fork this repo
-2. Configure `.secure/values.yaml` and `.secure/infra-output.json`
-3. Run `terraform apply` in infra workspace
-4. Run `terraform apply` in paragon workspace
-5. For upgrades: repeat steps 1-4 manually
+Since customer configs already live as Spacelift stacks in `enterprise-deployments`, the migration path is:
 
-**Proposed model with ArgoCD:**
+1. **Infra workspace** continues to be managed by Spacelift stacks in `enterprise-deployments` (provisions cloud resources + bootstraps ArgoCD)
+2. **`infra` workspace outputs** are written to AWS Secrets Manager (instead of `infra-output.json`)
+3. **ArgoCD** in each cluster reads Application manifests from this repo (chart definitions) and customer-specific values from the `enterprise-deployments` repo (via ArgoCD multi-source or a config branch)
+4. **External Secrets Operator** pulls secrets from AWS Secrets Manager into K8s Secrets
 
-**Option A: App-of-Apps pattern (recommended)**
-- One ArgoCD instance per customer cluster (see Q7 below)
-- A "root" `Application` deploys child `Application` resources for each chart
-- Customer-specific values stored in a per-customer branch or overlay directory
-- Upgrades: update chart versions in Git → all customers auto-deploy (or use Progressive Delivery)
+**Upgrade across 40 clusters:** Update the chart version in a single place → ArgoCD syncs all clusters. No per-customer Terraform apply.
 
-**Option B: ApplicationSet with Git Generator**
-- If managing multiple customers from a central ArgoCD, `ApplicationSet` with a Git generator can template `Application` resources per customer directory
-- Each customer gets a directory like `customers/<org>/values.yaml`
-- Adding a new customer = adding a directory with their values
-
-Both options reduce per-customer upgrade effort from "manual Terraform apply per customer" to "Git commit."
+**Adding a new customer:** Create Spacelift stack in `enterprise-deployments` (infra only), run `terraform apply` once (provisions infra + bootstraps ArgoCD), ArgoCD auto-deploys all charts.
 
 ### 7. Should each cluster have its own ArgoCD instance?
 
-**Yes — strongly recommended** for this deployment model, for several reasons:
+**Yes — this is the clear choice given your requirements:**
 
-| Consideration | Dedicated ArgoCD per cluster | Central ArgoCD |
-|---------------|------------------------------|----------------|
-| **Network access** | ArgoCD runs in the cluster it manages — no cross-VPC connectivity needed | Central ArgoCD needs network access to every customer cluster (complex, security concern) |
-| **Customer isolation** | Complete isolation — each customer's ArgoCD only sees their cluster | Central instance has credentials for all clusters (blast radius) |
-| **Failure domain** | ArgoCD failure affects only one customer | Central failure affects all customers |
-| **Credential management** | ArgoCD uses in-cluster ServiceAccount — no external credentials | Needs kubeconfig/tokens for every remote cluster |
-| **Sovereignty** | Runs in customer's own cloud account | May violate data residency requirements |
-| **Scalability** | No single bottleneck | Central ArgoCD must handle all clusters |
-
-**Recommended approach:**
-- Install ArgoCD as part of the `infra` workspace (Terraform installs the ArgoCD Helm chart during cluster bootstrap — this is a one-time operation)
-- ArgoCD's `Application` CRDs are stored in this Git repo
-- Each customer cluster's ArgoCD watches this repo (same branch or customer-specific branch)
-- ArgoCD manages itself after initial bootstrap (ArgoCD managing its own `Application`)
+- **Auditable with minimal centralized connections** — each ArgoCD is isolated, operates on in-cluster ServiceAccount only, audit trail per cluster
+- **40 customer clusters in separate cloud accounts** — no cross-VPC connectivity needed
+- **Hoop deployed everywhere** — Hoop agent can provide audited access to each ArgoCD instance when needed
+- **No compliance concerns with centralization** — each customer's ArgoCD touches only their cluster
 
 ---
 
-## Implementation Approach
+## Answering Your Two New Questions
 
-### What changes in this repo
+### Q1: Can the EBS CSI driver and ArgoCD be deployed without `helm_release`?
 
-#### New: ArgoCD Application manifests
+**Yes — both can be deployed without the Terraform Helm provider.**
 
-A new top-level directory (e.g. `argocd/`) would contain:
+**EBS CSI driver:** Already deployed without `helm_release`. It uses `aws_eks_addon` in `aws/workspaces/infra/cluster/cluster.tf`:
 
-```
-argocd/
-├── base/                          # Base Application manifests
-│   ├── bootstrap.yaml             # Ingress controller, cert-manager, etc.
-│   ├── paragon-onprem.yaml        # Main microservices
-│   ├── paragon-logging.yaml       # Logging stack
-│   ├── paragon-monitoring.yaml    # Monitoring stack
-│   ├── managed-sync.yaml          # Managed sync (optional)
-│   └── hoop.yaml                  # Hoop agent (optional)
-├── overlays/
-│   ├── aws/                       # AWS-specific values/patches
-│   ├── azure/                     # Azure-specific values/patches
-│   └── gcp/                       # GCP-specific values/patches
-└── app-of-apps.yaml               # Root Application that deploys all others
-```
-
-#### Changed: `infra` workspace
-
-Add ArgoCD installation:
 ```hcl
-resource "helm_release" "argocd" {
-  name       = "argocd"
-  repository = "https://argoproj.github.io/argo-helm"
-  chart      = "argo-cd"
-  namespace  = "argocd"
-  # ... minimal config, ArgoCD manages itself after this
+resource "aws_eks_addon" "addons" {
+  for_each = local.cluster_addons  # includes "aws-ebs-csi-driver"
+  addon_name   = each.key
+  addon_version = try(each.value.version, null)
+  cluster_name = module.eks.cluster_name
+  service_account_role_arn = each.key == "aws-ebs-csi-driver"
+    ? module.aws_ebs_csi_driver_iam_role.iam_role_arn : null
+  # ...
 }
 ```
 
-#### Changed: `paragon` workspace
+This is a pure AWS API call — no Kubernetes or Helm provider needed. The `aws_eks_addon` resource talks to the EKS control plane API (an AWS API), not the Kubernetes API directly.
 
-Remove:
-- All `helm_release` resources
-- All `kubernetes_*` resources  
-- Helm and Kubernetes providers
-- `helm/` submodule entirely
+**ArgoCD:** Multiple options, none requiring the Terraform Helm provider:
 
-Keep (cloud-API-only resources):
-- `alb/` — certificate management, DNS
-- `monitors/` — IAM for Grafana
-- `uptime/` — BetterStack monitors
-- `hoop/` (API connections only, not the Helm release)
+| Option | How it works | Terraform provider needed |
+|--------|-------------|--------------------------|
+| **EKS Blueprints Addon** | Use the `aws_eks_addon` resource with the ArgoCD add-on from the EKS marketplace | `aws` only |
+| **EKS Blueprints ArgoCD module** | Terraform module `aws-ia/eks-blueprints-addons/aws` supports ArgoCD as a managed add-on — it uses `helm_release` internally, but only during initial bootstrap | `helm` (one-time bootstrap only) |
+| **`kubectl apply` via `null_resource`** | Apply ArgoCD's install manifests via a `local-exec` provisioner that runs `kubectl apply` | None (just `null_resource`) |
+| **Bootstrapped via user-data / cloud-init** | EKS node bootstrap script or a Lambda function applies ArgoCD manifests post-cluster-creation | None |
+| **ArgoCD Autopilot** | CLI tool that bootstraps ArgoCD and configures it to manage itself from a Git repo | None (one-time CLI run) |
 
-#### Changed: Values management
+**Recommended approach:** Use `aws_eks_addon` if the ArgoCD EKS marketplace add-on meets your version/config needs. Otherwise, accept a minimal `helm_release` for the one-time ArgoCD bootstrap — this is the only Helm resource in the entire codebase, runs once per cluster creation, and ArgoCD self-manages after that. The K8s API endpoint can be temporarily public during initial provisioning and then restricted.
 
-Currently, Terraform merges `.secure/values.yaml` + `infra-output.json` + computed locals into a single `helm_values` map. With ArgoCD, this merging must happen differently:
+**Cluster-autoscaler (the other Helm usage in `infra`):** The `lablabs/eks-cluster-autoscaler` module currently uses `helm_release`. Options:
 
-**Option A: Pre-computed values file (simplest)**
-- A script (or GitHub Action) takes `infra-output.json` + `.secure/values.yaml` and produces a complete `values.yaml` committed to a customer branch
-- ArgoCD uses this single file
-- Pro: Simple, transparent, auditable in Git history
-- Con: Requires a "compile" step; secrets in Git (mitigated by SealedSecrets/SOPS/ExternalSecrets)
+1. **Replace with Karpenter EKS addon:** `aws_eks_addon` with `eks-pod-identity-agent` + Karpenter. Pure AWS API, no Helm provider. Karpenter is AWS's recommended autoscaler.
+2. **Move cluster-autoscaler to ArgoCD:** After ArgoCD bootstraps, it manages the cluster-autoscaler Helm chart. Removes it from Terraform.
+3. **Replace with EKS Auto Mode:** If on EKS 1.29+, EKS Auto Mode provides managed Karpenter — no addon or Helm chart needed at all. Just a cluster configuration flag.
 
-**Option B: ArgoCD + External Secrets Operator**
-- Chart values contain non-secret config only
-- Secrets are stored in the cloud secret manager (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager)
-- External Secrets Operator syncs cloud secrets → K8s Secrets
-- ArgoCD deploys the charts, referencing the K8s Secrets
-- Pro: No secrets in Git; aligns with cloud-native secret management
-- Con: Additional operator to manage; more moving parts
+Any of these eliminates the last `helm_release` from the `infra` workspace, allowing you to remove the Helm and Kubernetes providers entirely.
 
-**Option C: Helm value files + ArgoCD multi-source**
-- ArgoCD Application uses [multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/) — one for the chart, one for the values file (from a separate repo or path)
-- Pro: Clean separation of chart code and customer config
-- Con: Requires ArgoCD 2.6+
+### Q2: Can paragon workspace resources that won't be replaced by ArgoCD move to infra?
 
-**Recommendation:** Option B (External Secrets Operator) combined with Option C (multi-source). This eliminates secrets from Git entirely and cleanly separates concerns. The current pattern of Terraform writing `kubernetes_secret` resources maps directly to External Secrets syncing from cloud secret stores.
+**Yes — and this is the recommended approach.** It eliminates the `paragon` workspace entirely, leaving a single `infra` Terraform workspace per customer.
 
-### Migration path
+Here's what each submodule needs and whether it can move:
 
-The migration can be done incrementally per cloud provider, per customer:
+#### AWS `paragon` → `infra` migration
 
-1. **Phase 0: ArgoCD bootstrap** — Add ArgoCD Helm release to `infra` workspace. All three cloud providers.
-2. **Phase 1: Non-critical charts first** — Move `paragon-monitoring` and `paragon-logging` to ArgoCD. These are lowest risk.
-3. **Phase 2: Ingress and bootstrap** — Move ingress controller and cert-manager to ArgoCD.
-4. **Phase 3: Core application** — Move `paragon-onprem` to ArgoCD. This is the highest-value, highest-risk migration.
-5. **Phase 4: Managed sync** — Move `managed-sync` to ArgoCD.
-6. **Phase 5: Cleanup** — Remove Helm/Kubernetes providers from `paragon` workspace. Simplify the workspace to cloud-API-only resources.
+| Module | Current providers | Depends on K8s? | Can move to infra? | Dependencies to resolve |
+|--------|-------------------|------------------|--------------------|-----------------------|
+| **`alb/`** | `aws`, `cloudflare` | No, but has `depends_on` on `release_ingress` and `release_paragon_on_prem` | **Yes** | Remove Helm release dependencies. ALB is created by the ingress controller (deployed by ArgoCD). DNS records can use a data source to find the ALB after ArgoCD deploys ingress, or use a known/predictable LB name. |
+| **`uptime/`** | `betteruptime` | No | **Yes** | Needs `microservices` map with `public_url` values. These are deterministic from `organization` + `domain` — can be computed in `infra` locals. |
+| **`monitors/`** | `aws`, `random` | No | **Yes** | Needs Grafana/PGAdmin credentials. These can be generated in `infra` and stored in Secrets Manager. |
+| **`helm-config/`** | `random`, `tls` | No | **Yes** | Needs `base_helm_values`, `infra_values`, `microservices`, `domain`. The infra workspace already has `infra_values` (it produces them). `base_helm_values` and `microservices` can be computed from the same inputs. Generated secrets (random passwords, TLS keys) should be written to AWS Secrets Manager for ESO to sync. |
+| **`hoop/` (API part)** | `hoop` | **Partial** — `hoop_connection` depends on `data.kubernetes_secret.hoop_cluster_admin_token` | **Mostly yes, with redesign** | See detailed analysis below. |
 
-Each phase can be tested on a single customer before rolling out broadly.
+#### Hoop module: detailed migration analysis
+
+The Hoop module has two distinct parts:
+
+**Part 1: In-cluster resources (moves to ArgoCD)**
+- `helm_release.hoopagent` — Hoop agent chart
+- `kubernetes_service_account.hoop_cluster_admin` — SA for cluster access
+- `kubernetes_cluster_role_binding` — RBAC
+- `kubernetes_secret` — SA token
+
+**Part 2: Hoop API resources (moves to infra — with redesign)**
+- `hoop_connection.all_connections` — API calls to Hoop SaaS
+- `hoop_connection.postgres_connections` — API calls to Hoop SaaS
+- `hoop_plugin_connection.*` — API calls to Hoop SaaS
+- `hoop_plugin_config.*` — Slack integration config
+
+The problem: `hoop_connection` resources currently `depends_on` a `data.kubernetes_secret` (the SA token). This creates a K8s API dependency. To move Hoop API resources to the `infra` workspace:
+
+**Option A (recommended):** Remove the `depends_on` on `data.kubernetes_secret.hoop_cluster_admin_token`. The Hoop connections don't actually *use* the token value — the dependency is only for ordering (ensure the SA exists before creating connections). In the ArgoCD model, the SA is created by ArgoCD when deploying the Hoop agent chart. The Hoop API connections can be created independently — they reference the agent by `agent_id`, not by the SA token. The connections will work once the agent comes online.
+
+**Option B:** Use a two-phase approach — `infra` creates connections, ArgoCD deploys the agent. The agent registers with Hoop using its `hoop_key`, and connections are already configured. This is the standard Hoop workflow.
+
+#### Azure and GCP: same pattern
+
+Azure and GCP `paragon` workspaces have the same submodule structure minus `alb/` (they have `dns/` instead). The `dns/` module uses Cloudflare and depends on the load balancer IP/hostname from the Helm ingress — same dependency resolution as AWS `alb/`.
+
+#### Result: single `infra` workspace
+
+After migration:
+
+```
+{provider}/workspaces/infra/
+├── bastion/          (existing)
+├── cluster/          (existing — minus cluster-autoscaler helm)
+├── kafka/            (existing)
+├── network/          (existing)
+├── postgres/         (existing)
+├── redis/            (existing)
+├── storage/          (existing)
+├── alb/              (moved from paragon — AWS only)
+├── dns/              (moved from paragon — Azure/GCP only)
+├── uptime/           (moved from paragon)
+├── monitors/         (moved from paragon)
+├── hoop-connections/ (moved from paragon/hoop, API-only)
+├── secrets/          (NEW — writes computed config to Secrets Manager)
+├── argocd/           (NEW — one-time bootstrap)
+├── data.tf
+├── main.tf
+├── modules.tf
+├── outputs.tf
+├── providers.tf
+└── variables.tf
+```
+
+The `paragon` workspace directory is removed. The `enterprise-deployments` repo Spacelift stacks each point to a single workspace.
+
+---
+
+## Implementation Approach (Revised)
+
+### Architecture decisions
+
+Based on the follow-up answers, the recommended architecture is:
+
+1. **Helm chart registry:** Publish charts to an OCI registry (ECR or GHCR) with semantic versioning. The `update-charts.yaml` GitHub Action publishes new versions. `prepare.sh` is retired.
+2. **External Secrets Operator + AWS Secrets Manager:** Infra workspace writes computed config (merged `infra_vars` + `helm_vars` + generated credentials) to Secrets Manager. ESO syncs to K8s Secrets. No secrets in Git.
+3. **ArgoCD multi-source Applications:** Chart source from the registry, values from the `enterprise-deployments` repo (customer-specific non-secret config).
+4. **App-of-Apps with sync waves:** Ordered deployment (ingress → secrets → core app → logging → monitoring).
+5. **ArgoCD Notifications:** Slack integration for sync events across all 40 clusters.
+6. **Per-cluster ArgoCD:** Each of the 40 clusters runs its own ArgoCD instance.
+
+### Secrets and config flow (detailed)
+
+This is the most significant architectural change. Currently, `variables.tf` computes ~200 env vars by merging:
+- `infra_vars` (from `infra-output.json`) — database endpoints, Redis hosts, S3 buckets, IAM credentials
+- `helm_vars` (from `.secure/values.yaml`) — application config, license, feature flags
+- Computed locals — service URLs, ports, private URLs, storage config
+- `helm-config/secrets.tf` — managed sync credentials (random passwords, TLS keys, Kafka/Redis/Postgres config)
+
+**Proposed replacement:**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Terraform infra workspace                                    │
+│                                                              │
+│  1. Provisions infra (existing)                              │
+│  2. Computes merged config (same logic as current            │
+│     variables.tf, but outputs to Secrets Manager             │
+│     instead of helm_values)                                  │
+│  3. Writes to AWS Secrets Manager:                           │
+│     • paragon/<org>/env → all env vars (merged)              │
+│     • paragon/<org>/managed-sync → managed sync secrets      │
+│     • paragon/<org>/docker-cfg → docker credentials          │
+│     • paragon/<org>/openobserve → logging credentials        │
+└─────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ External Secrets Operator (in-cluster, deployed by ArgoCD)   │
+│                                                              │
+│  ExternalSecret CRDs reference Secrets Manager paths:        │
+│  • paragon-secrets ← paragon/<org>/env                       │
+│  • docker-cfg ← paragon/<org>/docker-cfg                     │
+│  • managed-sync-secrets ← paragon/<org>/managed-sync         │
+└─────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────────────────────────────┐
+│ ArgoCD Applications (Helm charts from registry)              │
+│                                                              │
+│  Charts reference K8s Secrets by name (same as today):       │
+│  • secretName: "paragon-secrets"                             │
+│  • imagePullSecrets: "docker-cfg"                            │
+│                                                              │
+│  Non-secret values (ports, domains, feature flags)           │
+│  come from values files in enterprise-deployments repo       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+This preserves the existing `variables.tf` merge logic — it just outputs to Secrets Manager instead of `helm_values`. The charts don't need to change at all since they already reference `paragon-secrets` by name.
+
+### Chart hosting and versioning
+
+**Current:** Charts live in this repo under `charts/`, are copied/prepared by `prepare.sh`, and versioned with SHA hashes of file contents.
+
+**Proposed:**
+1. Charts move to their own repo (or stay here, but are published as artifacts)
+2. CI pipeline on chart changes: `helm package` → `helm push` to OCI registry
+3. Versions follow semver (e.g., `paragon-onprem:2026.04.01`)
+4. ArgoCD Applications reference charts by registry URL + version constraint
+5. `update-charts.yaml` updates the version reference, triggering ArgoCD sync
+
+This means:
+- **`prepare.sh` is retired** — no more rsync, hash computation, sed replacements
+- **Charts are immutable, versioned artifacts** — reproducible deployments
+- **ArgoCD can use version ranges** (e.g., `~2026.04`) for auto-updates within a minor version
+
+### Migration path (revised for 40 AWS-primary clusters)
+
+#### Phase 0: Foundation (no customer impact)
+- Publish charts to OCI registry alongside existing mechanism
+- Add ArgoCD bootstrap to `infra` workspace (disabled by default via variable)
+- Add Secrets Manager output module to `infra` workspace
+- Add External Secrets Operator ArgoCD Application manifest
+- Replace `lablabs/eks-cluster-autoscaler` with Karpenter EKS addon (or move to ArgoCD)
+- Remove Helm/Kubernetes providers from `infra` workspace
+
+#### Phase 1: Pilot (1 internal/test cluster)
+- Enable ArgoCD on pilot cluster
+- Deploy `paragon-monitoring` and `paragon-logging` via ArgoCD (lowest risk)
+- `terraform state rm` those Helm releases from pilot's paragon workspace
+- Validate Slack notifications, drift detection, self-healing
+
+#### Phase 2: Expand pilot (same cluster)
+- Move ingress controller, metrics-server, node-termination-handler to ArgoCD
+- Move `paragon-onprem` to ArgoCD
+- Move managed-sync to ArgoCD (if enabled on pilot)
+- Move Hoop agent to ArgoCD
+- Validate full deployment lifecycle: upgrade, rollback, drift correction
+
+#### Phase 3: Consolidate pilot workspace
+- Move `alb/`, `uptime/`, `monitors/`, `hoop-connections/` into `infra` workspace
+- Eliminate `paragon` workspace on pilot cluster
+- Validate single-workspace Spacelift stack
+
+#### Phase 4: Roll out to remaining AWS clusters (batched)
+- Migrate in batches of ~5-10 clusters
+- Each batch: enable ArgoCD, `terraform state rm` Helm releases, validate
+- Consolidate to single workspace per batch
+- Leverage ArgoCD ApplicationSet for batch operations
+
+#### Phase 5: Azure and GCP clusters
+- Adapt ArgoCD Application manifests for Azure (NGINX ingress, cert-manager) and GCP (GKE ingress)
+- Same phased migration pattern
+
+#### Phase 6: Cleanup
+- Remove `paragon` workspace directories from all providers
+- Retire `prepare.sh`
+- Update `enterprise-deployments` repo Spacelift stacks to single workspace
+- Update documentation
+
+### ArgoCD Application structure
+
+```yaml
+# app-of-apps.yaml — root Application
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: paragon
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/useparagon/enterprise
+    path: argocd/apps
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+
+---
+# argocd/apps/paragon-onprem.yaml — child Application
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: paragon-onprem
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: default
+  sources:
+    - repoURL: oci://ghcr.io/useparagon/charts  # or ECR
+      chart: paragon-onprem
+      targetRevision: "2026.04.*"  # auto-update within patch
+      helm:
+        valueFiles:
+          - $values/customers/acme/values.yaml
+    - repoURL: https://github.com/useparagon/enterprise-deployments
+      ref: values
+      targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: paragon
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 30s
+        factor: 2
+```
+
+### Slack notifications configuration
+
+```yaml
+# ArgoCD Notifications ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+data:
+  service.slack: |
+    token: $slack-token
+  template.app-sync-succeeded: |
+    slack:
+      attachments: |
+        [{
+          "color": "#18be52",
+          "title": "{{.app.metadata.name}} synced",
+          "text": "Application {{.app.metadata.name}} synced to {{.app.status.sync.revision}}"
+        }]
+  template.app-sync-failed: |
+    slack:
+      attachments: |
+        [{
+          "color": "#E96D76",
+          "title": "{{.app.metadata.name}} sync failed",
+          "text": "Application {{.app.metadata.name}} failed to sync"
+        }]
+  trigger.on-sync-succeeded: |
+    - when: app.status.operationState.phase in ['Succeeded']
+      send: [app-sync-succeeded]
+  trigger.on-sync-failed: |
+    - when: app.status.operationState.phase in ['Error', 'Failed']
+      send: [app-sync-failed]
+```
 
 ---
 
 ## Risks and Considerations
 
-### Secrets management transition
+### Secrets management transition (highest complexity)
 
-The biggest complexity is how `variables.tf` currently computes ~200 environment variables by merging `infra_vars` and `helm_vars`. This logic (in `aws/workspaces/paragon/variables.tf` lines 607-834 and equivalents for Azure/GCP) must be replicated outside Terraform. Options:
+The `variables.tf` merge logic (~200 env vars) is the core complexity. Strategy:
+- **Keep the same Terraform logic**, but change the output target from `helm_values → helm_release` to `computed_config → aws_secretsmanager_secret`
+- The `helm-config/secrets.tf` module's `random_password`/`tls_private_key` values are in Terraform state. For existing clusters, import these values into Secrets Manager during migration (read from state, write to SM). For new clusters, generate fresh values.
+- **Validate:** Diff the Secrets Manager content against the current `kubernetes_secret` data to ensure no values were lost.
 
-- **Script-based:** Extend `prepare.sh` or `generate-tfvars.mjs` to produce a complete values file
-- **External Secrets:** Store computed values in cloud secret managers during `infra` workspace apply
-- **Init container:** A Kubernetes init container or operator that reads infra outputs and generates config
+### ALB/DNS dependency on ingress controller
 
-### The `helm-config` module complexity
+The `alb/` module currently depends on `helm_release.ingress` (to wait for the ALB to exist before creating DNS records). With ArgoCD deploying ingress, the ALB creation is asynchronous. Options:
+- Use `data.aws_lb` with a retry/wait mechanism in Terraform
+- Create the ALB pre-provisioned in Terraform and have the ingress controller adopt it (AWS LB Controller supports this via annotations)
+- Accept eventual consistency — DNS records can be created pointing to the expected ALB name; they resolve once ArgoCD deploys ingress
 
-The `helm-config/secrets.tf` module (used for managed sync) generates secrets by merging infra outputs with helm values and generating random credentials (`random_password`, `random_string`, `tls_private_key`). This stateful generation needs careful migration — the random values are stored in Terraform state and must not change during migration.
+### State migration for 40 clusters
 
-### Cloud-specific ingress differences
+Each cluster has Terraform state containing Helm release resources. Migration per cluster:
+1. `terraform state rm` all `helm_release.*` and `kubernetes_*` resources
+2. Run `terraform apply` (no-op — resources are removed from state)
+3. ArgoCD adopts the running workloads
 
-Each cloud handles ingress differently:
-- **AWS:** ALB Controller Helm release + ALB `Ingress` annotations
-- **Azure:** NGINX Ingress Controller + cert-manager + `kubectl_manifest` for `ClusterIssuer`
-- **GCP:** `kubectl_manifest` for GKE-native ingress + `FrontendConfig`/`ManagedCertificate`
+This is safe because we're not destroying resources — just removing them from Terraform's knowledge. The workloads continue running. ArgoCD compares live state against desired state and takes over management.
 
-ArgoCD handles all of these, but the cloud-specific Application manifests will differ.
+### ArgoCD availability
 
-### ArgoCD itself needs management
+ArgoCD is a critical-path component for deployments. Mitigations:
+- ArgoCD runs as a highly-available deployment (3 replicas by default)
+- If ArgoCD is down, existing workloads continue running — only new deployments are blocked
+- ArgoCD can manage its own upgrades (self-managing Application)
+- Hoop provides audited access to each cluster's ArgoCD for troubleshooting
 
-ArgoCD is another piece of infrastructure to maintain. However:
-- It's a mature CNCF graduated project
-- It runs as a Helm release in the cluster
-- It can manage its own upgrades (self-managing pattern)
-- The operational overhead is low compared to the current Terraform-based deployment complexity
+### Managed sync complexity
 
-### State migration
+`helm-config/secrets.tf` generates substantial config for managed-sync (Kafka, Postgres, Redis, OpenFGA, storage, monitoring — 100+ keys). This module stays in Terraform (moved to `infra`) and writes to Secrets Manager. ESO syncs to `paragon-managed-sync-secrets`. The managed-sync chart already expects to read from that secret name — no chart changes needed.
 
-Existing `helm_release` resources have Terraform state. Migration requires:
-1. `terraform state rm` the Helm releases from Terraform state
-2. Import the running Helm releases into ArgoCD
-3. ArgoCD adopts existing resources without disruption
-
-ArgoCD supports adopting existing resources via the `argocd.argoproj.io/managed-by` annotation and `Replace=true` sync option.
-
----
-
-## Summary: Evaluation Matrix
-
-| Criterion | Current (Terraform Helm) | Proposed (ArgoCD) |
-|-----------|--------------------------|-------------------|
-| K8s API access from CI | Required (public or VPC runner) | Not required |
-| Spacelift plan | Enterprise (private runners) or public K8s API | Starter (public cloud APIs only) |
-| Upgrade automation | Manual `terraform apply` | Automatic on Git push |
-| Rollback | Complex (state revert + re-apply) | One-click / one-command |
-| Drift detection | None | Continuous (every 3 min) |
-| Self-healing | None | Automatic with `selfHeal: true` |
-| Config duplication | High (TF locals + values.yaml + set blocks) | Lower (single values source per app) |
-| Multi-customer scaling | Per-customer `terraform apply` | Git-driven, automatable |
-| Observability | Terraform logs | ArgoCD UI + CLI + notifications |
-| Secrets in Git | N/A (Terraform state) | Solved via External Secrets Operator |
+Since managed sync is only enabled for a subset of customers, this complexity only applies during migration for those clusters.
 
 ---
 
-## Follow-up Questions
+## Summary: Evaluation Matrix (Updated)
 
-To refine this evaluation further, it would be helpful to clarify:
-
-1. **How many customer clusters are actively deployed today?** This affects the migration timeline and whether an ApplicationSet approach is worthwhile vs. per-customer branches.
-
-2. **Is there an existing secret management solution (AWS Secrets Manager, HashiCorp Vault, etc.) in use?** This determines whether External Secrets Operator can leverage existing secret stores or if new ones need to be created.
-
-3. **Is the `managed_sync_enabled` feature used by all customers or a subset?** The `helm-config` module's stateful secret generation (random passwords, TLS keys) is the most complex part of the migration. Understanding adoption helps prioritize.
-
-4. **Are there customers on all three cloud providers (AWS, Azure, GCP), or is one dominant?** This helps prioritize which cloud provider to migrate first.
-
-5. **How frequently are upgrades pushed to customers today?** If upgrades are infrequent, the GitOps automation benefit is lower-priority. If frequent, it's high-priority.
-
-6. **Is there a preference for how customer-specific config is organized?** Options include:
-   - Per-customer branches in this repo
-   - A separate "config" repo with per-customer directories
-   - Per-customer values files in a `.secure/` convention
-
-7. **Does Paragon's managed enterprise offering (mentioned in README) use the same Terraform approach?** If so, ArgoCD could benefit that workflow too, enabling the managed team to push upgrades via Git rather than running Terraform per customer.
-
-8. **Are there any compliance/regulatory requirements around who can deploy to customer clusters?** ArgoCD's RBAC and audit logging may need to satisfy specific compliance frameworks.
-
-9. **Is the `hoop` module deployed to all customers?** The Hoop agent Helm release is straightforward to move to ArgoCD, but the Hoop API connections (managed via the Hoop Terraform provider) must remain in Terraform.
-
-10. **Would you like ArgoCD notifications (Slack, email) on sync success/failure?** ArgoCD supports rich notification integrations that could replace manual monitoring of Terraform apply outputs.
-
-11. **Is the existing GitHub Actions workflow (`update-charts.yaml`) triggered automatically or manually?** Understanding the current automation level helps design the GitOps trigger chain.
-
-12. **What is the current state management for Terraform? (Spacelift managed, S3 backend, Terraform Cloud?)** The `main.tf.example` pattern suggests varied backends. Understanding this helps plan the state migration for removing Helm releases from Terraform.
+| Criterion | Current (Terraform Helm) | Proposed (ArgoCD + ESO) |
+|-----------|--------------------------|-------------------------|
+| Terraform workspaces per customer | 2 (infra + paragon) | **1 (infra only)** |
+| K8s API access from CI | Required (both workspaces on AWS) | **Not required** |
+| Spacelift plan required | Enterprise (private runners) or public K8s API | **Starter (public APIs only)** |
+| Upgrade frequency achievable | Monthly (manual per-customer) | **Daily (Git push → auto-sync)** |
+| Upgrade effort per release | `prepare.sh` + `terraform apply` × 40 clusters | **Single Git commit** |
+| Rollback | Complex (state revert + re-apply × 40) | **One-click per cluster, automatable** |
+| Drift detection | None | **Continuous (3 min interval)** |
+| Self-healing | None | **Automatic (`selfHeal: true`)** |
+| Config duplication | High (TF locals + values.yaml + set blocks) | **Single source (Secrets Manager + values file)** |
+| Secrets management | Terraform state (S3) | **AWS Secrets Manager (cloud-native)** |
+| Deployment observability | Terraform logs in Spacelift | **ArgoCD UI + Slack notifications** |
+| Chart management | `prepare.sh` + in-repo copies | **OCI registry with semver** |
+| Adding new customer | 2 Spacelift stacks + manual setup | **1 Spacelift stack + auto-deploy** |

--- a/docs/argocd-evaluation.md
+++ b/docs/argocd-evaluation.md
@@ -1,0 +1,391 @@
+# ArgoCD Deployment Evaluation
+
+## Executive Summary
+
+This document evaluates replacing the Terraform Helm provider (used in each cloud provider's `paragon` workspace) with ArgoCD for managing Helm chart deployments. The goal is to eliminate the need for Terraform to access the Kubernetes API, enable GitOps-based upgrades and rollbacks, and simplify multi-customer deployment management.
+
+**Recommendation:** ArgoCD can replace the `paragon` workspace's Helm release management and deliver meaningful improvements across all evaluation criteria. The `infra` workspace remains unchanged — it provisions cloud infrastructure (VPC, databases, K8s cluster, storage) and does not require K8s API access. The `paragon` workspace can be decomposed: some resources stay in Terraform (ALB certificates, DNS, uptime monitors, Grafana IAM), while all Helm releases and in-cluster resources move to ArgoCD.
+
+---
+
+## Current Architecture Analysis
+
+### How it works today
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ Terraform Runner (Spacelift / local)                                │
+│                                                                     │
+│  infra workspace ──► VPC, K8s cluster, Postgres, Redis, S3/GCS/Blob│
+│       │                                                             │
+│       ▼ outputs (infra-output.json)                                 │
+│                                                                     │
+│  paragon workspace ──► K8s API ──► helm_release resources           │
+│       │                    ▲        (paragon-onprem, logging,       │
+│       │                    │         monitoring, managed-sync,       │
+│       │                    │         ingress, metrics-server, hoop)  │
+│       │                    │                                        │
+│       │              Requires direct network                        │
+│       │              access to K8s API                              │
+│       │              (public endpoint or VPC runner)                │
+│       │                                                             │
+│       └──► kubernetes_secret, kubernetes_namespace,                  │
+│            kubernetes_config_map, kubernetes_storage_class           │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Pain points identified
+
+| Problem | Details |
+|---------|---------|
+| **Dual config locations** | Environment variables are defined in `.secure/values.yaml` (Helm values), merged/augmented in `variables.tf` locals (200+ env vars constructed from `infra_vars` + `helm_vars`), and cloud-specific values injected via `set`/`set_sensitive` in `helm.tf`. A single config change may require touching 2-3 files. |
+| **K8s API access requirement** | The `paragon` workspace's Helm and Kubernetes providers connect directly to the cluster API (EKS endpoint + auth token, AKS kubeconfig fields, GKE endpoint + OAuth token). This means the K8s API must be publicly accessible or the Terraform runner must be inside the VPC. |
+| **VPC runner cost** | Running Terraform inside the VPC requires Spacelift private workers (enterprise plan), self-hosted runners, or a public K8s API — all undesirable. |
+| **No GitOps / rollback** | Deployments are imperative (`terraform apply`). Rolling back means reverting state + re-applying. No automatic drift detection or self-healing. |
+| **Upgrade friction** | Upgrades require running `prepare.sh`, updating `VERSION` in values.yaml, then `terraform plan/apply` on both workspaces — a multi-step manual process. |
+
+---
+
+## Proposed Architecture with ArgoCD
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Terraform Runner (Spacelift Starter — public API only)       │
+│                                                              │
+│  infra workspace ──► VPC, K8s cluster, Postgres, Redis, S3   │
+│       │              + ArgoCD Helm release (bootstrap)        │
+│       │              + ExternalSecrets operator (optional)    │
+│       │                                                      │
+│       ▼ outputs (infra-output.json)                          │
+│                                                              │
+│  paragon workspace (reduced) ──► Cloud-only resources:       │
+│       ALB certificates, DNS records, uptime monitors,        │
+│       Grafana IAM, Hoop API connections                      │
+│       (NO K8s API access needed)                             │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│ ArgoCD (runs inside the K8s cluster)                         │
+│                                                              │
+│  Watches this Git repo ──► Deploys Helm charts:              │
+│    • paragon-onprem (all microservices)                       │
+│    • paragon-logging (fluent-bit + openobserve)              │
+│    • paragon-monitoring (grafana, prometheus, exporters)      │
+│    • managed-sync (when enabled)                             │
+│    • bootstrap/ingress (ingress controller, cert-manager)    │
+│    • hoop agent                                              │
+│                                                              │
+│  Also manages:                                               │
+│    • Kubernetes Secrets (via ExternalSecrets or SealedSecrets)│
+│    • Namespace, ConfigMaps, StorageClass                     │
+│    • Drift detection + self-healing                          │
+│    • Automatic sync on Git push                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Answering the Key Questions
+
+### 1. Can we eliminate the Terraform Helm provider entirely?
+
+**Yes, for the `paragon` workspace.** All `helm_release` resources in `{aws,azure,gcp}/workspaces/paragon/helm/` can be replaced by ArgoCD `Application` CRDs that point to the same charts in this repo.
+
+**What moves to ArgoCD:**
+- `helm_release.paragon_on_prem` — the main microservices umbrella chart
+- `helm_release.paragon_logging` — fluent-bit + openobserve
+- `helm_release.paragon_monitoring` — grafana, prometheus, exporters
+- `helm_release.managed_sync` — managed sync chart (when enabled)
+- `helm_release.ingress` — AWS LB controller / NGINX ingress / GKE ingress
+- `helm_release.metricsserver` — metrics server (AWS)
+- `helm_release.cert_manager` — cert-manager (Azure)
+- `helm_release.hoopagent` — hoop agent
+- `kubernetes_namespace.paragon` — namespace creation
+- `kubernetes_secret.docker_login` — docker pull secret
+- `kubernetes_secret.paragon_secrets` — application secrets
+- `kubernetes_config_map.feature_flag_content` — feature flags
+- `kubernetes_storage_class_v1.gp3_encrypted` — storage class (AWS)
+- `module.aws_node_termination_handler` — spot termination handler
+
+**What stays in Terraform (no K8s API needed):**
+- `module.alb` — ACM certificate creation/validation, DNS records (uses AWS API, not K8s)
+- `module.uptime` — BetterStack uptime monitors (uses BetterStack API)
+- `module.monitors` — IAM users for Grafana CloudWatch access (uses AWS API)
+- `module.hoop` (partially) — Hoop API connections (uses Hoop API); the `helm_release.hoopagent` moves to ArgoCD
+
+**Caveat — the `infra` workspace:** The `infra/cluster/` module on AWS uses the Kubernetes/Helm provider for bootstrapping (e.g. installing the EBS CSI driver via the EKS module). This is a one-time cluster setup concern and stays in Terraform. It's a different workspace that runs during initial provisioning only.
+
+### 2. Can we remove the need for private VPC Terraform execution?
+
+**Yes.** Today, the `paragon` workspace requires K8s API access because of the Helm and Kubernetes providers. With ArgoCD handling all in-cluster resources, the reduced `paragon` workspace only calls cloud provider APIs (AWS/Azure/GCP) and third-party APIs (BetterStack, Hoop) — none of which require VPC access.
+
+The `infra` workspace already works without K8s API access for the bulk of its resources. The one exception is the cluster bootstrap step (EKS module Kubernetes provider), which typically runs once during initial setup and can use the public K8s endpoint temporarily.
+
+### 3. Does GitOps provide reliable, automated upgrades?
+
+**Yes.** Here's how the upgrade workflow would change:
+
+| Step | Current (Terraform) | Proposed (ArgoCD) |
+|------|---------------------|-------------------|
+| 1 | Run `prepare.sh` to update charts and compute hashes | Same — `prepare.sh` or GitHub Actions workflow updates charts in-repo |
+| 2 | Update `VERSION` in `.secure/values.yaml` | Update `VERSION` in values file committed to Git (or in ArgoCD `Application` spec) |
+| 3 | Run `terraform plan` + `terraform apply` in paragon workspace | **Automatic** — ArgoCD detects Git changes and syncs |
+| 4 | Wait for Terraform to complete (~15-20 min timeout per release) | ArgoCD applies changes with configurable sync waves and health checks |
+| 5 | If failure: manually debug Terraform state | If failure: ArgoCD shows sync status, can auto-rollback |
+
+**Key improvements:**
+- **No manual `terraform apply` step** — Git push triggers deployment
+- **Sync waves** ensure ordering (ingress → secrets → paragon-onprem → logging → monitoring)
+- **Health checks** prevent unhealthy deployments from progressing
+- **Automatic retry** on transient failures
+- **Existing `update-charts.yaml` GitHub Action** can be extended to commit version bumps, triggering automatic deployment
+
+### 4. Does this improve rollback and drift handling?
+
+**Significantly.**
+
+**Rollback:**
+- **Current:** Requires reverting Terraform state files, re-running `terraform apply`, and dealing with potential state drift. The Helm provider's `atomic = true` helps with individual release failures, but cross-release rollback is manual.
+- **With ArgoCD:** `argocd app rollback <app> <revision>` or clicking "Rollback" in the UI. ArgoCD maintains a history of all synced Git revisions. Rolling back to a previous revision re-deploys the exact chart + values from that commit.
+
+**Drift detection:**
+- **Current:** None. If someone `kubectl edit`s a deployment or a Helm release is manually modified, Terraform has no idea until the next `plan` (which may be weeks later).
+- **With ArgoCD:** Continuous drift detection. ArgoCD compares live cluster state against the desired state in Git every 3 minutes (default). Drift is visible in the UI and can be auto-corrected (`selfHeal: true`).
+
+### 5. Does this allow us to remain on Spacelift Starter?
+
+**Yes.** Spacelift Starter supports public Terraform operations. With ArgoCD handling all K8s-facing work:
+
+- `infra` workspace: provisions cloud infrastructure via cloud provider APIs (public) ✓
+- `paragon` workspace (reduced): manages cloud-only resources via cloud provider APIs (public) ✓
+- ArgoCD: runs inside the cluster, no external runner needed ✓
+
+No private workers, no VPC runners, no enterprise plan required.
+
+### 6. Does GitOps simplify multi-customer application management?
+
+**Yes, substantially.**
+
+**Current model per customer:**
+1. Clone/fork this repo
+2. Configure `.secure/values.yaml` and `.secure/infra-output.json`
+3. Run `terraform apply` in infra workspace
+4. Run `terraform apply` in paragon workspace
+5. For upgrades: repeat steps 1-4 manually
+
+**Proposed model with ArgoCD:**
+
+**Option A: App-of-Apps pattern (recommended)**
+- One ArgoCD instance per customer cluster (see Q7 below)
+- A "root" `Application` deploys child `Application` resources for each chart
+- Customer-specific values stored in a per-customer branch or overlay directory
+- Upgrades: update chart versions in Git → all customers auto-deploy (or use Progressive Delivery)
+
+**Option B: ApplicationSet with Git Generator**
+- If managing multiple customers from a central ArgoCD, `ApplicationSet` with a Git generator can template `Application` resources per customer directory
+- Each customer gets a directory like `customers/<org>/values.yaml`
+- Adding a new customer = adding a directory with their values
+
+Both options reduce per-customer upgrade effort from "manual Terraform apply per customer" to "Git commit."
+
+### 7. Should each cluster have its own ArgoCD instance?
+
+**Yes — strongly recommended** for this deployment model, for several reasons:
+
+| Consideration | Dedicated ArgoCD per cluster | Central ArgoCD |
+|---------------|------------------------------|----------------|
+| **Network access** | ArgoCD runs in the cluster it manages — no cross-VPC connectivity needed | Central ArgoCD needs network access to every customer cluster (complex, security concern) |
+| **Customer isolation** | Complete isolation — each customer's ArgoCD only sees their cluster | Central instance has credentials for all clusters (blast radius) |
+| **Failure domain** | ArgoCD failure affects only one customer | Central failure affects all customers |
+| **Credential management** | ArgoCD uses in-cluster ServiceAccount — no external credentials | Needs kubeconfig/tokens for every remote cluster |
+| **Sovereignty** | Runs in customer's own cloud account | May violate data residency requirements |
+| **Scalability** | No single bottleneck | Central ArgoCD must handle all clusters |
+
+**Recommended approach:**
+- Install ArgoCD as part of the `infra` workspace (Terraform installs the ArgoCD Helm chart during cluster bootstrap — this is a one-time operation)
+- ArgoCD's `Application` CRDs are stored in this Git repo
+- Each customer cluster's ArgoCD watches this repo (same branch or customer-specific branch)
+- ArgoCD manages itself after initial bootstrap (ArgoCD managing its own `Application`)
+
+---
+
+## Implementation Approach
+
+### What changes in this repo
+
+#### New: ArgoCD Application manifests
+
+A new top-level directory (e.g. `argocd/`) would contain:
+
+```
+argocd/
+├── base/                          # Base Application manifests
+│   ├── bootstrap.yaml             # Ingress controller, cert-manager, etc.
+│   ├── paragon-onprem.yaml        # Main microservices
+│   ├── paragon-logging.yaml       # Logging stack
+│   ├── paragon-monitoring.yaml    # Monitoring stack
+│   ├── managed-sync.yaml          # Managed sync (optional)
+│   └── hoop.yaml                  # Hoop agent (optional)
+├── overlays/
+│   ├── aws/                       # AWS-specific values/patches
+│   ├── azure/                     # Azure-specific values/patches
+│   └── gcp/                       # GCP-specific values/patches
+└── app-of-apps.yaml               # Root Application that deploys all others
+```
+
+#### Changed: `infra` workspace
+
+Add ArgoCD installation:
+```hcl
+resource "helm_release" "argocd" {
+  name       = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-cd"
+  namespace  = "argocd"
+  # ... minimal config, ArgoCD manages itself after this
+}
+```
+
+#### Changed: `paragon` workspace
+
+Remove:
+- All `helm_release` resources
+- All `kubernetes_*` resources  
+- Helm and Kubernetes providers
+- `helm/` submodule entirely
+
+Keep (cloud-API-only resources):
+- `alb/` — certificate management, DNS
+- `monitors/` — IAM for Grafana
+- `uptime/` — BetterStack monitors
+- `hoop/` (API connections only, not the Helm release)
+
+#### Changed: Values management
+
+Currently, Terraform merges `.secure/values.yaml` + `infra-output.json` + computed locals into a single `helm_values` map. With ArgoCD, this merging must happen differently:
+
+**Option A: Pre-computed values file (simplest)**
+- A script (or GitHub Action) takes `infra-output.json` + `.secure/values.yaml` and produces a complete `values.yaml` committed to a customer branch
+- ArgoCD uses this single file
+- Pro: Simple, transparent, auditable in Git history
+- Con: Requires a "compile" step; secrets in Git (mitigated by SealedSecrets/SOPS/ExternalSecrets)
+
+**Option B: ArgoCD + External Secrets Operator**
+- Chart values contain non-secret config only
+- Secrets are stored in the cloud secret manager (AWS Secrets Manager, Azure Key Vault, GCP Secret Manager)
+- External Secrets Operator syncs cloud secrets → K8s Secrets
+- ArgoCD deploys the charts, referencing the K8s Secrets
+- Pro: No secrets in Git; aligns with cloud-native secret management
+- Con: Additional operator to manage; more moving parts
+
+**Option C: Helm value files + ArgoCD multi-source**
+- ArgoCD Application uses [multiple sources](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/) — one for the chart, one for the values file (from a separate repo or path)
+- Pro: Clean separation of chart code and customer config
+- Con: Requires ArgoCD 2.6+
+
+**Recommendation:** Option B (External Secrets Operator) combined with Option C (multi-source). This eliminates secrets from Git entirely and cleanly separates concerns. The current pattern of Terraform writing `kubernetes_secret` resources maps directly to External Secrets syncing from cloud secret stores.
+
+### Migration path
+
+The migration can be done incrementally per cloud provider, per customer:
+
+1. **Phase 0: ArgoCD bootstrap** — Add ArgoCD Helm release to `infra` workspace. All three cloud providers.
+2. **Phase 1: Non-critical charts first** — Move `paragon-monitoring` and `paragon-logging` to ArgoCD. These are lowest risk.
+3. **Phase 2: Ingress and bootstrap** — Move ingress controller and cert-manager to ArgoCD.
+4. **Phase 3: Core application** — Move `paragon-onprem` to ArgoCD. This is the highest-value, highest-risk migration.
+5. **Phase 4: Managed sync** — Move `managed-sync` to ArgoCD.
+6. **Phase 5: Cleanup** — Remove Helm/Kubernetes providers from `paragon` workspace. Simplify the workspace to cloud-API-only resources.
+
+Each phase can be tested on a single customer before rolling out broadly.
+
+---
+
+## Risks and Considerations
+
+### Secrets management transition
+
+The biggest complexity is how `variables.tf` currently computes ~200 environment variables by merging `infra_vars` and `helm_vars`. This logic (in `aws/workspaces/paragon/variables.tf` lines 607-834 and equivalents for Azure/GCP) must be replicated outside Terraform. Options:
+
+- **Script-based:** Extend `prepare.sh` or `generate-tfvars.mjs` to produce a complete values file
+- **External Secrets:** Store computed values in cloud secret managers during `infra` workspace apply
+- **Init container:** A Kubernetes init container or operator that reads infra outputs and generates config
+
+### The `helm-config` module complexity
+
+The `helm-config/secrets.tf` module (used for managed sync) generates secrets by merging infra outputs with helm values and generating random credentials (`random_password`, `random_string`, `tls_private_key`). This stateful generation needs careful migration — the random values are stored in Terraform state and must not change during migration.
+
+### Cloud-specific ingress differences
+
+Each cloud handles ingress differently:
+- **AWS:** ALB Controller Helm release + ALB `Ingress` annotations
+- **Azure:** NGINX Ingress Controller + cert-manager + `kubectl_manifest` for `ClusterIssuer`
+- **GCP:** `kubectl_manifest` for GKE-native ingress + `FrontendConfig`/`ManagedCertificate`
+
+ArgoCD handles all of these, but the cloud-specific Application manifests will differ.
+
+### ArgoCD itself needs management
+
+ArgoCD is another piece of infrastructure to maintain. However:
+- It's a mature CNCF graduated project
+- It runs as a Helm release in the cluster
+- It can manage its own upgrades (self-managing pattern)
+- The operational overhead is low compared to the current Terraform-based deployment complexity
+
+### State migration
+
+Existing `helm_release` resources have Terraform state. Migration requires:
+1. `terraform state rm` the Helm releases from Terraform state
+2. Import the running Helm releases into ArgoCD
+3. ArgoCD adopts existing resources without disruption
+
+ArgoCD supports adopting existing resources via the `argocd.argoproj.io/managed-by` annotation and `Replace=true` sync option.
+
+---
+
+## Summary: Evaluation Matrix
+
+| Criterion | Current (Terraform Helm) | Proposed (ArgoCD) |
+|-----------|--------------------------|-------------------|
+| K8s API access from CI | Required (public or VPC runner) | Not required |
+| Spacelift plan | Enterprise (private runners) or public K8s API | Starter (public cloud APIs only) |
+| Upgrade automation | Manual `terraform apply` | Automatic on Git push |
+| Rollback | Complex (state revert + re-apply) | One-click / one-command |
+| Drift detection | None | Continuous (every 3 min) |
+| Self-healing | None | Automatic with `selfHeal: true` |
+| Config duplication | High (TF locals + values.yaml + set blocks) | Lower (single values source per app) |
+| Multi-customer scaling | Per-customer `terraform apply` | Git-driven, automatable |
+| Observability | Terraform logs | ArgoCD UI + CLI + notifications |
+| Secrets in Git | N/A (Terraform state) | Solved via External Secrets Operator |
+
+---
+
+## Follow-up Questions
+
+To refine this evaluation further, it would be helpful to clarify:
+
+1. **How many customer clusters are actively deployed today?** This affects the migration timeline and whether an ApplicationSet approach is worthwhile vs. per-customer branches.
+
+2. **Is there an existing secret management solution (AWS Secrets Manager, HashiCorp Vault, etc.) in use?** This determines whether External Secrets Operator can leverage existing secret stores or if new ones need to be created.
+
+3. **Is the `managed_sync_enabled` feature used by all customers or a subset?** The `helm-config` module's stateful secret generation (random passwords, TLS keys) is the most complex part of the migration. Understanding adoption helps prioritize.
+
+4. **Are there customers on all three cloud providers (AWS, Azure, GCP), or is one dominant?** This helps prioritize which cloud provider to migrate first.
+
+5. **How frequently are upgrades pushed to customers today?** If upgrades are infrequent, the GitOps automation benefit is lower-priority. If frequent, it's high-priority.
+
+6. **Is there a preference for how customer-specific config is organized?** Options include:
+   - Per-customer branches in this repo
+   - A separate "config" repo with per-customer directories
+   - Per-customer values files in a `.secure/` convention
+
+7. **Does Paragon's managed enterprise offering (mentioned in README) use the same Terraform approach?** If so, ArgoCD could benefit that workflow too, enabling the managed team to push upgrades via Git rather than running Terraform per customer.
+
+8. **Are there any compliance/regulatory requirements around who can deploy to customer clusters?** ArgoCD's RBAC and audit logging may need to satisfy specific compliance frameworks.
+
+9. **Is the `hoop` module deployed to all customers?** The Hoop agent Helm release is straightforward to move to ArgoCD, but the Hoop API connections (managed via the Hoop Terraform provider) must remain in Terraform.
+
+10. **Would you like ArgoCD notifications (Slack, email) on sync success/failure?** ArgoCD supports rich notification integrations that could replace manual monitoring of Terraform apply outputs.
+
+11. **Is the existing GitHub Actions workflow (`update-charts.yaml`) triggered automatically or manually?** Understanding the current automation level helps design the GitOps trigger chain.
+
+12. **What is the current state management for Terraform? (Spacelift managed, S3 backend, Terraform Cloud?)** The `main.tf.example` pattern suggests varied backends. Understanding this helps plan the state migration for removing Helm releases from Terraform.

--- a/docs/argocd-evaluation.md
+++ b/docs/argocd-evaluation.md
@@ -4,9 +4,9 @@
 
 This document evaluates replacing the Terraform Helm provider (used in each cloud provider's `paragon` workspace) with ArgoCD for managing Helm chart deployments across 40 customer clusters (primarily AWS). The goal is to eliminate the need for Terraform to access the Kubernetes API, enable daily GitOps-based upgrades (up from monthly), provide rollback and drift detection, and stay on Spacelift Starter.
 
-**Recommendation:** Adopt ArgoCD with External Secrets Operator (ESO). The entire `paragon` workspace can be eliminated by moving cloud-API-only resources (ALB, DNS, uptime, monitors, Hoop API connections) into the `infra` workspace and moving all Helm releases / K8s resources to ArgoCD. The `infra` workspace's Helm/Kubernetes provider dependency (cluster-autoscaler module) can also be removed by switching to the EKS-managed Karpenter addon. ArgoCD itself can be bootstrapped via an EKS addon (the ArgoCD EKS add-on from the AWS marketplace) or a single `helm_release` during initial cluster provisioning.
+**Recommendation:** Adopt ArgoCD with External Secrets Operator (ESO). The entire `paragon` workspace can be eliminated by moving cloud-API-only resources (ALB, DNS, uptime, monitors, Hoop API connections) into the `infra` workspace and moving all Helm releases / K8s resources to ArgoCD. The `infra` workspace's Helm/Kubernetes provider dependency (cluster-autoscaler module) can also be removed by moving the autoscaler to ArgoCD management (and optionally migrating to Karpenter later). ArgoCD itself can be bootstrapped without a public K8s API on all three clouds — via EKS addon on AWS, `az aks command invoke` on Azure, and GKE Connect Gateway on GCP.
 
-This results in a single Terraform workspace (`infra`) that only calls cloud provider APIs — no K8s API access, no private runners, Spacelift Starter is sufficient.
+This results in a single Terraform workspace (`infra`) per customer that only calls cloud provider APIs — no K8s API access, no private runners, Spacelift Starter is sufficient. The Karpenter migration is recommended but should be decoupled from the ArgoCD adoption to reduce risk across the 40 clusters.
 
 ---
 
@@ -208,7 +208,7 @@ Since customer configs already live as Spacelift stacks in `enterprise-deploymen
 
 ---
 
-## Answering Your Two New Questions
+## Answering Additional Questions
 
 ### Q1: Can the EBS CSI driver and ArgoCD be deployed without `helm_release`?
 
@@ -249,6 +249,108 @@ This is a pure AWS API call — no Kubernetes or Helm provider needed. The `aws_
 3. **Replace with EKS Auto Mode:** If on EKS 1.29+, EKS Auto Mode provides managed Karpenter — no addon or Helm chart needed at all. Just a cluster configuration flag.
 
 Any of these eliminates the last `helm_release` from the `infra` workspace, allowing you to remove the Helm and Kubernetes providers entirely.
+
+### Q3: Can ArgoCD be deployed to Azure and GCP clusters without a public K8s API?
+
+**Yes — and Azure/GCP are actually easier than AWS in this regard.**
+
+The key insight is that ArgoCD runs *inside* the cluster it manages. It never needs external K8s API access — it uses the in-cluster ServiceAccount. The question is really about how to *bootstrap* ArgoCD onto a private cluster, since Terraform (running outside the cluster) can't reach the K8s API.
+
+#### Azure (AKS)
+
+The Azure `infra` workspace already has **no Kubernetes or Helm providers** — `providers.tf` only declares `azurerm` and `azuread`. AKS is provisioned entirely via `azurerm_kubernetes_cluster` and `azurerm_kubernetes_cluster_node_pool` resources (pure Azure ARM API calls). There is nothing to remove.
+
+**Bootstrap options for ArgoCD on private AKS:**
+
+| Option | How it works | Needs public API? |
+|--------|-------------|-------------------|
+| **AKS GitOps extension (Flux-based)** | `azurerm_kubernetes_cluster_extension` with `extension_type = "Microsoft.Flux"` — a native AKS feature that installs GitOps from the Azure API. While this installs Flux rather than ArgoCD, it can be used to bootstrap ArgoCD as the first Flux `HelmRelease`. | **No** — pure Azure ARM API |
+| **AKS `command invoke`** | `azurerm_kubernetes_command` (or `az aks command invoke` via `null_resource`) runs `kubectl`/`helm` commands on the cluster through the Azure API, tunneled via the managed control plane. Works even with fully private endpoints. | **No** — tunneled through Azure API |
+| **Azure Deployment Script** | `azurerm_resource_group_template_deployment` with a deployment script that runs inside the VNet and applies ArgoCD manifests. | **No** — runs in-VNet |
+| **One-time `helm_release`** | Accept a single `helm_release` for bootstrap, same as AWS. Run `terraform apply` once with public endpoint, then disable it. | **Temporarily** — one-time only |
+
+**Recommended for Azure:** Use `az aks command invoke` via a `null_resource` / `local-exec` provisioner. This is the simplest option — it sends `kubectl apply` commands through the Azure API without exposing the K8s endpoint. Example:
+
+```hcl
+resource "null_resource" "argocd_bootstrap" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      az aks command invoke \
+        --resource-group ${azurerm_kubernetes_cluster.cluster.resource_group_name} \
+        --name ${azurerm_kubernetes_cluster.cluster.name} \
+        --command "kubectl create namespace argocd && kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml"
+    EOT
+  }
+  depends_on = [azurerm_kubernetes_cluster_node_pool.pool]
+}
+```
+
+After this one-time bootstrap, ArgoCD manages itself (self-managing Application) and all other charts. No ongoing external K8s API access needed.
+
+#### GCP (GKE)
+
+The GCP `infra` workspace also has **no Kubernetes or Helm providers** — `providers.tf` only declares `google` and `google-beta`. The GKE cluster is provisioned via the `terraform-google-modules/kubernetes-engine/google//modules/private-cluster` module, which already supports a `disable_public_endpoint` variable (currently exposed as `var.disable_public_endpoint` in the cluster config).
+
+**Bootstrap options for ArgoCD on private GKE:**
+
+| Option | How it works | Needs public API? |
+|--------|-------------|-------------------|
+| **GKE Config Management** | `google_gke_hub_feature` + `google_gke_hub_feature_membership` with Config Sync — a native GKE feature that enables GitOps via the GCP API. Can bootstrap ArgoCD as its first sync target. | **No** — pure GCP API |
+| **Connect Gateway** | GKE Connect Gateway (`gcloud container fleet memberships generate-gateway-rbac`) allows `kubectl` access through the GCP API for Fleet-enrolled clusters. Use a `null_resource` with `gcloud` commands to apply ArgoCD manifests via the gateway. | **No** — tunneled through GCP API |
+| **Bastion / IAP tunnel** | The GCP infra workspace already provisions a bastion. A `null_resource` can SSH through IAP to the bastion and run `kubectl apply` to install ArgoCD. | **No** — tunneled through IAP |
+| **Master authorized networks** | The GKE module already supports `master_authorized_networks`. Allow the Spacelift runner's IP temporarily, apply ArgoCD, then remove. | **Temporarily** — restricted window |
+| **One-time `helm_release`** | Same as AWS/Azure — accept a one-time Helm provider usage during initial provisioning. | **Temporarily** |
+
+**Recommended for GCP:** Use GKE Connect Gateway via `null_resource`. Fleet enrollment is a single `google_gke_hub_membership` resource (GCP API), and `kubectl` commands then go through the GCP API without exposing the K8s endpoint. Alternatively, if the bastion is already provisioned, tunnel through it.
+
+#### Summary: ArgoCD bootstrap without public K8s API
+
+| Cloud | Current K8s/Helm provider in `infra`? | ArgoCD bootstrap method | Public K8s API needed? |
+|-------|---------------------------------------|------------------------|----------------------|
+| **AWS** | Yes (cluster-autoscaler only) | `aws_eks_addon` or one-time `helm_release` | EKS addon: **No**. `helm_release`: temporarily |
+| **Azure** | **No** | `az aks command invoke` via `null_resource` | **No** |
+| **GCP** | **No** | GKE Connect Gateway or bastion tunnel via `null_resource` | **No** |
+
+Azure and GCP are actually in a better position than AWS — their `infra` workspaces already have zero Helm/K8s provider usage, and both clouds offer API-tunneled `kubectl` access for the one-time ArgoCD bootstrap.
+
+### Q4: Are there other downsides or benefits to switching to the Karpenter addon for AWS?
+
+The current setup uses `lablabs/eks-cluster-autoscaler` (Helm-based Cluster Autoscaler) in the `infra` workspace and `qvest-digital/aws-node-termination-handler` (Helm-based NTH) in the `paragon` workspace. Switching to Karpenter replaces both.
+
+#### Benefits
+
+| Benefit | Details |
+|---------|---------|
+| **Eliminates Helm/K8s providers from `infra`** | The cluster-autoscaler module is the only reason the AWS `infra` workspace needs the Helm and Kubernetes providers. Karpenter as an EKS addon (`aws_eks_addon`) is a pure AWS API call — same pattern as the existing EBS CSI, CoreDNS, kube-proxy, and vpc-cni addons. |
+| **Eliminates aws-node-termination-handler** | Karpenter natively handles spot interruptions, instance rebalancing, and EC2 health events. The separate `aws_node_termination_handler` module (currently in the `paragon/helm/` workspace) is no longer needed. That's one less Helm chart to manage. |
+| **Faster scaling** | Cluster Autoscaler works at the Auto Scaling Group level — it adjusts `desired_count` and waits for the ASG to provision. Karpenter provisions EC2 instances directly, bypassing the ASG. Typical improvement: 60-90 seconds vs. 3-5 minutes for new nodes. |
+| **Better instance selection** | Cluster Autoscaler is limited to the instance types defined in the managed node group. The current config uses `eks_ondemand_node_instance_type` and `eks_spot_node_instance_type` (single-type lists). Karpenter can dynamically select from a wide range of instance types based on pod requirements and availability, improving cost and availability. |
+| **Simplified node group management** | Currently, Terraform manages explicit node groups with `module.eks_managed_node_group` (on-demand and spot pools with separate instance types, min/max counts). Karpenter replaces this with `NodePool` and `EC2NodeClass` CRDs that declaratively express constraints. Node groups become optional or can be minimal (one small on-demand group for system components). |
+| **Better bin-packing** | Karpenter consolidates underutilized nodes by moving pods and terminating empty nodes. Cluster Autoscaler only scales down nodes that become fully empty (or where all pods are movable). This can reduce costs for workloads with variable load — relevant if the 40 clusters have uneven utilization. |
+| **ArgoCD-managed after bootstrap** | Since Karpenter's `NodePool`/`EC2NodeClass` CRDs are Kubernetes manifests, ArgoCD can manage them. Changes to node configuration become GitOps-driven and auditable — aligning with the overall goal. |
+| **AWS-recommended path** | AWS has officially designated Karpenter as the recommended autoscaler for EKS. The Cluster Autoscaler continues to work but receives less investment. |
+
+#### Downsides / Risks
+
+| Risk | Details | Mitigation |
+|------|---------|------------|
+| **Migration complexity for 40 clusters** | Switching autoscalers requires careful node draining. Karpenter and Cluster Autoscaler can't run simultaneously on the same node groups — Karpenter needs to manage its own nodes. | Run Karpenter alongside existing managed node groups during transition. Karpenter ignores nodes it didn't create. Gradually taint/drain old node groups as Karpenter provisions replacements. |
+| **`NodePool`/`EC2NodeClass` CRD management** | Today, node configuration is Terraform variables (`eks_ondemand_node_instance_type`, `eks_spot_instance_percent`, `eks_min/max_node_count`). With Karpenter, these become K8s CRDs. The configuration format changes. | ArgoCD manages the CRDs. Customer-specific node config goes into the same values/config system as the rest of the application. Actually a benefit — node config is now GitOps-managed alongside everything else. |
+| **Managed node groups still needed for system components** | Karpenter itself, CoreDNS, and kube-proxy need nodes to run on. You can't remove all managed node groups — you need at least a small on-demand group for the control plane components. | Keep the existing `default_node_pool` (or a minimal managed node group). The current AWS config already has separate on-demand/spot groups; the on-demand group can be minimized to a small always-on pool. |
+| **Spot handling behavioral changes** | Cluster Autoscaler + NTH uses ASG-based spot pools with explicit instance types. Karpenter uses `capacity-spread` and `on-demand` fallback. The spot behavior is different — instance diversity is broader, which is generally better but changes the cost/availability profile. | Configure Karpenter's `NodePool` with explicit `instanceTypes` constraints if you need to restrict instance families. The current `eks_spot_node_instance_type` list can be directly mapped. |
+| **IAM changes** | Karpenter needs its own IAM role with EC2 permissions (launch instances, create/tag ENIs, manage security groups). Different from the Cluster Autoscaler's ASG-only permissions. | The `aws_eks_addon` for Karpenter can use pod identity or IRSA. The EKS Blueprints addon module handles IAM automatically. Straightforward Terraform IAM resources, same pattern as the existing `aws_ebs_csi_driver_iam_role`. |
+| **Learning curve** | Operations team needs to understand Karpenter's `NodePool`/`EC2NodeClass` model instead of ASG-based autoscaling. Debugging is different (Karpenter logs vs. ASG events). | Karpenter has excellent documentation and observability. The Prometheus metrics are richer than Cluster Autoscaler's. The ArgoCD UI + Grafana dashboards provide visibility into node provisioning. |
+| **Version compatibility** | Karpenter versions are tied to specific EKS versions. Must validate compatibility with the current `k8s_version = "1.31"` in `cluster/variables.tf`. | Karpenter v1.x supports EKS 1.25+. Version 1.31 is well within support range. Pin the addon version, same as other EKS addons. |
+| **Terraform variable changes** | The current `eks_spot_instance_percent`, `eks_min/max_node_count`, `eks_ondemand/spot_node_instance_type` variables in `infra/cluster/variables.tf` no longer directly apply. The 40 customers' `vars.auto.tfvars` files reference these. | During migration, keep the variables but use them to generate Karpenter `NodePool` CRDs (via a ConfigMap or ArgoCD values). Or migrate customer configs in the `enterprise-deployments` repo to the new Karpenter-native format. |
+
+#### Recommendation
+
+**Switch to Karpenter, but decouple it from the ArgoCD migration.**
+
+- **Phase 0 (ArgoCD migration):** Keep Cluster Autoscaler as-is but move it from `infra` Terraform to ArgoCD management (ArgoCD installs the existing cluster-autoscaler Helm chart). This eliminates the Helm provider from `infra` without changing autoscaler behavior. Also move `aws-node-termination-handler` to ArgoCD.
+- **Phase N (later):** Migrate from Cluster Autoscaler to Karpenter. This is a separate project that can be done per-cluster at your own pace. ArgoCD manages the Karpenter `NodePool` CRDs. Once migrated, remove the cluster-autoscaler and NTH ArgoCD Applications.
+
+This avoids conflating two significant changes (GitOps migration + autoscaler migration) in one risky step across 40 clusters. However, if you want to minimize the number of migrations, doing both together on the pilot cluster (Phase 1) is reasonable — just don't batch-roll both changes to all 40 at once.
 
 ### Q2: Can paragon workspace resources that won't be replaced by ArgoCD move to infra?
 
@@ -590,15 +692,17 @@ Since managed sync is only enabled for a subset of customers, this complexity on
 | Criterion | Current (Terraform Helm) | Proposed (ArgoCD + ESO) |
 |-----------|--------------------------|-------------------------|
 | Terraform workspaces per customer | 2 (infra + paragon) | **1 (infra only)** |
-| K8s API access from CI | Required (both workspaces on AWS) | **Not required** |
-| Spacelift plan required | Enterprise (private runners) or public K8s API | **Starter (public APIs only)** |
+| K8s API access from CI | Required (both workspaces on AWS) | **Not required (any cloud)** |
+| Public K8s API required | Yes (or VPC runner) | **No — bootstrap tunneled via cloud API on all 3 clouds** |
+| Spacelift plan required | Enterprise (private runners) or public K8s API | **Starter (public cloud APIs only)** |
 | Upgrade frequency achievable | Monthly (manual per-customer) | **Daily (Git push → auto-sync)** |
 | Upgrade effort per release | `prepare.sh` + `terraform apply` × 40 clusters | **Single Git commit** |
 | Rollback | Complex (state revert + re-apply × 40) | **One-click per cluster, automatable** |
 | Drift detection | None | **Continuous (3 min interval)** |
 | Self-healing | None | **Automatic (`selfHeal: true`)** |
 | Config duplication | High (TF locals + values.yaml + set blocks) | **Single source (Secrets Manager + values file)** |
-| Secrets management | Terraform state (S3) | **AWS Secrets Manager (cloud-native)** |
+| Secrets management | Terraform state (S3) | **Cloud-native secret managers (AWS SM, Azure KV, GCP SM)** |
 | Deployment observability | Terraform logs in Spacelift | **ArgoCD UI + Slack notifications** |
 | Chart management | `prepare.sh` + in-repo copies | **OCI registry with semver** |
+| Node autoscaling | Cluster Autoscaler (Helm) + NTH (Helm) | **ArgoCD-managed (Karpenter migration optional)** |
 | Adding new customer | 2 Spacelift stacks + manual setup | **1 Spacelift stack + auto-deploy** |

--- a/docs/argocd-evaluation.md
+++ b/docs/argocd-evaluation.md
@@ -664,12 +664,210 @@ The `alb/` module currently depends on `helm_release.ingress` (to wait for the A
 
 ### State migration for 40 clusters
 
-Each cluster has Terraform state containing Helm release resources. Migration per cluster:
-1. `terraform state rm` all `helm_release.*` and `kubernetes_*` resources
-2. Run `terraform apply` (no-op — resources are removed from state)
-3. ArgoCD adopts the running workloads
+State migration requires two operations per cluster: **`terraform state rm`** to remove K8s/Helm resources from the `paragon` workspace, and **`terraform import`** to bring cloud-API resources into the `infra` workspace. The import step is critical — without it, the next `terraform apply` on `infra` would attempt to create resources that already exist, causing conflicts or destruction.
 
-This is safe because we're not destroying resources — just removing them from Terraform's knowledge. The workloads continue running. ArgoCD compares live state against desired state and takes over management.
+#### Migration strategy overview
+
+The migration is a three-step process per cluster:
+
+1. **`terraform import`** cloud-API resources into the `infra` workspace (new module addresses)
+2. **`terraform state rm`** all resources from the `paragon` workspace (both K8s-bound and cloud-API)
+3. **`terraform plan`** on both workspaces to verify zero-diff (no changes planned)
+
+Step 1 must happen before step 2 to ensure cloud resources are always managed by at least one workspace. The order prevents any window where a resource is unmanaged.
+
+#### Automation approach
+
+With 40 clusters, manual import is impractical. A migration script should:
+
+1. Read the `paragon` workspace state via `terraform state list` and `terraform state show` to extract resource IDs
+2. Map each resource to its new address in the `infra` workspace
+3. Generate and execute `terraform import` commands against the `infra` workspace
+4. Generate and execute `terraform state rm` commands against the `paragon` workspace
+5. Run `terraform plan` on both workspaces to verify zero-diff
+
+This script can be templated and run per-customer via Spacelift or a CI pipeline.
+
+#### AWS resource import inventory
+
+Resources being moved from `module.*` in the `paragon` workspace to new addresses in the `infra` workspace. The `for_each` keys and `count` indices vary per customer — the migration script must enumerate them from the source state.
+
+**`module.alb` → `module.alb` (or `module.dns`) in `infra`**
+
+| Source address | Resource type | Import ID (from state) | Notes |
+|---------------|---------------|----------------------|-------|
+| `module.alb.aws_route53_zone.paragon` | `aws_route53_zone` | Zone ID (`Z...`) | Core dependency — import first |
+| `module.alb.aws_route53_record.microservice["<key>"]` | `aws_route53_record` | `{zone_id}_{fqdn}_{type}` | `for_each` keys = service names from `merge(public_microservices, public_monitors)` |
+| `module.alb.aws_route53_record.caa` | `aws_route53_record` | `{zone_id}_{domain}_{CAA}` | Single resource |
+| `module.alb.cloudflare_record.nameserver[<n>]` | `cloudflare_record` | `{zone_id}/{record_id}` | `count` = number of NS records; only when Cloudflare is configured |
+| `module.alb.module.acm_request_certificate[0].aws_acm_certificate.default[0]` | `aws_acm_certificate` | Certificate ARN | Only when `var.certificate == null` (Terraform-managed cert) |
+| `module.alb.module.acm_request_certificate[0].aws_route53_record.default["<domain>"]` | `aws_route53_record` | `{zone_id}_{fqdn}_{type}` | ACM DNS validation records |
+
+**`module.uptime` → `module.uptime` in `infra`**
+
+| Source address | Resource type | Import ID | Notes |
+|---------------|---------------|-----------|-------|
+| `module.uptime.betteruptime_monitor_group.group[0]` | `betteruptime_monitor_group` | Numeric group ID | Only when `uptime_api_token` is set |
+| `module.uptime.betteruptime_monitor.monitor["<key>"]` | `betteruptime_monitor` | Numeric monitor ID | `for_each` keys = microservice names |
+| `module.uptime.betteruptime_grafana_integration.webhook[0]` | `betteruptime_grafana_integration` | Numeric integration ID | Single resource |
+
+**`module.monitors[0]` → `module.monitors[0]` in `infra`** (only when `monitors_enabled = true`)
+
+| Source address | Resource type | Import ID | Notes |
+|---------------|---------------|-----------|-------|
+| `module.monitors[0].aws_iam_user.grafana[0]` | `aws_iam_user` | IAM user name | Only when Grafana keys not supplied in tfvars |
+| `module.monitors[0].aws_iam_access_key.grafana[0]` | `aws_iam_access_key` | Access key ID | |
+| `module.monitors[0].aws_iam_group.grafana[0]` | `aws_iam_group` | Group name | |
+| `module.monitors[0].aws_iam_group_membership.grafana[0]` | `aws_iam_group_membership` | Membership name | |
+| `module.monitors[0].aws_iam_group_policy.grafana_ro[0]` | `aws_iam_group_policy` | `{group_name}:{policy_name}` | |
+| `module.monitors[0].random_string.grafana_admin_email_prefix[0]` | `random_string` | See note below | |
+| `module.monitors[0].random_password.grafana_admin_password[0]` | `random_password` | See note below | |
+| `module.monitors[0].random_string.pgadmin_admin_email_prefix[0]` | `random_string` | See note below | |
+| `module.monitors[0].random_password.pgadmin_admin_password[0]` | `random_password` | See note below | |
+
+**`module.managed_sync_config[0]` → `module.managed_sync_config[0]` in `infra`** (only when `managed_sync_enabled = true`)
+
+| Source address | Resource type | Import ID | Notes |
+|---------------|---------------|-----------|-------|
+| `module.managed_sync_config[0].random_string.postgres_username["openfga"]` | `random_string` | See note below | `for_each` over `["openfga", "sync_instance", "sync_project"]` |
+| `module.managed_sync_config[0].random_string.postgres_username["sync_instance"]` | `random_string` | | |
+| `module.managed_sync_config[0].random_string.postgres_username["sync_project"]` | `random_string` | | |
+| `module.managed_sync_config[0].random_password.postgres_password["openfga"]` | `random_password` | | Same `for_each` keys |
+| `module.managed_sync_config[0].random_password.postgres_password["sync_instance"]` | `random_password` | | |
+| `module.managed_sync_config[0].random_password.postgres_password["sync_project"]` | `random_password` | | |
+| `module.managed_sync_config[0].random_string.queue_exporter_username` | `random_string` | | Single resource |
+| `module.managed_sync_config[0].random_password.queue_exporter_password` | `random_password` | | |
+| `module.managed_sync_config[0].random_string.openfga_preshared_key` | `random_string` | | |
+| `module.managed_sync_config[0].tls_private_key.managed_sync_signing_key` | `tls_private_key` | Not importable — see note below | |
+
+**`module.hoop` → `module.hoop_connections` in `infra`** (cloud-API-only resources)
+
+| Source address | Resource type | Import ID | Notes |
+|---------------|---------------|-----------|-------|
+| `module.hoop.aws_iam_role.hoop_support[0]` | `aws_iam_role` | Role name | Only when OIDC provider ARN is set |
+| `module.hoop.aws_iam_role_policy_attachment.hoop_support[0]` | `aws_iam_role_policy_attachment` | `{role_name}/{policy_arn}` | |
+| `module.hoop.hoop_connection.all_connections["<key>"]` | `hoop_connection` | Connection ID from Hoop API | `for_each` keys vary per customer |
+| `module.hoop.hoop_connection.postgres_connections["<key>"]` | `hoop_connection` | Connection ID | `for_each` keys vary per customer |
+| `module.hoop.hoop_plugin_connection.custom_connections_access_control["<key>"]` | `hoop_plugin_connection` | Plugin connection ID | |
+| `module.hoop.hoop_plugin_connection.default_connections_access_control["<key>"]` | `hoop_plugin_connection` | Plugin connection ID | |
+| `module.hoop.hoop_plugin_connection.postgres_connections_access_control["<key>"]` | `hoop_plugin_connection` | Plugin connection ID | |
+| `module.hoop.hoop_plugin_config.slack[0]` | `hoop_plugin_config` | Plugin config ID | Only when Slack is enabled |
+| `module.hoop.hoop_plugin_connection.slack["<key>"]` | `hoop_plugin_connection` | Plugin connection ID | |
+
+#### Azure and GCP differences
+
+Azure and GCP have the same general pattern but with:
+- **`module.dns`** (Cloudflare records) instead of `module.alb` (Route53/ACM)
+- **No IAM resources** in Azure `module.monitors` or `module.hoop` (just `random_*` resources)
+- **GCP-specific IAM** in `module.hoop`: `google_service_account`, `google_project_iam_member`, `google_service_account_iam_member`
+
+#### Special handling for `random` and `tls` resources
+
+`random_string`, `random_password`, and `tls_private_key` resources are **stateful** — their values exist only in Terraform state. These are the most sensitive resources to migrate because:
+
+- **`random_*` import:** The `random` provider supports import, but the imported resource will generate a **new** random value on the next `apply` unless the state matches exactly. The correct approach is to use **`terraform state mv`** (state-to-state transfer) rather than `import`:
+
+  ```bash
+  # Extract from paragon state, inject into infra state
+  terraform state pull -state=paragon.tfstate | \
+    jq '.resources[] | select(.module == "module.managed_sync_config[0]")' > extracted.json
+  # Then terraform state push into infra (with address remapping)
+  ```
+
+  Alternatively, use the **`terraform_remote_state`** data source during a transition period to read values from the paragon workspace state before removing it.
+
+- **`tls_private_key` import:** The `tls` provider **does not support import** for `tls_private_key`. The private key exists only in state. Options:
+  1. **`terraform state mv`** from paragon to infra state (requires direct state manipulation)
+  2. **Read the key from state before migration,** write it to AWS Secrets Manager, and have the new Terraform config read it from there instead of generating it
+  3. **Accept key rotation** for managed-sync signing keys — generate new keys during migration and update the dependent services. This is simpler but requires coordinating the key change with the managed-sync deployment.
+
+  Recommendation: Option 2 — extract the existing key into Secrets Manager. This is already aligned with the broader move to External Secrets Operator.
+
+#### Recommended migration script outline
+
+```bash
+#!/bin/bash
+# migrate-customer.sh <customer-org> <cloud-provider>
+# Run per customer to migrate state from paragon → infra workspace
+
+set -euo pipefail
+ORG="$1"
+CLOUD="$2"
+PARAGON_DIR="${CLOUD}/workspaces/paragon"
+INFRA_DIR="${CLOUD}/workspaces/infra"
+
+# Phase 1: Extract resource IDs from paragon state
+echo "=== Extracting resource IDs from paragon workspace ==="
+cd "$PARAGON_DIR"
+
+# Get all resource addresses and their IDs
+terraform state list | while read -r addr; do
+  # Filter to cloud-API-only resources (skip helm_release, kubernetes_*)
+  case "$addr" in
+    *helm_release*|*kubernetes_*|*kubectl_manifest*|*time_sleep*) continue ;;
+  esac
+  echo "$addr"
+done > /tmp/resources_to_move.txt
+
+# For each resource, extract its import ID
+while read -r addr; do
+  terraform state show -json "$addr" | jq -r '{address: .address, id: .values.id // .values.arn // .values.zone_id}' >> /tmp/import_ids.json
+done < /tmp/resources_to_move.txt
+
+# Phase 2: Import into infra workspace
+echo "=== Importing resources into infra workspace ==="
+cd "../../$INFRA_DIR"
+
+# Map old addresses → new addresses and import
+# (address mapping depends on the new module structure)
+while read -r line; do
+  OLD_ADDR=$(echo "$line" | jq -r '.address')
+  IMPORT_ID=$(echo "$line" | jq -r '.id')
+  NEW_ADDR=$(map_address "$OLD_ADDR")  # custom function for address remapping
+
+  terraform import "$NEW_ADDR" "$IMPORT_ID"
+done < /tmp/import_ids.json
+
+# Phase 3: Handle random/tls resources via state manipulation
+echo "=== Migrating stateful resources (random, tls) ==="
+# These require terraform state mv or state pull/push
+# ... (see detailed handling above)
+
+# Phase 4: Remove all resources from paragon state
+echo "=== Removing resources from paragon workspace ==="
+cd "../../$PARAGON_DIR"
+
+terraform state list | while read -r addr; do
+  terraform state rm "$addr"
+done
+
+# Phase 5: Verify
+echo "=== Verifying zero-diff on both workspaces ==="
+cd "../../$INFRA_DIR"
+terraform plan -detailed-exitcode  # exit code 0 = no changes
+
+cd "../../$PARAGON_DIR"
+terraform plan -detailed-exitcode  # should show empty plan (no resources)
+
+echo "=== Migration complete for $ORG ==="
+```
+
+#### Migration order and batching
+
+Given 40 clusters:
+
+1. **Pilot cluster (1):** Full dry run. Execute migration script, verify zero-diff, validate all resources are intact. Document any edge cases.
+2. **Internal clusters (2-3):** Migrate a small batch of internal/test clusters. Soak for 1-2 days.
+3. **Production batches (5-10 per batch):** Roll out in batches. Between batches, verify no regressions.
+4. **Stragglers:** Handle any clusters with unique configurations (custom Hoop connections, non-standard monitors, etc.) individually.
+
+#### Rollback plan
+
+If migration fails for a cluster:
+1. The paragon workspace state still exists (until step 4) — `terraform state rm` can be undone by re-importing
+2. The infra workspace imports can be reverted with `terraform state rm`
+3. No real resources are created or destroyed during migration — only state files change
+4. Worst case: restore both state files from S3 versioned backups (S3 backend supports versioning)
 
 ### ArgoCD availability
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Issues Closed

- PARA-18824

### Brief Summary

evaluate argocd to replace terraform helm deployments

### Detailed Summary

Comprehensive evaluation of replacing the Terraform Helm provider with ArgoCD for managing Helm chart deployments across 40 customer clusters (primarily AWS). Based on thorough analysis of the current architecture and iterative Q&A.

**Key conclusions:**
- The entire `paragon` workspace can be eliminated — Helm releases move to ArgoCD, cloud-API-only resources move to `infra`
- ArgoCD can be bootstrapped without a public K8s API on all three clouds
- Karpenter migration recommended but decoupled from ArgoCD adoption
- External Secrets Operator + cloud-native secret managers for secrets
- Enables daily releases (up from monthly) across 40 clusters via single Git commit
- Spacelift Starter is sufficient — no private runners needed
- Detailed state migration plan for safely moving resources from `paragon` to `infra` across 40 clusters via `terraform import` + `terraform state rm`

### Changes

- Added `docs/argocd-evaluation.md` with:
  - Current architecture analysis with pain points
  - Proposed single-workspace + ArgoCD architecture with diagrams
  - Answers to all 7 original evaluation questions
  - Q1: EBS CSI/ArgoCD deployment without helm_release
  - Q2: Merging paragon workspace into infra (eliminates paragon entirely)
  - Q3: ArgoCD bootstrap on Azure/GCP without public K8s API
  - Q4: Karpenter benefits/risks analysis
  - **Q5 (new): Terraform state migration plan** — full resource import inventory (AWS alb, uptime, monitors, helm-config, hoop with import ID formats), special handling for `random`/`tls` stateful resources, migration script outline, batching strategy for 40 clusters, rollback plan via S3 state versioning
  - Context table from 12 follow-up Q&A
  - Detailed secrets flow design
  - Chart hosting strategy (OCI registry replacing `prepare.sh`)
  - 6-phase migration plan
  - ArgoCD Application manifest examples and Slack notification config

### Unrelated Changes

None

### Future Work

- Build migration script for automated state import/remove across 40 clusters
- Prototype ArgoCD + ESO on a test cluster (Phase 1)
- Set up OCI chart registry and CI publishing pipeline
- Build Secrets Manager output module for infra workspace
- Design `enterprise-deployments` repo changes for single-workspace stacks

### Steps to Test

This is a planning document — no code changes to test. Review the evaluation for accuracy against the current architecture.

### QA Notes

N/A — documentation only

### Deployment Notes

No deployment changes. This is an evaluation document.

### Screenshots

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02025c31-cb79-475b-9a3d-b5819e90eaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02025c31-cb79-475b-9a3d-b5819e90eaa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

