### PR TITLE
Azure standard tier storage support

### DIFF
--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -89,6 +89,7 @@ No resources.
 | <a name="input_redis_sku_name"></a> [redis\_sku\_name](#input\_redis\_sku\_name) | The SKU Name of the Redis cache (`Basic`, `Standard` or `Premium`). | `string` | `"Premium"` | no |
 | <a name="input_redis_ssl_only"></a> [redis\_ssl\_only](#input\_redis\_ssl\_only) | Flag whether only SSL connections are allowed. | `bool` | `false` | no |
 | <a name="input_ssh_whitelist"></a> [ssh\_whitelist](#input\_ssh\_whitelist) | An optional list of IP addresses to whitelist SSH access. | `string` | `""` | no |
+| <a name="input_storage_account_tier"></a> [storage\_account\_tier](#input\_storage\_account\_tier) | Storage account tier. Use "Standard" for new deployments that need public CDN container access (Premium BlockBlobStorage does not support it). | `string` | `"Premium"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for the virtual network. A `/16` (65,536 IPs) or larger is recommended. | `string` | `"10.0.0.0/16"` | no |
 
 ## Outputs

--- a/azure/workspaces/infra/modules.tf
+++ b/azure/workspaces/infra/modules.tf
@@ -71,6 +71,7 @@ module "storage" {
   source = "./storage"
 
   managed_sync_enabled       = var.managed_sync_enabled
+  storage_account_tier       = var.storage_account_tier
   auditlogs_lock_enabled     = var.auditlogs_lock_enabled
   auditlogs_retention_days   = var.auditlogs_retention_days
   resource_group             = module.network.resource_group

--- a/azure/workspaces/infra/storage/blob.tf
+++ b/azure/workspaces/infra/storage/blob.tf
@@ -16,9 +16,9 @@ resource "azurerm_storage_account" "blob" {
   resource_group_name = var.resource_group.name
   location            = var.resource_group.location
 
-  account_kind                    = "BlockBlobStorage"
+  account_kind                    = var.storage_account_tier == "Premium" ? "BlockBlobStorage" : "StorageV2"
   account_replication_type        = "LRS"
-  account_tier                    = "Premium"
+  account_tier                    = var.storage_account_tier
   allow_nested_items_to_be_public = true
   tags                            = merge(var.tags, { Name = local.storage_account_name })
 }

--- a/azure/workspaces/infra/storage/variables.tf
+++ b/azure/workspaces/infra/storage/variables.tf
@@ -31,3 +31,9 @@ variable "auditlogs_lock_enabled" {
   description = "Whether to lock the audit logs container immutability policy."
   type        = bool
 }
+
+variable "storage_account_tier" {
+  description = "Storage account tier. Use \"Standard\" for new deployments that need public CDN container access (Premium BlockBlobStorage does not support it)."
+  type        = string
+  default     = "Premium"
+}

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -252,6 +252,12 @@ variable "k8s_sku_tier" {
   }
 }
 
+variable "storage_account_tier" {
+  description = "Storage account tier. Use \"Standard\" for new deployments that need public CDN container access (Premium BlockBlobStorage does not support it)."
+  type        = string
+  default     = "Premium"
+}
+
 variable "managed_sync_enabled" {
   description = "Whether to enable managed sync."
   type        = bool

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.03.19"
+version="2026.04.07"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-20019

### Brief Summary

add configurable storage account tier for azure deployments

### Detailed Summary

Azure now blocks public container access on Premium BlockBlobStorage accounts. New enterprise deployments need a publicly accessible CDN container, which requires Standard StorageV2 instead. Rather than hardcoding the change (which would be destructive to existing deployments), a `storage_account_tier` variable was added that defaults to `"Premium"` so existing environments like dragos are unaffected, while new deployments can override it to `"Standard"`.

### Changes

- Add `storage_account_tier` variable (default `"Premium"`) at root, module, and storage levels
- Conditionally set `account_kind` to `BlockBlobStorage` or `StorageV2` based on the tier
- Pass the variable through `modules.tf` to the storage submodule

### Unrelated Changes

- Version bump in `prepare.sh`

### Future Work

- PARA-11880 - remove public access to CDN bucket
- Migrate existing deployments from Premium BlockBlobStorage to Standard StorageV2 if Azure fully deprecates public access on Premium accounts

### Steps to Test

1. Deploy a new environment with `storage_account_tier = "Standard"` — verify storage account is created as Standard StorageV2 with public CDN container access working
2. Verify an existing environment (e.g. dragos) plans with no changes when the variable is not set (defaults to Premium)

### QA Notes

N/A

### Deployment Notes

New deployments must set `storage_account_tier = "Standard"` in `vars.auto.tfvars`. Existing deployments should not set this variable — changing from Premium to Standard on a live storage account forces a destroy/recreate and loses all data.

### Screenshots

N/A