### PR TITLE
feat(charts): healthz for worker-workflows

### DIFF
--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -79,6 +79,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 6
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-templates/templates/_deployment.yaml
+++ b/charts/paragon-templates/templates/_deployment.yaml
@@ -61,6 +61,11 @@ spec:
           {{- $serviceData := fromJson (include "service.inputs" $root) }}
           {{- $category := $serviceData.category | default "" }}
           {{- if or (eq $category "microservice") (eq $category "worker") }}
+          {{- $probes := $root.Values.probes | default dict }}
+          {{- $readinessProbeCfg := index $probes "readiness" | default dict }}
+          {{- $livenessProbeCfg := index $probes "liveness" | default dict }}
+          {{- $readinessFailureThreshold := int (default 3 (index $readinessProbeCfg "failureThreshold")) }}
+          {{- $livenessFailureThreshold := int (default 3 (index $livenessProbeCfg "failureThreshold")) }}
           lifecycle:
             # need to sleep for `deregistration_delay` + 5s to prevent downtime on deployments
             # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1719#issuecomment-743452334
@@ -77,6 +82,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+            failureThreshold: {{ $livenessFailureThreshold }}
           readinessProbe:
             httpGet:
               path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
@@ -84,6 +90,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+            failureThreshold: {{ $readinessFailureThreshold }}
           startupProbe:
             httpGet:
               path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}

--- a/charts/paragon-templates/templates/_deployment.yaml
+++ b/charts/paragon-templates/templates/_deployment.yaml
@@ -61,11 +61,6 @@ spec:
           {{- $serviceData := fromJson (include "service.inputs" $root) }}
           {{- $category := $serviceData.category | default "" }}
           {{- if or (eq $category "microservice") (eq $category "worker") }}
-          {{- $probes := $root.Values.probes | default dict }}
-          {{- $readinessProbeCfg := index $probes "readiness" | default dict }}
-          {{- $livenessProbeCfg := index $probes "liveness" | default dict }}
-          {{- $readinessFailureThreshold := int (default 3 (index $readinessProbeCfg "failureThreshold")) }}
-          {{- $livenessFailureThreshold := int (default 3 (index $livenessProbeCfg "failureThreshold")) }}
           lifecycle:
             # need to sleep for `deregistration_delay` + 5s to prevent downtime on deployments
             # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1719#issuecomment-743452334
@@ -82,7 +77,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: {{ $livenessFailureThreshold }}
+            {{- if $root.Values.probes }}
+            {{- if and $root.Values.probes.liveness (hasKey $root.Values.probes.liveness "failureThreshold") }}
+            failureThreshold: {{ int $root.Values.probes.liveness.failureThreshold }}
+            {{- end }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
@@ -90,7 +89,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-            failureThreshold: {{ $readinessFailureThreshold }}
+            {{- if $root.Values.probes }}
+            {{- if and $root.Values.probes.readiness (hasKey $root.Values.probes.readiness "failureThreshold") }}
+            failureThreshold: {{ int $root.Values.probes.readiness.failureThreshold }}
+            {{- end }}
+            {{- end }}
           startupProbe:
             httpGet:
               path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}


### PR DESCRIPTION
### Issues Closed

- [PARA-19760](https://useparagon.atlassian.net/browse/PARA-19760)

### Brief Summary

configurable k8s probe failure thresholds; worker-workflows stricter liveness tolerance

### Detailed Summary

We align with Kubernetes guidance and staff review: keep the same /healthz endpoint for readiness and liveness (full Terminus / dependency checks), and avoid ?isLite=true so we do not mark workers ready or keep them on the load balancer while Redis or other deps are unhealthy. The shared deployment.standard template now optionally emits failureThreshold for liveness and/or readiness only when a subchart sets probes.liveness.failureThreshold or probes.readiness.failureThreshold in its values.yaml, so all other services keep the previous rendered manifests and implicit API defaults (including default failure count). worker-workflows opts in with probes.liveness.failureThreshold: 6 so readiness (implicit threshold 3) tends to drop the pod from the Service before liveness triggers a restart on sustained failures.

### Changes

- charts/paragon-templates/templates/_deployment.yaml: optional probes.liveness.failureThreshold / probes.readiness.failureThreshold from per-chart values.yaml; omit from rendered YAML when unset (defaults unchanged for everyone else).
- charts/paragon-onprem/charts/worker-workflows/values.yaml: ingress.healthcheck_path: /healthz; add probes.liveness.failureThreshold: 6.


### Unrelated Changes

- None

### Future Work

- Optional: add probes.readiness.failureThreshold (or other probe timings) per service in values.yaml if product wants different readiness vs liveness sensitivity.
- Optional: align Deployments with StatefulSets (readycheck_path vs healthcheck_path) for path splits

### Steps to Test

1. Render or deploy charts; for worker-workflows, kubectl get deploy worker-workflows -o yaml (or describe the pod) and confirm:

- readiness and liveness httpGet.path are /healthz.
- liveness includes failureThreshold: 6; readiness has no explicit failureThreshold unless you set it (then expect API default 3). 

2. Pick any other microservice/worker chart: confirm rendered probes do not include failureThreshold lines unless that chart sets probes.*.

### QA Notes

- Full /healthz still returns 503 while the service is terminating (unchanged).
- Behavior for charts without probes in values is intended to match pre-change defaults (same timings; implicit failure thresholds).

### Deployment Notes

- Helm chart-only change after prepare.sh / normal release pipeline; no new tfvars keys for this work.
- If a customer overrides worker-workflows values (e.g. healthcheck_path or probes), those overrides still win.

### Screenshots


[PARA-19760]: https://useparagon.atlassian.net/browse/PARA-19760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ