### PR TITLE
feat(hoop): agent IRSA via Helm SA on AWS/GCP

### DIFF
--- a/aws/workspaces/paragon/hoop/agent.tf
+++ b/aws/workspaces/paragon/hoop/agent.tf
@@ -23,4 +23,17 @@ resource "helm_release" "hoopagent" {
     name  = "image.tag"
     value = var.hoop_version
   }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  dynamic "set" {
+    for_each = try(aws_iam_role.hoop_support[0].arn, null) != null ? [1] : []
+    content {
+      name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      value = aws_iam_role.hoop_support[0].arn
+    }
+  }
 }

--- a/aws/workspaces/paragon/hoop/iam.tf
+++ b/aws/workspaces/paragon/hoop/iam.tf
@@ -15,7 +15,7 @@ resource "aws_iam_role" "hoop_support" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringEquals = {
-            "${replace(var.eks_oidc_issuer_url, "https://", "")}:sub" = "system:serviceaccount:${var.namespace_paragon.id}:hoop-cluster-admin"
+            "${replace(var.eks_oidc_issuer_url, "https://", "")}:sub" = "system:serviceaccount:${var.namespace_paragon.id}:hoopagent"
             "${replace(var.eks_oidc_issuer_url, "https://", "")}:aud" = "sts.amazonaws.com"
           }
         }

--- a/aws/workspaces/paragon/hoop/iam.tf
+++ b/aws/workspaces/paragon/hoop/iam.tf
@@ -1,4 +1,4 @@
-# IAM role for Hoop agent ServiceAccount with SupportUser access (IRSA)
+# IAM role for Hoop agent ServiceAccount with read-only access (IRSA)
 resource "aws_iam_role" "hoop_support" {
   count = var.hoop_enabled && var.eks_oidc_provider_arn != null ? 1 : 0
 
@@ -32,5 +32,5 @@ resource "aws_iam_role_policy_attachment" "hoop_support" {
   count = var.hoop_enabled && var.eks_oidc_provider_arn != null ? 1 : 0
 
   role       = aws_iam_role.hoop_support[0].name
-  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }

--- a/aws/workspaces/paragon/hoop/serviceaccounts.tf
+++ b/aws/workspaces/paragon/hoop/serviceaccounts.tf
@@ -5,14 +5,9 @@ resource "kubernetes_service_account" "hoop_cluster_admin" {
   metadata {
     name      = "hoop-cluster-admin"
     namespace = var.namespace_paragon.id
-    annotations = merge(
-      {
-        "kubernetes.io/service-account.name" = "hoop-cluster-admin"
-      },
-      try(aws_iam_role.hoop_support[0].arn, null) != null ? {
-        "eks.amazonaws.com/role-arn" = aws_iam_role.hoop_support[0].arn
-      } : {}
-    )
+    annotations = {
+      "kubernetes.io/service-account.name" = "hoop-cluster-admin"
+    }
   }
   depends_on = [helm_release.hoopagent]
 }

--- a/gcp/workspaces/paragon/hoop/agent.tf
+++ b/gcp/workspaces/paragon/hoop/agent.tf
@@ -23,4 +23,17 @@ resource "helm_release" "hoopagent" {
     name  = "image.tag"
     value = var.hoop_version
   }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  dynamic "set" {
+    for_each = try(google_service_account.hoop_agent[0].email, null) != null ? [1] : []
+    content {
+      name  = "serviceAccount.annotations.iam\\.gke\\.io/gcp-service-account"
+      value = google_service_account.hoop_agent[0].email
+    }
+  }
 }

--- a/gcp/workspaces/paragon/hoop/iam.tf
+++ b/gcp/workspaces/paragon/hoop/iam.tf
@@ -1,4 +1,4 @@
-# GCP Service Account for Hoop agent with Editor access via Workload Identity
+# GCP Service Account for Hoop agent with read-only access via Workload Identity
 resource "google_service_account" "hoop_agent" {
   count = var.hoop_enabled && var.gcp_project_id != null ? 1 : 0
 
@@ -12,7 +12,7 @@ resource "google_project_iam_member" "hoop_support" {
   count = var.hoop_enabled && var.gcp_project_id != null ? 1 : 0
 
   project = var.gcp_project_id
-  role    = "roles/editor"
+  role    = "roles/viewer"
   member  = "serviceAccount:${google_service_account.hoop_agent[0].email}"
 }
 

--- a/gcp/workspaces/paragon/hoop/iam.tf
+++ b/gcp/workspaces/paragon/hoop/iam.tf
@@ -21,5 +21,5 @@ resource "google_service_account_iam_member" "hoop_workload_identity" {
 
   service_account_id = google_service_account.hoop_agent[0].name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${var.namespace_paragon.id}/hoop-cluster-admin]"
+  member             = "serviceAccount:${var.gcp_project_id}.svc.id.goog[${var.namespace_paragon.id}/hoopagent]"
 }

--- a/gcp/workspaces/paragon/hoop/serviceaccounts.tf
+++ b/gcp/workspaces/paragon/hoop/serviceaccounts.tf
@@ -5,14 +5,9 @@ resource "kubernetes_service_account" "hoop_cluster_admin" {
   metadata {
     name      = "hoop-cluster-admin"
     namespace = var.namespace_paragon.id
-    annotations = merge(
-      {
-        "kubernetes.io/service-account.name" = "hoop-cluster-admin"
-      },
-      try(google_service_account.hoop_agent[0].email, null) != null ? {
-        "iam.gke.io/gcp-service-account" = google_service_account.hoop_agent[0].email
-      } : {}
-    )
+    annotations = {
+      "kubernetes.io/service-account.name" = "hoop-cluster-admin"
+    }
   }
   depends_on = [helm_release.hoopagent]
 }


### PR DESCRIPTION
### Issues Closed

- [PARA-19453](https://useparagon.atlassian.net/browse/PARA-19453)

### Brief Summary

hoop agent irsa via helm sa on aws and gcp; oidc trust fixed for agent ksa

### Detailed Summary

The Hoop agent is installed with the upstream hoopagent-chart Helm release. IRSA / workload identity should attach to the Kubernetes service account the chart creates for the agent (hoopagent), not to the separate Terraform-managed hoop-cluster-admin SA used for cluster-admin token / Hoop connections. This PR has the Helm release create that service account and annotate it with the cloud identity (EKS IAM role ARN on AWS, GKE GCP SA email on GCP), fixes the EKS OIDC trust sub to system:serviceaccount:<ns>:hoopagent, and removes the eks.amazonaws.com/role-arn (and equivalent) annotation from hoop-cluster-admin so Terraform and Helm are not fighting over the same SA identity.

### Changes

- AWS (aws/workspaces/paragon/hoop/): helm_release.hoopagent — serviceAccount.create=true and conditional set for eks.amazonaws.com/role-arn when aws_iam_role.hoop_support exists; iam.tf OIDC subject updated from hoop-cluster-admin to hoopagent; serviceaccounts.tf — hoop-cluster-admin annotations reduced so it no longer carries the IAM role (keeps token/RBAC use only).
- GCP (gcp/workspaces/paragon/hoop/): same Helm serviceAccount.create + iam.gke.io/gcp-service-account annotation pattern when the GCP support SA exists; serviceaccounts.tf aligned so hoop-cluster-admin is not the workload-identity target for the agent (parallel to AWS).

### Unrelated Changes

None

### Future Work

- Azure: Check out for upstream updates support az cli

### Steps to Test

1. In a non-prod cluster with hoop_enabled = true: terraform plan / apply for the paragon workspace (AWS and/or GCP as applicable).
2. After apply: kubectl -n <paragon-ns> get sa hoopagent -o yaml — expect create by chart and role / GCP SA annotation present when IAM/GSA exists.
3. Confirm hoop-cluster-admin SA does not show eks.amazonaws.com/role-arn (AWS) or the GKE WI annotation meant for the agent.
4. Confirm Hoop agent still registers and connections that use the cluster-admin token still work (hoop_connection / token secret unchanged in intent).

### QA Notes

- Order / drift: first apply may recreate or patch the Helm release; watch for brief agent disconnect during upgrade.
- Risk: wrong OIDC sub breaks IRSA for the agent until corrected — validate aws sts get-caller-identity from a debug pod using the agent SA if you use that pattern.

### Deployment Notes

- Requires hoop_enabled and existing Hoop variables (hoop_key, hoop_agent_id, etc.) as today; no new customer tfvars unless you add optional flags elsewhere.
- EKS: OIDC provider ARN / issuer must still be passed into the module as today.
- GCP: project + workload identity wiring for the agent namespace must remain valid after the SA name change on the trust side.

### Screenshots

None

[PARA-19453]: https://useparagon.atlassian.net/browse/PARA-19453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ