### PR TITLE
fix(PARA-20371): align pod termination grace with preStop and ALB deregistration

### DIFF
--- a/charts/paragon-templates/templates/_deployment.yaml
+++ b/charts/paragon-templates/templates/_deployment.yaml
@@ -38,6 +38,7 @@ spec:
       labels:
         {{- include (printf "%s.selectorLabels" $name) $root | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: 65
       {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/paragon-templates/templates/_stateful-set.yaml
+++ b/charts/paragon-templates/templates/_stateful-set.yaml
@@ -33,6 +33,7 @@ spec:
       labels:
         {{- include (printf "%s.selectorLabels" $name) $root | nindent 8 }}
     spec:
+      terminationGracePeriodSeconds: 65
       {{- with $root.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
### Issues Closed

- PARA-20371

### Brief Summary

pod grace period exceeds prest stop and alb deregistration window

### Detailed Summary

Kubernetes defaults `terminationGracePeriodSeconds` to 30s while microservice and statefulset templates run a 35s `preStop` sleep so targets can drain from the ALB after deregistration (30s in ingress). That mismatch could end graceful shutdown before `preStop` and app teardown finish. Pod `spec` now sets 65s grace on the shared deployment and statefulset templates so every chart that uses them gets enough time during scale-down, drains, and spot evictions.

### Changes

- Set pod-level termination grace to 65 seconds on standard Deployment and StatefulSet pod specs so shutdown aligns with the existing 35s preStop and ALB target group deregistration behavior

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. Render or deploy a chart that includes `paragon-templates` (for example run `helm template` on a prepared subchart that uses `deployment.standard` or `statefulset.standard`).
2. Confirm rendered pod `spec` includes `terminationGracePeriodSeconds: 65` under `template.spec`.

### QA Notes

N/A

### Deployment Notes

Rollout via normal Helm upgrade; no Terraform or values changes required. Existing pods pick up the new value on their next rollout.

### Screenshots

N/A