### PR TITLE
fix(logging): add startup grace windows for fluent-bit probes

### DIFF
--- a/charts/paragon-logging/charts/fluent-bit/values.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/values.yaml
@@ -191,11 +191,19 @@ livenessProbe:
   httpGet:
     path: /
     port: http
+  initialDelaySeconds: 45
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 
 readinessProbe:
   httpGet:
     path: /api/v1/health
     port: http
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
 
 resources:
   limits:


### PR DESCRIPTION
### Issues Closed

- [PARA-20489](https://useparagon.atlassian.net/browse/PARA-20489)

### Brief Summary

_tolerate fluent-bit probe startup delays_

### Detailed Summary

Fluent-bit’s HTTP endpoints used for Kubernetes probes can come up after the main process has started. Without a grace period, liveness failures during bootstrap caused restart loops (see [SEV-757](https://www.notion.so/useparagon/SEV-757-Observe-ai-US-Service-fluent-bit-has-restarted-more-than-twice-in-the-last-10-minutes-34b61d1eb9a880dc8a99f72b435f583d)). This change adds explicit startup-oriented timing on the embedded fluent-bit subchart defaults so probes do not treat a slow HTTP listener as a dead container, while keeping normal failure detection after the initial delay.

### Changes

- Add `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, and `failureThreshold` to `livenessProbe` and `readinessProbe` defaults in `charts/paragon-logging/charts/fluent-bit/values.yaml` (45s / 30s initial delays respectively).

### Unrelated Changes

None.

### Future Work

- Tune delay and thresholds using observed startup percentiles (e.g. p95 time to HTTP-ready) from non-prod or incident metrics; consider `startupProbe` if startup time becomes highly variable.

### Steps to Test

1. Render the chart locally (after `prepare.sh` if your pipeline replaces chart versions): `helm template` on the fluent-bit subchart or parent `paragon-logging` and confirm the fluent-bit workload spec includes the new probe fields.
2. Deploy to a **non-production** environment, restart or roll the fluent-bit DaemonSet/Deployment, and watch pods until **Ready** without crash loops during normal startup.
3. Port-forward to the fluent-bit HTTP port and verify `/` and `/api/v1/health` respond as before.
4. Spot-check log forwarding to configured backends (e.g. OpenObserve) for regressions.

### QA Notes

- Behavior change is limited to probe scheduling; no application image or fluent-bit config content was modified in this PR.
- Exact numeric delays are chart defaults; clusters that override `livenessProbe` / `readinessProbe` in higher-level values will need their overrides reviewed.

### Deployment Notes

- Release follows the normal Enterprise chart flow (`prepare.sh` / Terraform–Helm apply per environment). No separate config file updates beyond deploying the updated chart version.

### Screenshots

N/A (Helm values / manifest-only change).