### PR TITLE
feat(azure): enable zone-redundant HA for all PostgreSQL instances

### DIFF
--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -77,9 +77,9 @@ No resources.
 | <a name="input_location"></a> [location](#input\_location) | Azure geographic region to deploy resources in. | `string` | n/a | yes |
 | <a name="input_managed_sync_enabled"></a> [managed\_sync\_enabled](#input\_managed\_sync\_enabled) | Whether to enable managed sync. | `bool` | `false` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of organization to include in resource names. | `string` | n/a | yes |
-| <a name="input_postgres_base_sku_name"></a> [postgres\_base\_sku\_name](#input\_postgres\_base\_sku\_name) | Default PostgreSQL SKU name for instances that don't use the main postgres\_sku\_name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`) | `string` | `"B_Standard_B2s"` | no |
+| <a name="input_postgres_base_sku_name"></a> [postgres\_base\_sku\_name](#input\_postgres\_base\_sku\_name) | PostgreSQL SKU for secondary instances. Use GP\_Standard\_D2ads\_v5 for HA support. | `string` | `"B_Standard_B2s"` | no |
 | <a name="input_postgres_multiple_instances"></a> [postgres\_multiple\_instances](#input\_postgres\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
-| <a name="input_postgres_redundant"></a> [postgres\_redundant](#input\_postgres\_redundant) | Whether zone redundant HA should be enabled | `bool` | `false` | no |
+| <a name="input_postgres_redundant"></a> [postgres\_redundant](#input\_postgres\_redundant) | Enable zone-redundant HA. Recommended: true for production (requires GP/MO SKU, not Burstable). | `bool` | `false` | no |
 | <a name="input_postgres_sku_name"></a> [postgres\_sku\_name](#input\_postgres\_sku\_name) | PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`) | `string` | `"GP_Standard_D2ds_v5"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version (14, 15 or 16) | `string` | `"14"` | no |
 | <a name="input_redis_base_capacity"></a> [redis\_base\_capacity](#input\_redis\_base\_capacity) | Default capacity of the Redis cache for instances that don't use the main redis\_capacity. | `number` | `1` | no |

--- a/azure/workspaces/infra/postgres/variables.tf
+++ b/azure/workspaces/infra/postgres/variables.tf
@@ -62,13 +62,13 @@ locals {
     cerberus = {
       name = "${var.workspace}-cerberus"
       db   = "cerberus"
-      ha   = false
+      ha   = var.postgres_redundant
       sku  = var.postgres_base_sku_name
     }
     eventlogs = {
       name = "${var.workspace}-eventlogs"
       db   = "eventlogs"
-      ha   = false
+      ha   = var.postgres_redundant
       sku  = var.postgres_base_sku_name
     }
     hermes = {
@@ -80,20 +80,20 @@ locals {
     triggerkit = {
       name = "${var.workspace}-triggerkit"
       db   = "triggerkit"
-      ha   = false
+      ha   = var.postgres_redundant
       sku  = var.postgres_base_sku_name
     }
     zeus = {
       name = "${var.workspace}-zeus"
       db   = "zeus"
-      ha   = false
+      ha   = var.postgres_redundant
       sku  = var.postgres_base_sku_name
     }
     }, var.managed_sync_enabled ? {
     managed_sync = {
       name = "${var.workspace}-managed-sync"
       db   = "managed_sync"
-      ha   = false
+      ha   = var.postgres_redundant
       sku  = var.postgres_base_sku_name
     }
     } : {}) : {

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -125,7 +125,7 @@ variable "postgres_sku_name" {
 }
 
 variable "postgres_base_sku_name" {
-  description = "PostgreSQL SKU for secondary instances. Use GP_Standard_D2ads_v5 for HA support."
+  description = "PostgreSQL SKU for secondary instances. Use GP_Standard_D2ads_v5 for HA support. SKU availability may vary by Azure region."
   type        = string
   default     = "B_Standard_B2s"
 }

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -113,7 +113,7 @@ variable "cloudflare_tunnel_email_domain" {
 
 # postgres
 variable "postgres_redundant" {
-  description = "Whether zone redundant HA should be enabled"
+  description = "Enable zone-redundant HA. Recommended: true for production (requires GP/MO SKU, not Burstable)."
   type        = bool
   default     = false
 }
@@ -125,7 +125,7 @@ variable "postgres_sku_name" {
 }
 
 variable "postgres_base_sku_name" {
-  description = "Default PostgreSQL SKU name for instances that don't use the main postgres_sku_name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`)"
+  description = "PostgreSQL SKU for secondary instances. Use GP_Standard_D2ads_v5 for HA support."
   type        = string
   default     = "B_Standard_B2s"
 }

--- a/prepare.sh
+++ b/prepare.sh
@@ -155,7 +155,7 @@ if [[ "$provider" != "k8s" ]]; then
             return
         fi
 
-        node "$script_dir/scripts/generate-tfvars.mjs" "$vars_file" "$out_file"
+        node "$script_dir/scripts/generate-tfvars.mjs" "$vars_file" "$out_file" "$provider"
     }
 
     generate_tfvars "$workspaces/infra/variables.tf" "$workspaces/infra/vars.auto.tfvars"

--- a/scripts/generate-tfvars.mjs
+++ b/scripts/generate-tfvars.mjs
@@ -4,9 +4,20 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { basename } from "path";
 
 const SCRIPT_NAME = basename(process.argv[1]);
-const USAGE = `Usage: node ${SCRIPT_NAME} <variables.tf> <output.tfvars>\n` +
+const USAGE = `Usage: node ${SCRIPT_NAME} <variables.tf> <output.tfvars> [provider]\n` +
   "  <variables.tf>    Path to a Terraform variables file.\n" +
-  "  <output.tfvars>   Path to write generated vars.auto.tfvars.\n";
+  "  <output.tfvars>   Path to write generated vars.auto.tfvars.\n" +
+  "  [provider]        Optional cloud provider (aws, azure, gcp, k8s).\n";
+
+const AZURE_INFRA_RECOMMENDATIONS = [
+  "",
+  "# PostgreSQL Zone-Redundant HA (recommended for production).",
+  "# Requires General Purpose or Memory Optimized SKUs (not Burstable).",
+  "# Remove or comment out these lines if not required.",
+  'postgres_redundant     = true',
+  'postgres_base_sku_name = "GP_Standard_D2ads_v5"',
+  "",
+].join("\n");
 
 function exitWithError(message) {
   console.error(message);
@@ -18,14 +29,14 @@ function exitWithUsageError(message) {
 }
 
 function verifyArgs() {
-  const [varsPath, outPath] = process.argv.slice(2);
+  const [varsPath, outPath, provider] = process.argv.slice(2);
   if (!varsPath || !outPath) {
     exitWithUsageError("Missing required arguments.");
   }
   if (!existsSync(varsPath)) {
     exitWithUsageError(`Variables file does not exist: ${varsPath}`);
   }
-  return { varsPath, outPath };
+  return { varsPath, outPath, provider: provider || "" };
 }
 
 function countBraces(line) {
@@ -131,9 +142,14 @@ function generateTfvars(varsText) {
 }
 
 function main() {
-  const { varsPath, outPath } = verifyArgs();
+  const { varsPath, outPath, provider } = verifyArgs();
   const varsText = readFileSync(varsPath, "utf-8");
-  const output = generateTfvars(varsText);
+  let output = generateTfvars(varsText);
+
+  if (provider === "azure" && outPath.includes("/infra/")) {
+    output += AZURE_INFRA_RECOMMENDATIONS;
+  }
+
   writeFileSync(outPath, output);
 }
 

--- a/scripts/generate-tfvars.mjs
+++ b/scripts/generate-tfvars.mjs
@@ -29,14 +29,14 @@ function exitWithUsageError(message) {
 }
 
 function verifyArgs() {
-  const [varsPath, outPath, provider] = process.argv.slice(2);
+  const [varsPath, outPath, provider = ""] = process.argv.slice(2);
   if (!varsPath || !outPath) {
     exitWithUsageError("Missing required arguments.");
   }
   if (!existsSync(varsPath)) {
     exitWithUsageError(`Variables file does not exist: ${varsPath}`);
   }
-  return { varsPath, outPath, provider: provider || "" };
+  return { varsPath, outPath, provider };
 }
 
 function countBraces(line) {


### PR DESCRIPTION
### Issues Closed

- [PARA-20976](https://useparagon.atlassian.net/browse/PARA-20976)

### Brief Summary

enable postgresql zone-redundant ha for azure enterprise

### Detailed Summary

PostgreSQL HA posture was inconsistent across Azure enterprise deployments. Only the primary instance (hermes/paragon) respected the `postgres_redundant` variable; secondary instances (cerberus, eventlogs, triggerkit, zeus, managed_sync) had `ha = false` hardcoded, making it impossible to enable HA on them even when setting `postgres_redundant = true`. This change wires all instances to respect the variable and enriches variable descriptions with HA and SKU recommendations. Additionally, `generate-tfvars.mjs` now auto-includes recommended HA settings (`postgres_redundant = true` and `postgres_base_sku_name = "GP_Standard_D2ads_v5"`) in generated Azure infra tfvars, so new deployments get HA by default with opt-out guidance.

### Changes

- Updated `postgres_redundant` and `postgres_base_sku_name` variable descriptions in `azure/workspaces/infra/variables.tf` with HA recommendations and SKU guidance
- Changed hardcoded `ha = false` to `ha = var.postgres_redundant` for cerberus, eventlogs, triggerkit, zeus, and managed_sync in `azure/workspaces/infra/postgres/variables.tf`
- Extended `scripts/generate-tfvars.mjs` with optional `[provider]` argument; appends recommended PostgreSQL HA settings when provider is `azure` and output path includes `/infra/`
- Updated `prepare.sh` to pass `$provider` as third argument to `generate-tfvars.mjs`
- Updated `azure/workspaces/infra/README.md` inputs table to reflect new descriptions

### Unrelated Changes

None.

### Future Work

- Maintenance-window-aware alert suppression

### Steps to Test

1. Run `terraform init -backend=false && terraform validate` in `azure/workspaces/infra/` — should pass
2. Run `node scripts/generate-tfvars.mjs azure/workspaces/infra/variables.tf /tmp/test.tfvars azure` — verify output includes the HA recommendation block at the end
3. Run `node scripts/generate-tfvars.mjs aws/workspaces/infra/variables.tf /tmp/test-aws.tfvars aws` — verify output does NOT include the HA block
4. For an Azure customer with `postgres_redundant = true` and `postgres_base_sku_name = "GP_Standard_D2ads_v5"` in their tfvars, run `terraform plan` and verify all instances show `high_availability { mode = "ZoneRedundant" }` being added (in-place update, no destroy/recreate)
5. For an Azure customer without `postgres_redundant` in their tfvars, verify `terraform plan` shows no changes (default remains `false`)

### QA Notes

- Enabling HA on instances with Burstable SKUs (`B_Standard_*`) will fail at `terraform apply` — Azure only supports zone-redundant HA on General Purpose (`GP_Standard_*`) and Memory Optimized (`MO_Standard_*`) SKUs. The generated tfvars includes `postgres_base_sku_name = "GP_Standard_D2ads_v5"` alongside `postgres_redundant = true` to handle this.
- Changing SKU from Burstable to General Purpose causes a brief restart (~30-60 seconds). Coordinate with customer for production applies.
- HA enablement is an in-place update — no data loss or instance recreation.

### Deployment Notes

- No config changes needed for existing customers who already have `postgres_redundant` set in their tfvars
- Existing customers who want HA should add to their `vars.auto.tfvars`: `postgres_redundant = true postgres_base_sku_name = "GP_Standard_D2ads_v5"` 
- New Azure deployments via `prepare.sh` will automatically include these values with a comment indicating they can be removed if not required

### Screenshots
N/A — infrastructure-only changes, no UI impact.
