### PR TITLE
feat/PARA-20977/-arden-helm-deployment-conf-for-azure-managed-service-failover-events

### DIFF
--- a/charts/paragon-onprem/charts/account/values.yaml
+++ b/charts/paragon-onprem/charts/account/values.yaml
@@ -72,6 +72,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/account/values.yaml
+++ b/charts/paragon-onprem/charts/account/values.yaml
@@ -74,7 +74,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/api-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/values.yaml
@@ -287,6 +287,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/api-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/values.yaml
@@ -289,7 +289,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/cerberus/values.yaml
+++ b/charts/paragon-onprem/charts/cerberus/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/cerberus/values.yaml
+++ b/charts/paragon-onprem/charts/cerberus/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/connect/values.yaml
+++ b/charts/paragon-onprem/charts/connect/values.yaml
@@ -72,6 +72,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/connect/values.yaml
+++ b/charts/paragon-onprem/charts/connect/values.yaml
@@ -74,7 +74,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/dashboard/values.yaml
+++ b/charts/paragon-onprem/charts/dashboard/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/dashboard/values.yaml
+++ b/charts/paragon-onprem/charts/dashboard/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/hades/values.yaml
+++ b/charts/paragon-onprem/charts/hades/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/hades/values.yaml
+++ b/charts/paragon-onprem/charts/hades/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -87,6 +87,10 @@ ingress:
   healthcheck_path: /healthz
   group_order: '-10'
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -89,7 +89,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/passport/values.yaml
+++ b/charts/paragon-onprem/charts/passport/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/passport/values.yaml
+++ b/charts/paragon-onprem/charts/passport/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/pheme/values.yaml
+++ b/charts/paragon-onprem/charts/pheme/values.yaml
@@ -75,6 +75,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []
@@ -91,8 +95,3 @@ affinity:
           - spot
 
 tls_secret: ''
-
-env:
-  WORKER_SHARED_AUTOSCALING_DISABLED: false
-  WORKER_SHARED_SERVICE_MAX_INSTANCES: 4
-  WORKER_SHARED_SERVICE_MIN_INSTANCES: 2

--- a/charts/paragon-onprem/charts/pheme/values.yaml
+++ b/charts/paragon-onprem/charts/pheme/values.yaml
@@ -77,7 +77,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -66,6 +66,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -68,7 +68,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: "" # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -71,6 +71,10 @@ ingress:
   healthcheck_path: /healthz
   group_order: '-10'
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -73,7 +73,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -81,7 +81,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 6
+    failureThreshold: 18
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -81,7 +81,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -70,6 +70,10 @@ ingress:
   host: '' # When empty, will use chart name + domain
   healthcheck_path: /healthz
 
+probes:
+  liveness:
+    failureThreshold: 18
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -72,7 +72,7 @@ ingress:
 
 probes:
   liveness:
-    failureThreshold: 18
+    failureThreshold: 12
 
 nodeSelector: {}
 

--- a/charts/paragon-templates/templates/_deployment.yaml
+++ b/charts/paragon-templates/templates/_deployment.yaml
@@ -72,36 +72,11 @@ spec:
                   - -c
                   - sleep 35
           livenessProbe:
-            httpGet:
-              path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            {{- if $root.Values.probes }}
-            {{- if and $root.Values.probes.liveness (hasKey $root.Values.probes.liveness "failureThreshold") }}
-            failureThreshold: {{ int $root.Values.probes.liveness.failureThreshold }}
-            {{- end }}
-            {{- end }}
+            {{- include "probes.httpGet" (dict "root" $root "type" "liveness") | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            {{- if $root.Values.probes }}
-            {{- if and $root.Values.probes.readiness (hasKey $root.Values.probes.readiness "failureThreshold") }}
-            failureThreshold: {{ int $root.Values.probes.readiness.failureThreshold }}
-            {{- end }}
-            {{- end }}
+            {{- include "probes.httpGet" (dict "root" $root "type" "readiness") | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
-              port: http
-            failureThreshold: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+            {{- include "probes.httpGet" (dict "root" $root "type" "startup") | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml $root.Values.resources | nindent 12 }}

--- a/charts/paragon-templates/templates/_probes.tpl
+++ b/charts/paragon-templates/templates/_probes.tpl
@@ -1,0 +1,56 @@
+{{/*
+Render a Kubernetes container probe (httpGet) for liveness, readiness, or startup.
+
+Usage:
+  livenessProbe:
+    {{- include "probes.httpGet" (dict "root" $ "type" "liveness") | nindent 12 }}
+  readinessProbe:
+    {{- include "probes.httpGet" (dict "root" $ "type" "readiness") | nindent 12 }}
+  startupProbe:
+    {{- include "probes.httpGet" (dict "root" $ "type" "startup") | nindent 12 }}
+
+Path resolution (in order):
+  liveness  -> .Values.ingress.livecheck_path    | .Values.ingress.healthcheck_path | "/healthz"
+  readiness -> .Values.ingress.readycheck_path   | .Values.ingress.healthcheck_path | "/healthz"
+  startup   -> .Values.ingress.startupcheck_path | .Values.ingress.healthcheck_path | "/healthz"
+
+Per-probe overrides (any subset) via .Values.probes.<type>.<field>:
+  initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold
+
+Defaults preserve historical chart behavior:
+  liveness, readiness -> initialDelaySeconds: 10, periodSeconds: 10, timeoutSeconds: 5, failureThreshold: 3
+  startup             ->                          periodSeconds: 10, timeoutSeconds: 5, failureThreshold: 30
+*/}}
+{{- define "probes.httpGet" -}}
+{{- $root := .root -}}
+{{- $type := .type -}}
+{{- $ingress := $root.Values.ingress | default dict -}}
+{{- $defaultPath := $ingress.healthcheck_path | default "/healthz" -}}
+{{- $path := $defaultPath -}}
+{{- if eq $type "liveness" -}}
+{{- $path = $ingress.livecheck_path | default $defaultPath -}}
+{{- else if eq $type "readiness" -}}
+{{- $path = $ingress.readycheck_path | default $defaultPath -}}
+{{- else if eq $type "startup" -}}
+{{- $path = $ingress.startupcheck_path | default $defaultPath -}}
+{{- end -}}
+{{- $cfg := dict -}}
+{{- if and $root.Values.probes (kindIs "map" $root.Values.probes) (hasKey $root.Values.probes $type) -}}
+{{- $cfg = index $root.Values.probes $type | default dict -}}
+{{- end -}}
+{{- $isStartup := eq $type "startup" -}}
+httpGet:
+  path: {{ $path }}
+  port: http
+{{- if hasKey $cfg "initialDelaySeconds" }}
+initialDelaySeconds: {{ int (index $cfg "initialDelaySeconds") }}
+{{- else if not $isStartup }}
+initialDelaySeconds: 10
+{{- end }}
+periodSeconds: {{ if hasKey $cfg "periodSeconds" }}{{ int (index $cfg "periodSeconds") }}{{ else }}10{{ end }}
+timeoutSeconds: {{ if hasKey $cfg "timeoutSeconds" }}{{ int (index $cfg "timeoutSeconds") }}{{ else }}5{{ end }}
+{{- if hasKey $cfg "successThreshold" }}
+successThreshold: {{ int (index $cfg "successThreshold") }}
+{{- end }}
+failureThreshold: {{ if hasKey $cfg "failureThreshold" }}{{ int (index $cfg "failureThreshold") }}{{ else if $isStartup }}30{{ else }}3{{ end }}
+{{- end -}}

--- a/charts/paragon-templates/templates/_probes.tpl
+++ b/charts/paragon-templates/templates/_probes.tpl
@@ -1,56 +1,38 @@
 {{/*
-Render a Kubernetes container probe (httpGet) for liveness, readiness, or startup.
-
-Usage:
-  livenessProbe:
-    {{- include "probes.httpGet" (dict "root" $ "type" "liveness") | nindent 12 }}
-  readinessProbe:
-    {{- include "probes.httpGet" (dict "root" $ "type" "readiness") | nindent 12 }}
-  startupProbe:
-    {{- include "probes.httpGet" (dict "root" $ "type" "startup") | nindent 12 }}
-
-Path resolution (in order):
-  liveness  -> .Values.ingress.livecheck_path    | .Values.ingress.healthcheck_path | "/healthz"
-  readiness -> .Values.ingress.readycheck_path   | .Values.ingress.healthcheck_path | "/healthz"
-  startup   -> .Values.ingress.startupcheck_path | .Values.ingress.healthcheck_path | "/healthz"
-
-Per-probe overrides (any subset) via .Values.probes.<type>.<field>:
-  initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold, successThreshold
-
-Defaults preserve historical chart behavior:
-  liveness, readiness -> initialDelaySeconds: 10, periodSeconds: 10, timeoutSeconds: 5, failureThreshold: 3
-  startup             ->                          periodSeconds: 10, timeoutSeconds: 5, failureThreshold: 30
+Render httpGet probe YAML for liveness, readiness, or startup.
+include "probes.httpGet" (dict "root" $root "type" "liveness")
 */}}
 {{- define "probes.httpGet" -}}
 {{- $root := .root -}}
 {{- $type := .type -}}
-{{- $ingress := $root.Values.ingress | default dict -}}
-{{- $defaultPath := $ingress.healthcheck_path | default "/healthz" -}}
-{{- $path := $defaultPath -}}
-{{- if eq $type "liveness" -}}
-{{- $path = $ingress.livecheck_path | default $defaultPath -}}
-{{- else if eq $type "readiness" -}}
-{{- $path = $ingress.readycheck_path | default $defaultPath -}}
-{{- else if eq $type "startup" -}}
-{{- $path = $ingress.startupcheck_path | default $defaultPath -}}
-{{- end -}}
-{{- $cfg := dict -}}
-{{- if and $root.Values.probes (kindIs "map" $root.Values.probes) (hasKey $root.Values.probes $type) -}}
-{{- $cfg = index $root.Values.probes $type | default dict -}}
-{{- end -}}
-{{- $isStartup := eq $type "startup" -}}
+{{- $values := index $root "Values" | default dict -}}
+{{- $ingress := get $values "ingress" | default dict -}}
+{{- $healthPath := $ingress.healthcheck_path | default "/healthz" -}}
+{{- $pathField := dict "liveness" "livecheck_path" "readiness" "readycheck_path" "startup" "startupcheck_path" -}}
+{{- $path := index $ingress (index $pathField $type) | default $healthPath -}}
+{{- $defaultsByType := dict
+  "liveness" (dict
+    "initialDelaySeconds" 10
+    "periodSeconds" 10
+    "timeoutSeconds" 5
+    "failureThreshold" 3
+  )
+  "readiness" (dict
+    "initialDelaySeconds" 10
+    "periodSeconds" 10
+    "timeoutSeconds" 5
+    "failureThreshold" 3
+  )
+  "startup" (dict
+    "periodSeconds" 10
+    "timeoutSeconds" 5
+    "failureThreshold" 30
+  )
+-}}
+{{- $overrides := index (get $values "probes" | default dict) $type | default dict -}}
+{{- $cfg := mergeOverwrite (index $defaultsByType $type) $overrides -}}
 httpGet:
   path: {{ $path }}
   port: http
-{{- if hasKey $cfg "initialDelaySeconds" }}
-initialDelaySeconds: {{ int (index $cfg "initialDelaySeconds") }}
-{{- else if not $isStartup }}
-initialDelaySeconds: 10
-{{- end }}
-periodSeconds: {{ if hasKey $cfg "periodSeconds" }}{{ int (index $cfg "periodSeconds") }}{{ else }}10{{ end }}
-timeoutSeconds: {{ if hasKey $cfg "timeoutSeconds" }}{{ int (index $cfg "timeoutSeconds") }}{{ else }}5{{ end }}
-{{- if hasKey $cfg "successThreshold" }}
-successThreshold: {{ int (index $cfg "successThreshold") }}
-{{- end }}
-failureThreshold: {{ if hasKey $cfg "failureThreshold" }}{{ int (index $cfg "failureThreshold") }}{{ else if $isStartup }}30{{ else }}3{{ end }}
+{{- toYaml $cfg }}
 {{- end -}}

--- a/charts/paragon-templates/templates/_probes.tpl
+++ b/charts/paragon-templates/templates/_probes.tpl
@@ -32,7 +32,7 @@ include "probes.httpGet" (dict "root" $root "type" "liveness")
 {{- $overrides := index (get $values "probes" | default dict) $type | default dict -}}
 {{- $cfg := mergeOverwrite (index $defaultsByType $type) $overrides -}}
 httpGet:
-  path: {{ $path }}
+  path: {{ $path | quote }}
   port: http
-{{- toYaml $cfg }}
-{{- end -}}
+{{ toYaml $cfg }}
+{{- end }}

--- a/charts/paragon-templates/templates/_stateful-set.yaml
+++ b/charts/paragon-templates/templates/_stateful-set.yaml
@@ -64,26 +64,11 @@ spec:
                   - -c
                   - sleep 35
           livenessProbe:
-            httpGet:
-              path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            {{- include "probes.httpGet" (dict "root" $root "type" "liveness") | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: {{ $root.Values.ingress.readycheck_path | default $root.Values.ingress.healthcheck_path | default "/healthz" }}
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
+            {{- include "probes.httpGet" (dict "root" $root "type" "readiness") | nindent 12 }}
           startupProbe:
-            httpGet:
-              path: {{ $root.Values.ingress.healthcheck_path | default "/healthz" }}
-              port: http
-            failureThreshold: 30
-            periodSeconds: 10
-            timeoutSeconds: 5
+            {{- include "probes.httpGet" (dict "root" $root "type" "startup") | nindent 12 }}
           resources:
             {{- toYaml $root.Values.resources | nindent 12 }}
           env:

--- a/charts/paragon-templates/values.yaml
+++ b/charts/paragon-templates/values.yaml
@@ -1,0 +1,7 @@
+# Library chart: not installed alone. Documents Values keys referenced by templates
+# (real defaults are set in paragon-onprem subcharts passed as include "root").
+
+ingress:
+  healthcheck_path: /healthz
+
+probes: {}

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.05.01"
+version="2026.05.18"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- [PARA-20977](https://useparagon.atlassian.net/browse/PARA-20977)

### Brief Summary

harden k8s probes for azure dependency blips

### Detailed Summary

Azure-managed PostgreSQL and Redis maintenance and failover can cause short `/healthz` failures (dependency checks). Default liveness settings (~30s to kill) were too aggressive and contributed to unnecessary pod restarts during those windows (e.g. SEV-754 / SEV-794 class incidents).

This PR centralizes probe rendering in a shared Helm helper, lets Deployments use separate HTTP paths for liveness vs readiness (and optional startup path), exposes full per-probe tuning via `values`, and sets a higher default `probes.liveness.failureThreshold` on Postgres+Redis-backed `paragon-onprem` services so kubelet allows roughly ~3 minutes of consecutive liveness failures before restart while readiness stays stricter by default.

### Changes

- Add `charts/paragon-templates/templates/_probes.tpl` with `probes.httpGet` helper (paths: `ingress.livecheck_path`, `readycheck_path`, `startupcheck_path` with fallbacks; overrides under `probes.{liveness,readiness,startup}.*`).
- Wire `_deployment.yaml` and `_stateful-set.yaml` to use the helper for all three probes (parity between workload kinds).
- Set `probes.liveness.failureThreshold: 18` in default `values.yaml` for all subcharts that depend on Postgres and Redis per `files/service-inputs.json` (includes `pheme`, `worker-eventlogs`, other workers, API/microservices in that set); align `worker-workflows` from 6 to 18.

### Unrelated Changes

- None intentionally. No application code, Terraform, or `prepare.sh` / `scripts` dependency changes as part of this PR.

### Future Work

- Add a dedicated low-dependency liveness HTTP path in services (e.g. `/live`) and set `ingress.livecheck_path` in charts; team policy excludes using `?isLite` on probes.
- Application-side Postgres/Redis retry, backoff, and connection timeouts (separate tickets / monorepo).
- Maintenance-aware alerting and any Azure-specific defaults only if you introduce a stable `values` signal (e.g. cloud provider) without widening probes on other clouds.

### Steps to Test

- From repo root after `prepare.sh` for your provider (or equivalent copy of `charts/` into the workspace charts path Terraform uses), run `helm dependency build` on `paragon-onprem` if needed, then `helm template` with typical `global.env` / image settings and confirm rendered Deployments/StatefulSets show expected `livenessProbe` / `readinessProbe` / `startupProbe` fields (paths and thresholds).
- Spot-check a service with overrides: set `ingress.livecheck_path`, `probes.liveness.periodSeconds`, etc., and confirm rendered YAML matches.
- Optionally `helm lint` on prepared charts per `AGENTS.md` (expect known parent-chart / semver placeholder noise until versions are substituted).

### QA Notes

- Behavior change: liveness tolerates longer consecutive failures before pod restart (~180s with default `periodSeconds: 10` and `failureThreshold: 18`). Readiness defaults unchanged (still fails out of Service relatively quickly). Risk: a truly wedged process may take longer to be killed by liveness alone.
- `/healthz` still performs dependency checks unless a separate live path is configured; this mitigates churn; it does not fix bad client retry behavior.

### Deployment Notes

- No new secrets or ConfigMaps. Rolling deploy will pick up probe changes on next release. No manual config change required beyond normal Helm/Terraform apply for the Paragon chart bundle.

### Screenshots

None