### PR TITLE
feat/PARA-20444/openobserve-uds-post-hook

### DIFF
--- a/.cursor/skills/helm-development.md
+++ b/.cursor/skills/helm-development.md
@@ -25,7 +25,7 @@ Each application chart declares its subcharts as `file://` dependencies in `Char
 
 After `helm install` / `helm upgrade` of `paragon-logging`, the `openobserve` subchart runs a **post-install,post-upgrade** Helm hook `Job` that applies the user-defined schema for the `paragon` logs stream.
 
-- **Files**: `charts/paragon-logging/charts/openobserve/files/apply-uds.sh`, `openobserve-uds-schema.json`
+- **Files**: `charts/paragon-logging/charts/openobserve/files/apply-uds.sh`, `openobserve-uds-schema.json` (Helm loads them as `files/<name>` via `.Files.Get`, same as `service-inputs.json` elsewhere)
 - **Templates**: `uds-configmap.yaml`, `uds-apply-job.yaml`
 - **Auth**: same Kubernetes secret as the OpenObserve StatefulSet (`secretName`, keys `ZO_ROOT_USER_EMAIL` / `ZO_ROOT_USER_PASSWORD` from `paragon-secrets` unless overridden in `openobserve.secrets`)
 - **Idempotent**: GET schema → skip PUT if `defined_schema_fields` already matches desired JSON

--- a/.cursor/skills/helm-development.md
+++ b/.cursor/skills/helm-development.md
@@ -21,6 +21,25 @@ Each application chart declares its subcharts as `file://` dependencies in `Char
 - **`paragon-monitoring`**: `bull-exporter`, `grafana`, `kafka-exporter`, `kube-state-metrics`, `node-exporter`, `pgadmin`, `postgres-exporter`, `prometheus`, `redis-exporter`, `redis-insight`
 - **`paragon-logging`**: `fluent-bit`, `openobserve`
 
+### OpenObserve UDS post-hook (PARA-20444)
+
+After `helm install` / `helm upgrade` of `paragon-logging`, the `openobserve` subchart runs a **post-install,post-upgrade** Helm hook `Job` that applies the user-defined schema for the `paragon` logs stream.
+
+- **Files**: `charts/paragon-logging/charts/openobserve/files/apply-uds.sh`, `openobserve-uds-schema.json`
+- **Templates**: `uds-configmap.yaml`, `uds-apply-job.yaml`
+- **Auth**: same Kubernetes secret as the OpenObserve StatefulSet (`secretName`, keys `ZO_ROOT_USER_EMAIL` / `ZO_ROOT_USER_PASSWORD` from `paragon-secrets` unless overridden in `openobserve.secrets`)
+- **Idempotent**: GET schema → skip PUT if `defined_schema_fields` already matches desired JSON
+- **Disable**: `openobserve.uds.enabled: false`
+
+Local test (with OpenObserve reachable):
+
+```bash
+kubectl port-forward -n paragon svc/openobserve 5080:5080
+export O2_HOST=http://localhost:5080
+export ZO_ROOT_USER_EMAIL=... ZO_ROOT_USER_PASSWORD=...
+sh charts/paragon-logging/charts/openobserve/files/apply-uds.sh
+```
+
 ### Subchart Enable/Disable
 
 Each subchart can be toggled via `condition` fields in the parent `Chart.yaml`, controlled by values like:

--- a/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
+++ b/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Apply OpenObserve user-defined schema for the paragon logs stream (idempotent).
-# PARA-20444 — same semantics as o2-apply-uds.ts (GET, compare, single PUT).
+# PARA-20444 — POSIX sh (Alpine /bin/sh); no bash-isms.
 set -eu
 
 DESIRED_SCHEMA="${DESIRED_SCHEMA:-/uds/openobserve-uds-schema.json}"
@@ -19,7 +19,6 @@ if [ ! -f "$DESIRED_SCHEMA" ]; then
   exit 1
 fi
 
-# Strip trailing slash from O2_HOST
 O2_HOST="${O2_HOST%/}"
 
 auth_curl() {
@@ -40,18 +39,18 @@ done
 echo "Fetching current schema"
 current="$(auth_curl "${O2_HOST}/api/default/streams/paragon/schema?type=logs")"
 
-if jq -e --slurpfile d "$DESIRED_SCHEMA" '
+if echo "$current" | jq -e --slurpfile d "$DESIRED_SCHEMA" '
   (.settings.defined_schema_fields // []) as $cur |
   [$d[0].schema[].name] as $want |
   (($want | length) == ($cur | length)) and
   ($want | all(. as $n | $cur | index($n) != null))
-' <<<"$current" >/dev/null; then
+' >/dev/null; then
   echo "UDS already applied; skipping PUT"
   exit 0
 fi
 
 echo "Building UDS payload"
-payload="$(jq -c --slurpfile d "$DESIRED_SCHEMA" '
+payload="$(echo "$current" | jq -c --slurpfile d "$DESIRED_SCHEMA" '
   . as $current |
   $d[0].schema as $desired |
   ($desired | map(.name)) as $add_names |
@@ -67,7 +66,7 @@ payload="$(jq -c --slurpfile d "$DESIRED_SCHEMA" '
       remove: $remove_fields
     }
   }
-' <<<"$current")"
+')"
 
 echo "Applying UDS schema"
 auth_curl \
@@ -78,6 +77,6 @@ auth_curl \
 
 echo "Verifying updated schema"
 updated="$(auth_curl "${O2_HOST}/api/default/streams/paragon/schema?type=logs")"
-uds_count="$(jq '(.uds_schema // []) | length' <<<"$updated")"
-defined_count="$(jq '(.settings.defined_schema_fields // []) | length' <<<"$updated")"
+uds_count="$(echo "$updated" | jq '(.uds_schema // []) | length')"
+defined_count="$(echo "$updated" | jq '(.settings.defined_schema_fields // []) | length')"
 echo "UDS applied: ${uds_count} uds_schema fields, ${defined_count} defined_schema_fields"

--- a/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
+++ b/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
@@ -1,55 +1,94 @@
 #!/bin/sh
-# Apply OpenObserve user-defined schema for the paragon logs stream (idempotent).
-# PARA-20444 — POSIX sh (Alpine /bin/sh); no bash-isms.
+# OpenObserve UDS apply hook (PARA-20444) — POSIX sh for Alpine /bin/sh.
+#
+# When to run: Helm post-install / post-upgrade on paragon-logging (OpenObserve must be up).
+#
+# Process:
+#   1. Load the desired field list from openobserve-uds-schema.json (chart files/).
+#   2. GET the live "paragon" logs stream schema from OpenObserve.
+#   3. If settings.defined_schema_fields already matches desired names, skip PUT (idempotent).
+#   4. Otherwise build a PUT body:
+#        - add: every desired field name + field definitions
+#        - remove: names/types present on the server but not in the desired list
+#   5. PUT stream settings, then GET again and fail unless counts match the JSON.
+#
+# All progress is written to stdout for hook Job logs (kubectl logs / cluster events).
 set -eu
 
+LOG_PREFIX="[openobserve-uds]"
 DESIRED_SCHEMA="${DESIRED_SCHEMA:-/uds/openobserve-uds-schema.json}"
 O2_HOST="${O2_HOST:-http://openobserve:5080}"
 O2_USER="${O2_USER:-${ZO_ROOT_USER_EMAIL:-}}"
 O2_PASS="${O2_PASS:-${ZO_ROOT_USER_PASSWORD:-}}"
 HEALTH_WAIT_SECONDS="${HEALTH_WAIT_SECONDS:-120}"
 
-if [ -z "$O2_USER" ] || [ -z "$O2_PASS" ]; then
-  echo "error: O2_USER/O2_PASS (or ZO_ROOT_USER_EMAIL/ZO_ROOT_USER_PASSWORD) required" >&2
+log() {
+  echo "${LOG_PREFIX} $*"
+}
+
+die() {
+  echo "${LOG_PREFIX} error: $*" >&2
   exit 1
+}
+
+if [ -z "$O2_USER" ] || [ -z "$O2_PASS" ]; then
+  die "O2_USER/O2_PASS (or ZO_ROOT_USER_EMAIL/ZO_ROOT_USER_PASSWORD) required"
 fi
 
 if [ ! -f "$DESIRED_SCHEMA" ]; then
-  echo "error: desired schema not found: $DESIRED_SCHEMA" >&2
-  exit 1
+  die "desired schema not found: ${DESIRED_SCHEMA}"
 fi
 
 O2_HOST="${O2_HOST%/}"
+
+expected_count="$(jq '.schema | length' "$DESIRED_SCHEMA")"
+log "starting UDS apply for stream paragon (desired fields: ${expected_count})"
+log "openobserve endpoint: ${O2_HOST}"
 
 auth_curl() {
   curl -sf -u "$O2_USER:$O2_PASS" "$@"
 }
 
-echo "Waiting for OpenObserve at ${O2_HOST}/healthz (max ${HEALTH_WAIT_SECONDS}s)..."
+schema_matches_desired() {
+  echo "$1" | jq -e --slurpfile d "$DESIRED_SCHEMA" '
+    (.settings.defined_schema_fields // []) as $cur |
+    [$d[0].schema[].name] as $want |
+    (($want | length) == ($cur | length)) and
+    ($want | all(. as $n | $cur | index($n) != null))
+  ' >/dev/null
+}
+
+print_schema_counts() {
+  _label="$1"
+  _json="$2"
+  _defined="$(echo "$_json" | jq '(.settings.defined_schema_fields // []) | length')"
+  _uds="$(echo "$_json" | jq '(.uds_schema // []) | length')"
+  log "${_label}: defined_schema_fields=${_defined}, uds_schema=${_uds} (expected ${expected_count})"
+}
+
+log "waiting for ${O2_HOST}/healthz (max ${HEALTH_WAIT_SECONDS}s)..."
 elapsed=0
 until auth_curl "${O2_HOST}/healthz" >/dev/null 2>&1; do
   if [ "$elapsed" -ge "$HEALTH_WAIT_SECONDS" ]; then
-    echo "error: OpenObserve not ready after ${HEALTH_WAIT_SECONDS}s" >&2
-    exit 1
+    die "OpenObserve not ready after ${HEALTH_WAIT_SECONDS}s"
   fi
   sleep 2
   elapsed=$((elapsed + 2))
 done
+log "openobserve is healthy"
 
-echo "Fetching current schema"
+log "fetching current schema"
 current="$(auth_curl "${O2_HOST}/api/default/streams/paragon/schema?type=logs")"
+print_schema_counts "before apply" "$current"
 
-if echo "$current" | jq -e --slurpfile d "$DESIRED_SCHEMA" '
-  (.settings.defined_schema_fields // []) as $cur |
-  [$d[0].schema[].name] as $want |
-  (($want | length) == ($cur | length)) and
-  ($want | all(. as $n | $cur | index($n) != null))
-' >/dev/null; then
-  echo "UDS already applied; skipping PUT"
+if schema_matches_desired "$current"; then
+  log "UDS already matches desired schema; skipping PUT"
+  log "done (no changes)"
   exit 0
 fi
 
-echo "Building UDS payload"
+log "schema drift detected; building PUT payload"
+# jq: compute add/remove vs desired list (same semantics as o2-apply-uds.ts).
 payload="$(echo "$current" | jq -c --slurpfile d "$DESIRED_SCHEMA" '
   . as $current |
   $d[0].schema as $desired |
@@ -68,15 +107,36 @@ payload="$(echo "$current" | jq -c --slurpfile d "$DESIRED_SCHEMA" '
   }
 ')"
 
-echo "Applying UDS schema"
+add_names="$(echo "$payload" | jq '.defined_schema_fields.add | length')"
+remove_names="$(echo "$payload" | jq '.defined_schema_fields.remove | length')"
+remove_fields="$(echo "$payload" | jq '.fields.remove | length')"
+log "PUT payload: add ${add_names} defined_schema_fields, remove ${remove_names} names, remove ${remove_fields} field objects"
+
+log "applying UDS via PUT ${O2_HOST}/api/default/streams/paragon/settings"
 auth_curl \
   -X PUT \
   -H "Content-Type: application/json" \
   -d "$payload" \
   "${O2_HOST}/api/default/streams/paragon/settings"
 
-echo "Verifying updated schema"
+log "verifying schema after PUT"
 updated="$(auth_curl "${O2_HOST}/api/default/streams/paragon/schema?type=logs")"
-uds_count="$(echo "$updated" | jq '(.uds_schema // []) | length')"
+print_schema_counts "after apply" "$updated"
+
 defined_count="$(echo "$updated" | jq '(.settings.defined_schema_fields // []) | length')"
-echo "UDS applied: ${uds_count} uds_schema fields, ${defined_count} defined_schema_fields"
+uds_count="$(echo "$updated" | jq '(.uds_schema // []) | length')"
+
+if [ "$defined_count" -ne "$expected_count" ]; then
+  die "post-PUT defined_schema_fields count ${defined_count} != expected ${expected_count}"
+fi
+
+if [ "$uds_count" -ne "$expected_count" ]; then
+  die "post-PUT uds_schema count ${uds_count} != expected ${expected_count}"
+fi
+
+if ! schema_matches_desired "$updated"; then
+  die "post-PUT schema field names do not match desired list"
+fi
+
+log "UDS apply succeeded: ${defined_count} defined_schema_fields, ${uds_count} uds_schema fields"
+log "done"

--- a/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
+++ b/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
@@ -16,10 +16,8 @@
 set -eu
 
 LOG_PREFIX="[openobserve-uds]"
-DESIRED_SCHEMA="${DESIRED_SCHEMA:-/uds/openobserve-uds-schema.json}"
+DESIRED_SCHEMA_FILE="${DESIRED_SCHEMA_FILE:-/uds/openobserve-uds-schema.json}"
 O2_HOST="${O2_HOST:-http://openobserve:5080}"
-O2_USER="${O2_USER:-${ZO_ROOT_USER_EMAIL:-}}"
-O2_PASS="${O2_PASS:-${ZO_ROOT_USER_PASSWORD:-}}"
 HEALTH_WAIT_SECONDS="${HEALTH_WAIT_SECONDS:-120}"
 
 log() {
@@ -31,26 +29,26 @@ die() {
   exit 1
 }
 
-if [ -z "$O2_USER" ] || [ -z "$O2_PASS" ]; then
-  die "O2_USER/O2_PASS (or ZO_ROOT_USER_EMAIL/ZO_ROOT_USER_PASSWORD) required"
+if [ -z "$ZO_ROOT_USER_EMAIL" ] || [ -z "$ZO_ROOT_USER_PASSWORD" ]; then
+  die "ZO_ROOT_USER_EMAIL and ZO_ROOT_USER_PASSWORD required"
 fi
 
-if [ ! -f "$DESIRED_SCHEMA" ]; then
-  die "desired schema not found: ${DESIRED_SCHEMA}"
+if [ ! -f "$DESIRED_SCHEMA_FILE" ]; then
+  die "desired schema not found: ${DESIRED_SCHEMA_FILE}"
 fi
 
 O2_HOST="${O2_HOST%/}"
 
-expected_count="$(jq '.schema | length' "$DESIRED_SCHEMA")"
+expected_count="$(jq '.schema | length' "$DESIRED_SCHEMA_FILE")"
 log "starting UDS apply for stream paragon (desired fields: ${expected_count})"
 log "openobserve endpoint: ${O2_HOST}"
 
 auth_curl() {
-  curl -sf -u "$O2_USER:$O2_PASS" "$@"
+  curl -sf -u "$ZO_ROOT_USER_EMAIL:$ZO_ROOT_USER_PASSWORD" "$@"
 }
 
 schema_matches_desired() {
-  echo "$1" | jq -e --slurpfile d "$DESIRED_SCHEMA" '
+  echo "$1" | jq -e --slurpfile d "$DESIRED_SCHEMA_FILE" '
     (.settings.defined_schema_fields // []) as $cur |
     [$d[0].schema[].name] as $want |
     (($want | length) == ($cur | length)) and
@@ -89,7 +87,7 @@ fi
 
 log "schema drift detected; building PUT payload"
 # jq: compute add/remove vs desired list (same semantics as o2-apply-uds.ts).
-payload="$(echo "$current" | jq -c --slurpfile d "$DESIRED_SCHEMA" '
+payload="$(echo "$current" | jq -c --slurpfile d "$DESIRED_SCHEMA_FILE" '
   . as $current |
   $d[0].schema as $desired |
   ($desired | map(.name)) as $add_names |

--- a/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
+++ b/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
@@ -3,7 +3,7 @@
 # PARA-20444 — same semantics as o2-apply-uds.ts (GET, compare, single PUT).
 set -eu
 
-DESIRED_SCHEMA="${DESIRED_SCHEMA:-/schema/openobserve-uds-schema.json}"
+DESIRED_SCHEMA="${DESIRED_SCHEMA:-/uds/openobserve-uds-schema.json}"
 O2_HOST="${O2_HOST:-http://openobserve:5080}"
 O2_USER="${O2_USER:-${ZO_ROOT_USER_EMAIL:-}}"
 O2_PASS="${O2_PASS:-${ZO_ROOT_USER_PASSWORD:-}}"

--- a/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
+++ b/charts/paragon-logging/charts/openobserve/files/apply-uds.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Apply OpenObserve user-defined schema for the paragon logs stream (idempotent).
+# PARA-20444 — same semantics as o2-apply-uds.ts (GET, compare, single PUT).
+set -eu
+
+DESIRED_SCHEMA="${DESIRED_SCHEMA:-/schema/openobserve-uds-schema.json}"
+O2_HOST="${O2_HOST:-http://openobserve:5080}"
+O2_USER="${O2_USER:-${ZO_ROOT_USER_EMAIL:-}}"
+O2_PASS="${O2_PASS:-${ZO_ROOT_USER_PASSWORD:-}}"
+HEALTH_WAIT_SECONDS="${HEALTH_WAIT_SECONDS:-120}"
+
+if [ -z "$O2_USER" ] || [ -z "$O2_PASS" ]; then
+  echo "error: O2_USER/O2_PASS (or ZO_ROOT_USER_EMAIL/ZO_ROOT_USER_PASSWORD) required" >&2
+  exit 1
+fi
+
+if [ ! -f "$DESIRED_SCHEMA" ]; then
+  echo "error: desired schema not found: $DESIRED_SCHEMA" >&2
+  exit 1
+fi
+
+# Strip trailing slash from O2_HOST
+O2_HOST="${O2_HOST%/}"
+
+auth_curl() {
+  curl -sf -u "$O2_USER:$O2_PASS" "$@"
+}
+
+echo "Waiting for OpenObserve at ${O2_HOST}/healthz (max ${HEALTH_WAIT_SECONDS}s)..."
+elapsed=0
+until auth_curl "${O2_HOST}/healthz" >/dev/null 2>&1; do
+  if [ "$elapsed" -ge "$HEALTH_WAIT_SECONDS" ]; then
+    echo "error: OpenObserve not ready after ${HEALTH_WAIT_SECONDS}s" >&2
+    exit 1
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+
+echo "Fetching current schema"
+current="$(auth_curl "${O2_HOST}/api/default/streams/paragon/schema?type=logs")"
+
+if jq -e --slurpfile d "$DESIRED_SCHEMA" '
+  (.settings.defined_schema_fields // []) as $cur |
+  [$d[0].schema[].name] as $want |
+  (($want | length) == ($cur | length)) and
+  ($want | all(. as $n | $cur | index($n) != null))
+' <<<"$current" >/dev/null; then
+  echo "UDS already applied; skipping PUT"
+  exit 0
+fi
+
+echo "Building UDS payload"
+payload="$(jq -c --slurpfile d "$DESIRED_SCHEMA" '
+  . as $current |
+  $d[0].schema as $desired |
+  ($desired | map(.name)) as $add_names |
+  (($current.settings.defined_schema_fields // []) | map(select(. as $n | $add_names | index($n) | not))) as $remove_names |
+  (($current.uds_schema // []) | map(select(.name as $n | $add_names | index($n) | not))) as $remove_fields |
+  {
+    defined_schema_fields: {
+      add: $add_names,
+      remove: $remove_names
+    },
+    fields: {
+      add: $desired,
+      remove: $remove_fields
+    }
+  }
+' <<<"$current")"
+
+echo "Applying UDS schema"
+auth_curl \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -d "$payload" \
+  "${O2_HOST}/api/default/streams/paragon/settings"
+
+echo "Verifying updated schema"
+updated="$(auth_curl "${O2_HOST}/api/default/streams/paragon/schema?type=logs")"
+uds_count="$(jq '(.uds_schema // []) | length' <<<"$updated")"
+defined_count="$(jq '(.settings.defined_schema_fields // []) | length' <<<"$updated")"
+echo "UDS applied: ${uds_count} uds_schema fields, ${defined_count} defined_schema_fields"

--- a/charts/paragon-logging/charts/openobserve/files/openobserve-uds-schema.json
+++ b/charts/paragon-logging/charts/openobserve/files/openobserve-uds-schema.json
@@ -1,0 +1,1980 @@
+{
+  "schema": [
+    {
+      "name": "_timestamp",
+      "type": "Int64"
+    },
+    {
+      "name": "action",
+      "type": "Utf8"
+    },
+    {
+      "name": "activeinstanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "activestepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "code",
+      "type": "Utf8"
+    },
+    {
+      "name": "connectcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "crontriggersubscriptionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "currentcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "customintegrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "customintegrationname",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_customintegrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "deploymentid",
+      "type": "Utf8"
+    },
+    {
+      "name": "deploymentids",
+      "type": "Utf8"
+    },
+    {
+      "name": "email",
+      "type": "Utf8"
+    },
+    {
+      "name": "enduserid",
+      "type": "Utf8"
+    },
+    {
+      "name": "error",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_headers_req_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_headers_retry_after",
+      "type": "Utf8"
+    },
+    {
+      "name": "eventid",
+      "type": "Utf8"
+    },
+    {
+      "name": "executiongroupid",
+      "type": "Utf8"
+    },
+    {
+      "name": "feature",
+      "type": "Utf8"
+    },
+    {
+      "name": "groupid",
+      "type": "Utf8"
+    },
+    {
+      "name": "host",
+      "type": "Utf8"
+    },
+    {
+      "name": "hostname",
+      "type": "Utf8"
+    },
+    {
+      "name": "httpmethod",
+      "type": "Utf8"
+    },
+    {
+      "name": "httpstatus",
+      "type": "Int64"
+    },
+    {
+      "name": "httpstatuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "id",
+      "type": "Utf8"
+    },
+    {
+      "name": "impersonated",
+      "type": "Boolean"
+    },
+    {
+      "name": "instanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "integration",
+      "type": "Utf8"
+    },
+    {
+      "name": "integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "integrationname",
+      "type": "Utf8"
+    },
+    {
+      "name": "intent",
+      "type": "Utf8"
+    },
+    {
+      "name": "interval",
+      "type": "Utf8"
+    },
+    {
+      "name": "isconnect",
+      "type": "Boolean"
+    },
+    {
+      "name": "isconnectproject",
+      "type": "Boolean"
+    },
+    {
+      "name": "isintegrationerror",
+      "type": "Boolean"
+    },
+    {
+      "name": "jobdatareferenceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "jobid",
+      "type": "Utf8"
+    },
+    {
+      "name": "jobname",
+      "type": "Utf8"
+    },
+    {
+      "name": "key",
+      "type": "Utf8"
+    },
+    {
+      "name": "kubernetes_container_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "kubernetes_pod_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "kubernetes_pod_ip",
+      "type": "Utf8"
+    },
+    {
+      "name": "kubernetes_pod_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "leaderid",
+      "type": "Utf8"
+    },
+    {
+      "name": "length",
+      "type": "Int64"
+    },
+    {
+      "name": "level",
+      "type": "Utf8"
+    },
+    {
+      "name": "log",
+      "type": "Utf8"
+    },
+    {
+      "name": "maxid",
+      "type": "Utf8"
+    },
+    {
+      "name": "memberid",
+      "type": "Utf8"
+    },
+    {
+      "name": "message",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_action",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_attempts",
+      "type": "Int64"
+    },
+    {
+      "name": "meta_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_connectcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_executionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_linenumber",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_plan",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_stepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_timelimit",
+      "type": "Int64"
+    },
+    {
+      "name": "meta_workflowid",
+      "type": "Utf8"
+    },
+    {
+      "name": "method",
+      "type": "Utf8"
+    },
+    {
+      "name": "migrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "minid",
+      "type": "Utf8"
+    },
+    {
+      "name": "msg",
+      "type": "Utf8"
+    },
+    {
+      "name": "name",
+      "type": "Utf8"
+    },
+    {
+      "name": "namespace",
+      "type": "Utf8"
+    },
+    {
+      "name": "nextstepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "organizationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "ownerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "paragonerrorcode",
+      "type": "Utf8"
+    },
+    {
+      "name": "paragonerrormessage",
+      "type": "Utf8"
+    },
+    {
+      "name": "path",
+      "type": "Utf8"
+    },
+    {
+      "name": "personaid",
+      "type": "Utf8"
+    },
+    {
+      "name": "pid",
+      "type": "Int64"
+    },
+    {
+      "name": "previnstanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "projectids",
+      "type": "Utf8"
+    },
+    {
+      "name": "projecttype",
+      "type": "Utf8"
+    },
+    {
+      "name": "providerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "releaseid",
+      "type": "Utf8"
+    },
+    {
+      "name": "releasejobid",
+      "type": "Utf8"
+    },
+    {
+      "name": "remaininginstances",
+      "type": "Int64"
+    },
+    {
+      "name": "req_url",
+      "type": "Utf8"
+    },
+    {
+      "name": "req_urlpattern",
+      "type": "Utf8"
+    },
+    {
+      "name": "request_path",
+      "type": "Utf8"
+    },
+    {
+      "name": "res_statuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "resourceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "result",
+      "type": "Utf8"
+    },
+    {
+      "name": "s3path",
+      "type": "Utf8"
+    },
+    {
+      "name": "sql",
+      "type": "Utf8"
+    },
+    {
+      "name": "stackid",
+      "type": "Utf8"
+    },
+    {
+      "name": "stacktrace",
+      "type": "Utf8"
+    },
+    {
+      "name": "starttime",
+      "type": "Int64"
+    },
+    {
+      "name": "status",
+      "type": "Utf8"
+    },
+    {
+      "name": "statuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "statustext",
+      "type": "Utf8"
+    },
+    {
+      "name": "step",
+      "type": "Utf8"
+    },
+    {
+      "name": "stepexecutionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "stepexecutiontime",
+      "type": "Int64"
+    },
+    {
+      "name": "stepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "stepinstanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "stepstatus",
+      "type": "Utf8"
+    },
+    {
+      "name": "steptype",
+      "type": "Utf8"
+    },
+    {
+      "name": "stream",
+      "type": "Utf8"
+    },
+    {
+      "name": "stripecustomerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "stripesubscriptionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "subscribers",
+      "type": "Int64"
+    },
+    {
+      "name": "subscriptionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "subscriptionids",
+      "type": "Utf8"
+    },
+    {
+      "name": "syncinstanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "team_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "team_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "team_organization_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "team_organization_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "team_organization_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "team_organizationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "teamid",
+      "type": "Utf8"
+    },
+    {
+      "name": "teammembers",
+      "type": "Utf8"
+    },
+    {
+      "name": "timestamp",
+      "type": "Utf8"
+    },
+    {
+      "name": "title",
+      "type": "Utf8"
+    },
+    {
+      "name": "trace",
+      "type": "Utf8"
+    },
+    {
+      "name": "traceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "triggerintent",
+      "type": "Utf8"
+    },
+    {
+      "name": "type",
+      "type": "Utf8"
+    },
+    {
+      "name": "unit",
+      "type": "Utf8"
+    },
+    {
+      "name": "usedmemory",
+      "type": "Int64"
+    },
+    {
+      "name": "userid",
+      "type": "Utf8"
+    },
+    {
+      "name": "utilization",
+      "type": "Float64"
+    },
+    {
+      "name": "version",
+      "type": "Utf8"
+    },
+    {
+      "name": "versionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "worker_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "worker_queue",
+      "type": "Utf8"
+    },
+    {
+      "name": "workercount",
+      "type": "Int64"
+    },
+    {
+      "name": "workercountneeded",
+      "type": "Int64"
+    },
+    {
+      "name": "workerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflowexecutionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflowid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflowmigrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflowteamid",
+      "type": "Utf8"
+    },
+    {
+      "name": "active",
+      "type": "Boolean"
+    },
+    {
+      "name": "attempts",
+      "type": "Int64"
+    },
+    {
+      "name": "authenticationtype",
+      "type": "Utf8"
+    },
+    {
+      "name": "authorization_model_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "authorizationstoreid",
+      "type": "Utf8"
+    },
+    {
+      "name": "authtype",
+      "type": "Utf8"
+    },
+    {
+      "name": "body_file_mimetype",
+      "type": "Utf8"
+    },
+    {
+      "name": "body_file_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "body_filename",
+      "type": "Utf8"
+    },
+    {
+      "name": "body_job_title",
+      "type": "Utf8"
+    },
+    {
+      "name": "body_state",
+      "type": "Utf8"
+    },
+    {
+      "name": "body_timestamp",
+      "type": "Utf8"
+    },
+    {
+      "name": "build_commit",
+      "type": "Utf8"
+    },
+    {
+      "name": "build_version",
+      "type": "Utf8"
+    },
+    {
+      "name": "category",
+      "type": "Utf8"
+    },
+    {
+      "name": "checkpoint",
+      "type": "Utf8"
+    },
+    {
+      "name": "clientstatus",
+      "type": "Utf8"
+    },
+    {
+      "name": "config_log_format",
+      "type": "Utf8"
+    },
+    {
+      "name": "config_log_level",
+      "type": "Utf8"
+    },
+    {
+      "name": "config_log_timestampformat",
+      "type": "Utf8"
+    },
+    {
+      "name": "configurationname",
+      "type": "Utf8"
+    },
+    {
+      "name": "context",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_credentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_datecreated",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_dateupdated",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_personaid",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_scheme",
+      "type": "Utf8"
+    },
+    {
+      "name": "credential_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_class",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_details",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_errors",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_innererror",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_intent",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_customintegrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_personaid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_method",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_operationtype",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_ownerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_providerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_queuedtime",
+      "type": "Int64"
+    },
+    {
+      "name": "data_releaseid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_sourceprojectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_starttime",
+      "type": "Int64"
+    },
+    {
+      "name": "data_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_statuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "data_suberror",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_subscriptionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_testing",
+      "type": "Boolean"
+    },
+    {
+      "name": "data_timestamp",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_trace_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_version",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_workflowid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_workflowmigrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_workflowversion",
+      "type": "Int64"
+    },
+    {
+      "name": "database",
+      "type": "Utf8"
+    },
+    {
+      "name": "date",
+      "type": "Utf8"
+    },
+    {
+      "name": "datecreated",
+      "type": "Utf8"
+    },
+    {
+      "name": "datesubmitted",
+      "type": "Utf8"
+    },
+    {
+      "name": "dateupdated",
+      "type": "Utf8"
+    },
+    {
+      "name": "delay",
+      "type": "Int64"
+    },
+    {
+      "name": "delayed",
+      "type": "Int64"
+    },
+    {
+      "name": "deletedrecords",
+      "type": "Int64"
+    },
+    {
+      "name": "delta",
+      "type": "Int64"
+    },
+    {
+      "name": "description",
+      "type": "Utf8"
+    },
+    {
+      "name": "dir",
+      "type": "Utf8"
+    },
+    {
+      "name": "duration",
+      "type": "Int64"
+    },
+    {
+      "name": "encryptedsessionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_file",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_length",
+      "type": "Int64"
+    },
+    {
+      "name": "err_line",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_routine",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_severity",
+      "type": "Utf8"
+    },
+    {
+      "name": "err_where",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_action",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_bucketname",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_context",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_description",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_headers_date",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_hostname",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_output_error",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_requestid",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_resource",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_response",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_response_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_response_statuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "error_stack",
+      "type": "Utf8"
+    },
+    {
+      "name": "error_statustext",
+      "type": "Utf8"
+    },
+    {
+      "name": "errorcode",
+      "type": "Utf8"
+    },
+    {
+      "name": "errorerror",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormessage",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormeta",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormeta_correlationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormeta_error",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormeta_error_description",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormeta_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "errormeta_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "errortype",
+      "type": "Utf8"
+    },
+    {
+      "name": "eventname",
+      "type": "Utf8"
+    },
+    {
+      "name": "execution_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "execution_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "execution_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "execution_stepcount",
+      "type": "Int64"
+    },
+    {
+      "name": "execution_workflowid",
+      "type": "Utf8"
+    },
+    {
+      "name": "executionids",
+      "type": "Utf8"
+    },
+    {
+      "name": "executions",
+      "type": "Utf8"
+    },
+    {
+      "name": "failedreason",
+      "type": "Utf8"
+    },
+    {
+      "name": "failuretype",
+      "type": "Utf8"
+    },
+    {
+      "name": "finalstepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "headers_category",
+      "type": "Utf8"
+    },
+    {
+      "name": "headers_customerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "headers_customername",
+      "type": "Utf8"
+    },
+    {
+      "name": "headers_x_paragon_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "headers_x_request_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "inactiveworkers",
+      "type": "Int64"
+    },
+    {
+      "name": "index",
+      "type": "Int64"
+    },
+    {
+      "name": "input_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "input_userid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_attemptsmade",
+      "type": "Int64"
+    },
+    {
+      "name": "job_data_action",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_activeinstanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_activestepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_connectcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_credentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_enduserid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_intent",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_operationtype",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_ownerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_providerid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_queuedtime",
+      "type": "Int64"
+    },
+    {
+      "name": "job_data_starttime",
+      "type": "Int64"
+    },
+    {
+      "name": "job_data_testing",
+      "type": "Boolean"
+    },
+    {
+      "name": "job_data_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_workflowid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_workflowmigrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_data_workflowversion",
+      "type": "Int64"
+    },
+    {
+      "name": "job_delay",
+      "type": "Int64"
+    },
+    {
+      "name": "job_failedreason",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_finishedon",
+      "type": "Int64"
+    },
+    {
+      "name": "job_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_opts_attempts",
+      "type": "Int64"
+    },
+    {
+      "name": "job_opts_backoff",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_opts_delay",
+      "type": "Int64"
+    },
+    {
+      "name": "job_opts_jobid",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_opts_pause",
+      "type": "Boolean"
+    },
+    {
+      "name": "job_opts_priority",
+      "type": "Int64"
+    },
+    {
+      "name": "job_opts_pushtofanoutstack",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_opts_queuesamestep",
+      "type": "Boolean"
+    },
+    {
+      "name": "job_opts_removeoncomplete",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_opts_timeout",
+      "type": "Int64"
+    },
+    {
+      "name": "job_opts_timestamp",
+      "type": "Int64"
+    },
+    {
+      "name": "job_processedon",
+      "type": "Int64"
+    },
+    {
+      "name": "job_stacktrace",
+      "type": "Utf8"
+    },
+    {
+      "name": "job_timestamp",
+      "type": "Int64"
+    },
+    {
+      "name": "kubernetes_host",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_expected",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_isintegrationerror",
+      "type": "Boolean"
+    },
+    {
+      "name": "meta_meta_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_meta_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_method",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_param",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_response_category",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_response_correlationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_response_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_response_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_source",
+      "type": "Utf8"
+    },
+    {
+      "name": "meta_statuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "meta_traceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "mime",
+      "type": "Utf8"
+    },
+    {
+      "name": "missing",
+      "type": "Utf8"
+    },
+    {
+      "name": "msg_sql",
+      "type": "Utf8"
+    },
+    {
+      "name": "next",
+      "type": "Utf8"
+    },
+    {
+      "name": "number",
+      "type": "Int64"
+    },
+    {
+      "name": "numberofdestinations",
+      "type": "Int64"
+    },
+    {
+      "name": "numdeployedworkflows",
+      "type": "Int64"
+    },
+    {
+      "name": "numofconsumerjobsinqueue",
+      "type": "Int64"
+    },
+    {
+      "name": "numofrepeatablejobs",
+      "type": "Int64"
+    },
+    {
+      "name": "numworkersoncurrenthost",
+      "type": "Int64"
+    },
+    {
+      "name": "oldcheckpoint_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "oldcheckpoint_value",
+      "type": "Utf8"
+    },
+    {
+      "name": "opts_delay",
+      "type": "Int64"
+    },
+    {
+      "name": "opts_jobid",
+      "type": "Utf8"
+    },
+    {
+      "name": "opts_movetodedicatedqueue",
+      "type": "Boolean"
+    },
+    {
+      "name": "opts_pause",
+      "type": "Boolean"
+    },
+    {
+      "name": "opts_priority",
+      "type": "Int64"
+    },
+    {
+      "name": "opts_pushtofanoutstack_instanceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "opts_pushtofanoutstack_stepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "opts_queuesamestep",
+      "type": "Boolean"
+    },
+    {
+      "name": "opts_removeoncomplete_age",
+      "type": "Int64"
+    },
+    {
+      "name": "opts_timeout",
+      "type": "Int64"
+    },
+    {
+      "name": "opts_timestamp",
+      "type": "Int64"
+    },
+    {
+      "name": "output_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "owner_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "pipeline",
+      "type": "Utf8"
+    },
+    {
+      "name": "port",
+      "type": "Int64"
+    },
+    {
+      "name": "query_end",
+      "type": "Utf8"
+    },
+    {
+      "name": "query_enduserid",
+      "type": "Utf8"
+    },
+    {
+      "name": "query_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "query_istest",
+      "type": "Boolean"
+    },
+    {
+      "name": "query_limit",
+      "type": "Int64"
+    },
+    {
+      "name": "query_page",
+      "type": "Int64"
+    },
+    {
+      "name": "query_sort",
+      "type": "Utf8"
+    },
+    {
+      "name": "query_start",
+      "type": "Utf8"
+    },
+    {
+      "name": "recordid",
+      "type": "Utf8"
+    },
+    {
+      "name": "remotecached",
+      "type": "Boolean"
+    },
+    {
+      "name": "replay",
+      "type": "Boolean"
+    },
+    {
+      "name": "request_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "requestname",
+      "type": "Utf8"
+    },
+    {
+      "name": "required",
+      "type": "Utf8"
+    },
+    {
+      "name": "resolved",
+      "type": "Utf8"
+    },
+    {
+      "name": "response_status",
+      "type": "Int64"
+    },
+    {
+      "name": "response_statuscode",
+      "type": "Int64"
+    },
+    {
+      "name": "response_suberror",
+      "type": "Utf8"
+    },
+    {
+      "name": "response_timestamp",
+      "type": "Utf8"
+    },
+    {
+      "name": "response_trace_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "result_error",
+      "type": "Utf8"
+    },
+    {
+      "name": "result_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "result_status",
+      "type": "Int64"
+    },
+    {
+      "name": "resultlength",
+      "type": "Int64"
+    },
+    {
+      "name": "results",
+      "type": "Utf8"
+    },
+    {
+      "name": "retentiondays",
+      "type": "Int64"
+    },
+    {
+      "name": "retriedon",
+      "type": "Int64"
+    },
+    {
+      "name": "retrycount",
+      "type": "Int64"
+    },
+    {
+      "name": "role",
+      "type": "Utf8"
+    },
+    {
+      "name": "scheme",
+      "type": "Utf8"
+    },
+    {
+      "name": "securitygroupid",
+      "type": "Utf8"
+    },
+    {
+      "name": "server_hostname",
+      "type": "Utf8"
+    },
+    {
+      "name": "server_pid",
+      "type": "Int64"
+    },
+    {
+      "name": "size",
+      "type": "Int64"
+    },
+    {
+      "name": "source",
+      "type": "Utf8"
+    },
+    {
+      "name": "source_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "source_remotecached",
+      "type": "Boolean"
+    },
+    {
+      "name": "source_start",
+      "type": "Int64"
+    },
+    {
+      "name": "source_stepid",
+      "type": "Utf8"
+    },
+    {
+      "name": "source_steptype",
+      "type": "Utf8"
+    },
+    {
+      "name": "source_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "source_version",
+      "type": "Utf8"
+    },
+    {
+      "name": "sourceprojectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "subscriptions",
+      "type": "Utf8"
+    },
+    {
+      "name": "subscriptionstatus",
+      "type": "Utf8"
+    },
+    {
+      "name": "subscriptiontype",
+      "type": "Utf8"
+    },
+    {
+      "name": "targets",
+      "type": "Utf8"
+    },
+    {
+      "name": "test",
+      "type": "Utf8"
+    },
+    {
+      "name": "testing",
+      "type": "Boolean"
+    },
+    {
+      "name": "throttlingkey",
+      "type": "Utf8"
+    },
+    {
+      "name": "time",
+      "type": "Utf8"
+    },
+    {
+      "name": "time_minutes",
+      "type": "Int64"
+    },
+    {
+      "name": "time_timezone",
+      "type": "Utf8"
+    },
+    {
+      "name": "traffic",
+      "type": "Utf8"
+    },
+    {
+      "name": "ts",
+      "type": "Utf8"
+    },
+    {
+      "name": "updatedcheckpoint_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "updatedcheckpoint_value",
+      "type": "Utf8"
+    },
+    {
+      "name": "updatetype",
+      "type": "Utf8"
+    },
+    {
+      "name": "url",
+      "type": "Utf8"
+    },
+    {
+      "name": "wal_dir",
+      "type": "Utf8"
+    },
+    {
+      "name": "wal_dir_dedicated",
+      "type": "Utf8"
+    },
+    {
+      "name": "weekday",
+      "type": "Utf8"
+    },
+    {
+      "name": "worker_count",
+      "type": "Int64"
+    },
+    {
+      "name": "workers",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_connectintegration_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_connectintegration_isactive",
+      "type": "Boolean"
+    },
+    {
+      "name": "workflow_connectintegration_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_connectintegration_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_description",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_steps",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_teamid",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflow_workflowversion",
+      "type": "Int64"
+    },
+    {
+      "name": "workflowexecutionstarttime",
+      "type": "Int64"
+    },
+    {
+      "name": "workflowexecutiontime",
+      "type": "Utf8"
+    },
+    {
+      "name": "workflowmigrations",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_httpstatus",
+      "type": "Int64"
+    },
+    {
+      "name": "wrappederror_logoninitialization",
+      "type": "Boolean"
+    },
+    {
+      "name": "wrappederror_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_action",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_apierror",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_baseid",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_connectcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_credentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_info",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_integrationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_isconnect",
+      "type": "Boolean"
+    },
+    {
+      "name": "wrappederror_meta_personaid",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_meta_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_name",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_response_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_response_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_response_meta",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_response_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "wrappederror_status",
+      "type": "Int64"
+    },
+    {
+      "name": "wrappederror_traceid",
+      "type": "Utf8"
+    },
+    {
+      "name": "checkpoint_type",
+      "type": "Utf8"
+    },
+    {
+      "name": "checkpoint_value",
+      "type": "Utf8"
+    },
+    {
+      "name": "cluster_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "correlationid",
+      "type": "Int64"
+    },
+    {
+      "name": "data_accountusage_canexecutetasks",
+      "type": "Boolean"
+    },
+    {
+      "name": "data_accountusage_concurrency",
+      "type": "Int64"
+    },
+    {
+      "name": "data_accountusage_graceperiodminutes",
+      "type": "Int64"
+    },
+    {
+      "name": "data_accountusage_integrationslimitcount",
+      "type": "Int64"
+    },
+    {
+      "name": "data_accountusage_period",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_accountusage_plan",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_accountusage_releasesconnectuserslimitcount",
+      "type": "Int64"
+    },
+    {
+      "name": "data_accountusage_status",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_accountusage_subscriptionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_accountusage_tasksexecutedcount",
+      "type": "Int64"
+    },
+    {
+      "name": "data_accountusage_taskslimitcount",
+      "type": "Int64"
+    },
+    {
+      "name": "data_action",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_connectcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_correlation_id",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_correlationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_credentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_enduserid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_code",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_codes",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_description",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_message",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_error_uri",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_connectcredentialid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_errormessage",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_organizationid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_projectid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_property",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_requestid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_subscriptionid",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_subscriptiontype",
+      "type": "Utf8"
+    },
+    {
+      "name": "data_meta_workflowid",
+      "type": "Utf8"
+    }
+  ]
+}

--- a/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
@@ -28,8 +28,7 @@ spec:
             - -c
             - |
               apk add --no-cache curl jq >/dev/null
-              chmod +x /uds/apply-uds.sh
-              exec /uds/apply-uds.sh
+              exec /bin/sh /uds/apply-uds.sh
           env:
             - name: O2_HOST
               value: "http://{{ include "openobserve.fullname" . }}:{{ .Values.service.port }}"

--- a/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.uds.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "openobserve.fullname" . }}-uds-apply
+  labels:
+    {{- include "openobserve.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.uds.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.uds.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        {{- include "openobserve.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: uds-apply
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: uds-apply
+          image: "{{ .Values.uds.image.repository }}:{{ .Values.uds.image.tag }}"
+          imagePullPolicy: {{ .Values.uds.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache curl jq >/dev/null
+              chmod +x /uds/apply-uds.sh
+              exec /uds/apply-uds.sh
+          env:
+            - name: O2_HOST
+              value: "http://{{ include "openobserve.fullname" . }}:{{ .Values.service.port }}"
+            - name: DESIRED_SCHEMA
+              value: /uds/openobserve-uds-schema.json
+            - name: HEALTH_WAIT_SECONDS
+              value: {{ .Values.uds.healthWaitSeconds | quote }}
+            - name: ZO_ROOT_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if and .Values.secrets (kindIs "map" .Values.secrets) (hasKey .Values.secrets "ZO_ROOT_USER_EMAIL") }}{{ .Values.secretName }}-{{ .Chart.Name }}{{ else }}{{ .Values.secretName }}{{ end }}
+                  key: ZO_ROOT_USER_EMAIL
+            - name: ZO_ROOT_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if and .Values.secrets (kindIs "map" .Values.secrets) (hasKey .Values.secrets "ZO_ROOT_USER_PASSWORD") }}{{ .Values.secretName }}-{{ .Chart.Name }}{{ else }}{{ .Values.secretName }}{{ end }}
+                  key: ZO_ROOT_USER_PASSWORD
+          volumeMounts:
+            - name: uds-files
+              mountPath: /uds
+              readOnly: true
+          resources:
+            {{- toYaml .Values.uds.resources | nindent 12 }}
+      volumes:
+        - name: uds-files
+          configMap:
+            name: {{ include "openobserve.fullname" . }}-uds
+            defaultMode: 0555
+            items:
+              - key: openobserve-uds-schema.json
+                path: openobserve-uds-schema.json
+              - key: apply-uds.sh
+                path: apply-uds.sh
+{{- end }}

--- a/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
@@ -32,7 +32,7 @@ spec:
           env:
             - name: O2_HOST
               value: "http://{{ include "openobserve.fullname" . }}:{{ .Values.service.port }}"
-            - name: DESIRED_SCHEMA
+            - name: DESIRED_SCHEMA_FILE
               value: /uds/openobserve-uds-schema.json
             - name: HEALTH_WAIT_SECONDS
               value: {{ .Values.uds.healthWaitSeconds | quote }}

--- a/charts/paragon-logging/charts/openobserve/templates/uds-configmap.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/uds-configmap.yaml
@@ -1,4 +1,12 @@
 {{- if .Values.uds.enabled }}
+{{- $schema := .Files.Get "files/openobserve-uds-schema.json" }}
+{{- $script := .Files.Get "files/apply-uds.sh" }}
+{{- if not $schema }}
+{{- fail "UDS schema missing: expected charts/openobserve/files/openobserve-uds-schema.json (run prepare.sh)" }}
+{{- end }}
+{{- if not $script }}
+{{- fail "UDS script missing: expected charts/openobserve/files/apply-uds.sh (run prepare.sh)" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +15,7 @@ metadata:
     {{- include "openobserve.labels" . | nindent 4 }}
 data:
   openobserve-uds-schema.json: |
-{{ .Files.Get "openobserve-uds-schema.json" | indent 4 }}
+{{ $schema | indent 4 }}
   apply-uds.sh: |
-{{ .Files.Get "apply-uds.sh" | indent 4 }}
+{{ $script | indent 4 }}
 {{- end }}

--- a/charts/paragon-logging/charts/openobserve/templates/uds-configmap.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/uds-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.uds.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openobserve.fullname" . }}-uds
+  labels:
+    {{- include "openobserve.labels" . | nindent 4 }}
+data:
+  openobserve-uds-schema.json: |
+{{ .Files.Get "openobserve-uds-schema.json" | indent 4 }}
+  apply-uds.sh: |
+{{ .Files.Get "apply-uds.sh" | indent 4 }}
+{{- end }}

--- a/charts/paragon-logging/charts/openobserve/values.yaml
+++ b/charts/paragon-logging/charts/openobserve/values.yaml
@@ -107,3 +107,22 @@ persistence:
   size: 5Gi
 
 secrets: {}
+
+# Post-install/upgrade hook to apply user-defined schema (PARA-20444).
+# Uses the same paragon-secrets credentials as the OpenObserve StatefulSet.
+uds:
+  enabled: true
+  image:
+    repository: alpine
+    tag: "3.20"
+    pullPolicy: IfNotPresent
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  healthWaitSeconds: 120
+  resources:
+    limits:
+      cpu: 200m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi

--- a/prepare.sh
+++ b/prepare.sh
@@ -123,8 +123,7 @@ for chart in "${charts[@]}"
 do
     # sha256 hash of all files in the chart folder with paths sorted then stripped for consistency across providers
     hash=$(find $chart -type f | sort | xargs shasum -a 256 -b | awk '{print $1}' | shasum -a 256 | awk '{print $1}' | cut -c1-8)
-    # Do not sed-replace inside chart files/ (UDS JSON, shell scripts, service-inputs, etc.)
-    find $chart -type f ! -path '*/files/*' -exec sed -i '' -e "s/__PARAGON_VERSION__/$version-$hash/g" {} +
+    find $chart -type f -exec sed -i '' -e "s/__PARAGON_VERSION__/$version-$hash/g" {} +
     echo "$(basename "$chart"): $hash"
 done
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -123,7 +123,8 @@ for chart in "${charts[@]}"
 do
     # sha256 hash of all files in the chart folder with paths sorted then stripped for consistency across providers
     hash=$(find $chart -type f | sort | xargs shasum -a 256 -b | awk '{print $1}' | shasum -a 256 | awk '{print $1}' | cut -c1-8)
-    find $chart -type f -exec sed -i '' -e "s/__PARAGON_VERSION__/$version-$hash/g" {} +
+    # Do not sed-replace inside chart files/ (UDS JSON, shell scripts, service-inputs, etc.)
+    find $chart -type f ! -path '*/files/*' -exec sed -i '' -e "s/__PARAGON_VERSION__/$version-$hash/g" {} +
     echo "$(basename "$chart"): $hash"
 done
 


### PR DESCRIPTION
### Issues Closed

- [PARA-20444](https://useparagon.atlassian.net/browse/PARA-20444)

### Brief Summary

openobserve uds post-install/post-upgrade helm hook

### Detailed Summary

Added an idempotent Helm post-install/post-upgrade hook on the `openobserve` subchart so the Paragon logs stream user-defined schema (UDS) is applied automatically after OpenObserve is up on each `paragon-logging` install or upgrade. This reduces OpenObserve RAM instability from high-cardinality fields by enforcing a fixed UDS instead of relying on manual runs of the standalone `o2-apply-uds.ts` script.

The hook is a short-lived Job (Alpine + `curl` + `jq`) that reads schema and script from chart `files/`, uses the same OpenObserve credentials as the StatefulSet, waits for `/healthz`, compares the live schema to the desired JSON, and issues a single `PUT` only when needed.

Fixes applied during implementation: Helm `.Files.Get` paths must use `files/<name>` (empty ConfigMap in staging otherwise); the hook script must be POSIX `sh` (no bash `<<<`); no `chmod` on the read-only ConfigMap mount.

### Changes

- add `files/openobserve-uds-schema.json` and `files/apply-uds.sh` under `charts/paragon-logging/charts/openobserve`
- add `templates/uds-configmap.yaml` and `templates/uds-apply-job.yaml` (post-install/post-upgrade hook)
- add `uds.*` values on the openobserve subchart (`enabled`, image, timeouts, resources)
- document the hook in `helm-development.md`

### Unrelated Changes

None.

### Future Work

- batching the `PUT` payload only if the schema grows large enough to stress the OpenObserve API

### Steps to Test

1. Run `./prepare.sh -p <aws|azure|gcp>` from the enterprise repo on a branch that includes this change.
2. Confirm prepared chart contains non-empty UDS assets:
   - `aws/workspaces/paragon/charts/paragon-logging/charts/openobserve/files/openobserve-uds-schema.json`
   - `.../files/apply-uds.sh`
3. `helm upgrade paragon-logging` in a cluster with OpenObserve running (or fresh install).
4. During upgrade, optionally watch: `kubectl get jobs,pods -n paragon -l app.kubernetes.io/component=uds-apply`
5. Verify hook success via events: `Job completed` (not `BackoffLimitExceeded`).
6. Confirm ConfigMap is populated: `kubectl get cm openobserve-uds -n paragon -o yaml` (schema JSON and script present; no `<<<`).
7. Re-run upgrade: hook should complete again; OpenObserve schema should show ~494 `defined_schema_fields` or logs should say `UDS already applied; skipping PUT`.
8. Optional local check: `hoop connect customer_name-openobserve` then `http://127.0.0.1:8999/web`

### QA Notes

- The hook Job is deleted after success (`hook-delete-policy: before-hook-creation,hook-succeeded`); `kubectl get job openobserve-uds-apply` will often return NotFound even when the hook succeeded. Use namespace events or a second upgrade with `kubectl logs` during the run.
- Hook failure fails the Helm release when `atomic = true` on `paragon_logging`.
- Disable with `openobserve.uds.enabled: false` if needed for a one-off bypass.
- Staging may use `paragon-secrets-openobserve` for O2 credentials; the hook uses the same secret selection logic as the OpenObserve StatefulSet.

### Deployment Notes

- Requires a new enterprise chart build after merge: run `prepare.sh` so provider workspaces get updated charts and chart hash/version.
- Deploy via normal Terraform `helm_release.paragon_logging` / `helm upgrade` path; no new container image in `useparagon/*`, no changes to `enterprise/scripts/`.
- No new tfvars required; `openobserve.uds.enabled` defaults to `true`.

### Screenshots
Before:
<img width="1129" height="926" alt="staging-o2-no-uds" src="https://github.com/user-attachments/assets/98055acc-f55d-4965-85d5-8c75426401d4" />
After:
<img width="1136" height="916" alt="staging-o2-uds-applied" src="https://github.com/user-attachments/assets/317d751d-ecc1-44e4-80f0-f4d91b9b9fd7" />
