### PR TITLE
fix/PARA-21338/hoop-redis-auth

### DIFF
--- a/aws/workspaces/paragon/hoop/locals.tf
+++ b/aws/workspaces/paragon/hoop/locals.tf
@@ -60,7 +60,9 @@ locals {
             "envvar:DB_NUMBER" = tostring(try(instance_config.db_number, 0))
           },
           try(instance_config.ssl, false) == true ? { "envvar:REDIS_TLS" = "1" } : {},
-          try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {}
+          try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {},
+          try(instance_config.password, "") != "" ? { "envvar:PASS" = instance_config.password } : {},
+          try(instance_config.user, "") != "" ? { "envvar:USER" = instance_config.user } : {}
         )
         access_mode_runbooks = "enabled"
         access_mode_exec     = "enabled"

--- a/aws/workspaces/paragon/hoop/variables.tf
+++ b/aws/workspaces/paragon/hoop/variables.tf
@@ -127,6 +127,8 @@ variable "infra_vars" {
         db_number      = optional(number, 0)
         ssl            = optional(bool, false)
         ca_certificate = optional(string, null)
+        password       = optional(string)
+        user           = optional(string)
       })), {})
     }))
   })

--- a/aws/workspaces/paragon/hoop/variables.tf
+++ b/aws/workspaces/paragon/hoop/variables.tf
@@ -109,6 +109,7 @@ variable "hoop_slack_channel_ids" {
 
 variable "infra_vars" {
   description = "Infrastructure variables from infra-output.json."
+  sensitive   = true
   type = object({
     postgres = optional(object({
       value = optional(map(object({

--- a/azure/workspaces/paragon/hoop/locals.tf
+++ b/azure/workspaces/paragon/hoop/locals.tf
@@ -60,7 +60,9 @@ locals {
             "envvar:DB_NUMBER" = tostring(try(instance_config.db_number, 0))
           },
           try(instance_config.ssl, false) == true ? { "envvar:REDIS_TLS" = "1" } : {},
-          try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {}
+          try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {},
+          try(instance_config.password, "") != "" ? { "envvar:PASS" = instance_config.password } : {},
+          try(instance_config.user, "") != "" ? { "envvar:USER" = instance_config.user } : {}
         )
         access_mode_runbooks = "enabled"
         access_mode_exec     = "enabled"

--- a/azure/workspaces/paragon/hoop/variables.tf
+++ b/azure/workspaces/paragon/hoop/variables.tf
@@ -127,6 +127,8 @@ variable "infra_vars" {
         db_number      = optional(number, 0)
         ssl            = optional(bool, false)
         ca_certificate = optional(string, null)
+        password       = optional(string)
+        user           = optional(string)
       })), {})
     }))
   })

--- a/azure/workspaces/paragon/hoop/variables.tf
+++ b/azure/workspaces/paragon/hoop/variables.tf
@@ -109,6 +109,7 @@ variable "hoop_slack_channel_ids" {
 
 variable "infra_vars" {
   description = "Infrastructure variables from infra-output.json."
+  sensitive   = true
   type = object({
     postgres = optional(object({
       value = optional(map(object({

--- a/gcp/workspaces/paragon/hoop/locals.tf
+++ b/gcp/workspaces/paragon/hoop/locals.tf
@@ -60,7 +60,9 @@ locals {
             "envvar:DB_NUMBER" = tostring(try(instance_config.db_number, 0))
           },
           try(instance_config.ssl, false) == true ? { "envvar:REDIS_TLS" = "1" } : {},
-          try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {}
+          try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {},
+          try(instance_config.password, "") != "" ? { "envvar:PASS" = instance_config.password } : {},
+          try(instance_config.user, "") != "" ? { "envvar:USER" = instance_config.user } : {}
         )
         access_mode_runbooks = "enabled"
         access_mode_exec     = "enabled"

--- a/gcp/workspaces/paragon/hoop/variables.tf
+++ b/gcp/workspaces/paragon/hoop/variables.tf
@@ -127,6 +127,8 @@ variable "infra_vars" {
         db_number      = optional(number, 0)
         ssl            = optional(bool, false)
         ca_certificate = optional(string, null)
+        password       = optional(string)
+        user           = optional(string)
       })), {})
     }))
   })

--- a/gcp/workspaces/paragon/hoop/variables.tf
+++ b/gcp/workspaces/paragon/hoop/variables.tf
@@ -109,6 +109,7 @@ variable "hoop_slack_channel_ids" {
 
 variable "infra_vars" {
   description = "Infrastructure variables from infra-output.json."
+  sensitive   = true
   type = object({
     postgres = optional(object({
       value = optional(map(object({


### PR DESCRIPTION
### Issues Closed

- [PARA-21338](https://useparagon.atlassian.net/browse/PARA-21338)

### Brief Summary

hoop redis auth from infra-output

### Detailed Summary

Hoop Redis connections were provisioned with host, port, TLS, and CA only—no credentials—even when Azure/GCP infra outputs include a Redis password (required for on Azure Cache for Redis). This change extends the Hoop module's `infra_vars.redis` schema and wires optional `password` and `user` into connection secrets as `envvar:PASS` and `envvar:USER`, matching the existing Postgres pattern. When those fields are absent (typical AWS ElastiCache), behavior is unchanged.

### Changes

- Added optional `password` and `user` to `infra_vars.redis` in `hoop/variables.tf` (AWS, Azure, GCP)
- Conditionally set `envvar:PASS` and `envvar:USER` on Hoop Redis connections in `hoop/locals.tf` when values are present in `infra-output.json` (AWS, Azure, GCP)

### Unrelated Changes

- None

### Future Work

- Align `locals.tf` null checks with the `ca_certificate` pattern (`!= null && != ""`) to avoid edge cases when `password` is explicitly null
- Smoke-test on  after apply; if Hoop/redis-cli does not pick up `PASS`/`USER`, add `envvar:REDISCLI_AUTH` as a fallback
- Add Azure `username` to infra outputs only if a customer requires Redis ACL with a non-default user

### Steps to Test

1. `cd azure/workspaces/paragon && terraform init -backend=false && terraform validate` (repeat for `aws/` and `gcp/` if desired)
2. On an Azure deployment with Redis auth, ensure `infra-output.json` includes `redis.*.password` from infra apply
3. Run `terraform plan` / apply on the `paragon` workspace with `hoop_enabled = true`
4. In Hoop, open a Redis connection (e.g. `{prefix}-redis-cache`) and run `PING` or a read-only command—should succeed without `NOAUTH`
5. On AWS (no Redis password in infra output), confirm Hoop Redis connections are unchanged (no `envvar:PASS` in plan)

### QA Notes

- Credentials come from existing sensitive infra outputs; they should not appear in non-sensitive Terraform logs
- Functional validation requires Hoop access to the target environment after apply—local `terraform validate` alone is insufficient

### Deployment Notes

- No new tfvars or Helm changes; requires `paragon` workspace apply so Hoop connections are updated
- Azure: confirm `infra-output.json` already includes `password` under `redis` (from `azure/workspaces/infra/redis/outputs.tf`)

### Screenshots

- N/A (Terraform / Hoop connection config only)

[PARA-21338]: https://useparagon.atlassian.net/browse/PARA-21338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ