### PR TITLE
fix/PARA-21338/hoop-for-each-nonsensitive-keys

### DIFF
--- a/aws/workspaces/paragon/hoop/connections.tf
+++ b/aws/workspaces/paragon/hoop/connections.tf
@@ -2,22 +2,22 @@
 resource "hoop_connection" "all_connections" {
   for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.all_connections))) : []
 
-  name     = local.all_connections[each.value].name
-  type     = local.all_connections[each.value].type
+  name     = local.all_connections_config[each.value].name
+  type     = local.all_connections_config[each.value].type
   agent_id = var.hoop_agent_id
 
-  access_mode_runbooks = local.all_connections[each.value].access_mode_runbooks
-  access_mode_exec     = local.all_connections[each.value].access_mode_exec
-  access_mode_connect  = local.all_connections[each.value].access_mode_connect
-  access_schema        = local.all_connections[each.value].access_schema
+  access_mode_runbooks = local.all_connections_config[each.value].access_mode_runbooks
+  access_mode_exec     = local.all_connections_config[each.value].access_mode_exec
+  access_mode_connect  = local.all_connections_config[each.value].access_mode_connect
+  access_schema        = local.all_connections_config[each.value].access_schema
 
-  subtype         = local.all_connections[each.value].subtype
-  command         = local.all_connections[each.value].command
-  guardrail_rules = try(local.all_connections[each.value].guardrail_rules, null) != null && length(coalesce(try(local.all_connections[each.value].guardrail_rules, null), [])) > 0 ? local.all_connections[each.value].guardrail_rules : null
-  reviewers       = try(local.all_connections[each.value].reviewers, null) != null && length(coalesce(try(local.all_connections[each.value].reviewers, null), [])) > 0 ? local.all_connections[each.value].reviewers : null
+  subtype         = local.all_connections_config[each.value].subtype
+  command         = local.all_connections_config[each.value].command
+  guardrail_rules = local.all_connections_config[each.value].guardrail_rules
+  reviewers       = local.all_connections_config[each.value].reviewers
 
   secrets = local.all_connections[each.value].secrets
-  tags    = local.all_connections[each.value].tags
+  tags    = local.all_connections_config[each.value].tags
 
   depends_on = [
     data.kubernetes_secret.hoop_cluster_admin_token
@@ -28,22 +28,22 @@ resource "hoop_connection" "all_connections" {
 resource "hoop_connection" "postgres_connections" {
   for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.postgres_connections))) : []
 
-  name     = local.postgres_connections[each.value].name
-  type     = local.postgres_connections[each.value].type
+  name     = local.postgres_connections_config[each.value].name
+  type     = local.postgres_connections_config[each.value].type
   agent_id = var.hoop_agent_id
 
-  access_mode_runbooks = local.postgres_connections[each.value].access_mode_runbooks
-  access_mode_exec     = local.postgres_connections[each.value].access_mode_exec
-  access_mode_connect  = local.postgres_connections[each.value].access_mode_connect
-  access_schema        = local.postgres_connections[each.value].access_schema
+  access_mode_runbooks = local.postgres_connections_config[each.value].access_mode_runbooks
+  access_mode_exec     = local.postgres_connections_config[each.value].access_mode_exec
+  access_mode_connect  = local.postgres_connections_config[each.value].access_mode_connect
+  access_schema        = local.postgres_connections_config[each.value].access_schema
 
-  subtype         = local.postgres_connections[each.value].subtype
-  command         = local.postgres_connections[each.value].command
-  guardrail_rules = try(local.postgres_connections[each.value].guardrail_rules, null) != null && length(coalesce(try(local.postgres_connections[each.value].guardrail_rules, null), [])) > 0 ? local.postgres_connections[each.value].guardrail_rules : null
-  reviewers       = try(local.postgres_connections[each.value].reviewers, null) != null && length(coalesce(try(local.postgres_connections[each.value].reviewers, null), [])) > 0 ? local.postgres_connections[each.value].reviewers : null
+  subtype         = local.postgres_connections_config[each.value].subtype
+  command         = local.postgres_connections_config[each.value].command
+  guardrail_rules = local.postgres_connections_config[each.value].guardrail_rules
+  reviewers       = local.postgres_connections_config[each.value].reviewers
 
   secrets = local.postgres_connections[each.value].secrets
-  tags    = local.postgres_connections[each.value].tags
+  tags    = local.postgres_connections_config[each.value].tags
 
   lifecycle {
     ignore_changes = [command]
@@ -65,8 +65,8 @@ resource "hoop_plugin_connection" "custom_connections_access_control" {
 
 resource "hoop_plugin_connection" "default_connections_access_control" {
   for_each = var.hoop_enabled ? {
-    for conn_name, groups in local.access_control_groups :
-    conn_name => groups
+    for conn_name in nonsensitive(keys(local.access_control_groups)) :
+    conn_name => nonsensitive(local.access_control_groups[conn_name])
     if !startswith(conn_name, "custom-")
   } : {}
 
@@ -76,7 +76,10 @@ resource "hoop_plugin_connection" "default_connections_access_control" {
 }
 
 resource "hoop_plugin_connection" "postgres_connections_access_control" {
-  for_each = var.hoop_enabled ? local.postgres_access_control_groups : {}
+  for_each = var.hoop_enabled ? {
+    for conn_name in nonsensitive(keys(local.postgres_access_control_groups)) :
+    conn_name => nonsensitive(local.postgres_access_control_groups[conn_name])
+  } : {}
 
   plugin_name   = "access_control"
   connection_id = hoop_connection.postgres_connections[each.key].id

--- a/aws/workspaces/paragon/hoop/connections.tf
+++ b/aws/workspaces/paragon/hoop/connections.tf
@@ -1,6 +1,6 @@
 # Unified Hoop connections - all connection types in a single resource
 resource "hoop_connection" "all_connections" {
-  for_each = var.hoop_enabled ? toset(keys(local.all_connections)) : []
+  for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.all_connections))) : []
 
   name     = local.all_connections[each.value].name
   type     = local.all_connections[each.value].type
@@ -26,7 +26,7 @@ resource "hoop_connection" "all_connections" {
 
 # Provider normalizes Postgres command; ignore to avoid perpetual drift.
 resource "hoop_connection" "postgres_connections" {
-  for_each = var.hoop_enabled ? toset(keys(local.postgres_connections)) : []
+  for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.postgres_connections))) : []
 
   name     = local.postgres_connections[each.value].name
   type     = local.postgres_connections[each.value].type

--- a/aws/workspaces/paragon/hoop/locals.tf
+++ b/aws/workspaces/paragon/hoop/locals.tf
@@ -61,8 +61,13 @@ locals {
           },
           try(instance_config.ssl, false) == true ? { "envvar:REDIS_TLS" = "1" } : {},
           try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {},
-          try(instance_config.password, "") != "" ? { "envvar:PASS" = instance_config.password } : {},
-          try(instance_config.user, "") != "" ? { "envvar:USER" = instance_config.user } : {}
+          {
+            for k, v in {
+              "envvar:PASS" = try(instance_config.password, null)
+              "envvar:USER" = try(instance_config.user, null)
+            } : k => v
+            if v != null && v != ""
+          }
         )
         access_mode_runbooks = "enabled"
         access_mode_exec     = "enabled"
@@ -313,4 +318,37 @@ locals {
   }
 
   all_connections = local.connections_merge
+
+  # Non-secret fields only (infra_vars is sensitive; keeps plan output readable)
+  all_connections_config = {
+    for k, v in local.all_connections : k => {
+      name                 = nonsensitive(v.name)
+      type                 = nonsensitive(v.type)
+      subtype              = nonsensitive(v.subtype)
+      command              = nonsensitive(v.command)
+      access_mode_runbooks = nonsensitive(v.access_mode_runbooks)
+      access_mode_exec     = nonsensitive(v.access_mode_exec)
+      access_mode_connect  = nonsensitive(v.access_mode_connect)
+      access_schema        = nonsensitive(v.access_schema)
+      guardrail_rules      = try(v.guardrail_rules, null) != null && length(coalesce(try(v.guardrail_rules, null), [])) > 0 ? nonsensitive(v.guardrail_rules) : null
+      reviewers            = try(v.reviewers, null) != null && length(coalesce(try(v.reviewers, null), [])) > 0 ? nonsensitive(v.reviewers) : null
+      tags                 = nonsensitive(v.tags)
+    }
+  }
+
+  postgres_connections_config = {
+    for k, v in local.postgres_connections : k => {
+      name                 = nonsensitive(v.name)
+      type                 = nonsensitive(v.type)
+      subtype              = nonsensitive(v.subtype)
+      command              = nonsensitive(v.command)
+      access_mode_runbooks = nonsensitive(v.access_mode_runbooks)
+      access_mode_exec     = nonsensitive(v.access_mode_exec)
+      access_mode_connect  = nonsensitive(v.access_mode_connect)
+      access_schema        = nonsensitive(v.access_schema)
+      guardrail_rules      = try(v.guardrail_rules, null) != null && length(coalesce(try(v.guardrail_rules, null), [])) > 0 ? nonsensitive(v.guardrail_rules) : null
+      reviewers            = try(v.reviewers, null) != null && length(coalesce(try(v.reviewers, null), [])) > 0 ? nonsensitive(v.reviewers) : null
+      tags                 = nonsensitive(v.tags)
+    }
+  }
 }

--- a/aws/workspaces/paragon/hoop/slack.tf
+++ b/aws/workspaces/paragon/hoop/slack.tf
@@ -1,5 +1,5 @@
 resource "hoop_plugin_config" "slack" {
-  count = local.slack_enabled ? 1 : 0
+  count = nonsensitive(local.slack_enabled) ? 1 : 0
 
   plugin_name = "slack"
   config = {
@@ -9,7 +9,7 @@ resource "hoop_plugin_config" "slack" {
 }
 
 resource "hoop_plugin_connection" "slack" {
-  for_each = local.slack_enabled ? local.review_required_connections : {}
+  for_each = nonsensitive(local.slack_enabled) ? toset(nonsensitive(keys(local.review_required_connections))) : toset([])
 
   plugin_name   = "slack"
   connection_id = hoop_connection.all_connections[each.key].id

--- a/azure/workspaces/paragon/hoop/connections.tf
+++ b/azure/workspaces/paragon/hoop/connections.tf
@@ -2,22 +2,22 @@
 resource "hoop_connection" "all_connections" {
   for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.all_connections))) : []
 
-  name     = local.all_connections[each.value].name
-  type     = local.all_connections[each.value].type
+  name     = local.all_connections_config[each.value].name
+  type     = local.all_connections_config[each.value].type
   agent_id = var.hoop_agent_id
 
-  access_mode_runbooks = local.all_connections[each.value].access_mode_runbooks
-  access_mode_exec     = local.all_connections[each.value].access_mode_exec
-  access_mode_connect  = local.all_connections[each.value].access_mode_connect
-  access_schema        = local.all_connections[each.value].access_schema
+  access_mode_runbooks = local.all_connections_config[each.value].access_mode_runbooks
+  access_mode_exec     = local.all_connections_config[each.value].access_mode_exec
+  access_mode_connect  = local.all_connections_config[each.value].access_mode_connect
+  access_schema        = local.all_connections_config[each.value].access_schema
 
-  subtype         = local.all_connections[each.value].subtype
-  command         = local.all_connections[each.value].command
-  guardrail_rules = try(local.all_connections[each.value].guardrail_rules, null) != null && length(coalesce(try(local.all_connections[each.value].guardrail_rules, null), [])) > 0 ? local.all_connections[each.value].guardrail_rules : null
-  reviewers       = try(local.all_connections[each.value].reviewers, null) != null && length(coalesce(try(local.all_connections[each.value].reviewers, null), [])) > 0 ? local.all_connections[each.value].reviewers : null
+  subtype         = local.all_connections_config[each.value].subtype
+  command         = local.all_connections_config[each.value].command
+  guardrail_rules = local.all_connections_config[each.value].guardrail_rules
+  reviewers       = local.all_connections_config[each.value].reviewers
 
   secrets = local.all_connections[each.value].secrets
-  tags    = local.all_connections[each.value].tags
+  tags    = local.all_connections_config[each.value].tags
 
   depends_on = [
     data.kubernetes_secret.hoop_cluster_admin_token
@@ -28,22 +28,22 @@ resource "hoop_connection" "all_connections" {
 resource "hoop_connection" "postgres_connections" {
   for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.postgres_connections))) : []
 
-  name     = local.postgres_connections[each.value].name
-  type     = local.postgres_connections[each.value].type
+  name     = local.postgres_connections_config[each.value].name
+  type     = local.postgres_connections_config[each.value].type
   agent_id = var.hoop_agent_id
 
-  access_mode_runbooks = local.postgres_connections[each.value].access_mode_runbooks
-  access_mode_exec     = local.postgres_connections[each.value].access_mode_exec
-  access_mode_connect  = local.postgres_connections[each.value].access_mode_connect
-  access_schema        = local.postgres_connections[each.value].access_schema
+  access_mode_runbooks = local.postgres_connections_config[each.value].access_mode_runbooks
+  access_mode_exec     = local.postgres_connections_config[each.value].access_mode_exec
+  access_mode_connect  = local.postgres_connections_config[each.value].access_mode_connect
+  access_schema        = local.postgres_connections_config[each.value].access_schema
 
-  subtype         = local.postgres_connections[each.value].subtype
-  command         = local.postgres_connections[each.value].command
-  guardrail_rules = try(local.postgres_connections[each.value].guardrail_rules, null) != null && length(coalesce(try(local.postgres_connections[each.value].guardrail_rules, null), [])) > 0 ? local.postgres_connections[each.value].guardrail_rules : null
-  reviewers       = try(local.postgres_connections[each.value].reviewers, null) != null && length(coalesce(try(local.postgres_connections[each.value].reviewers, null), [])) > 0 ? local.postgres_connections[each.value].reviewers : null
+  subtype         = local.postgres_connections_config[each.value].subtype
+  command         = local.postgres_connections_config[each.value].command
+  guardrail_rules = local.postgres_connections_config[each.value].guardrail_rules
+  reviewers       = local.postgres_connections_config[each.value].reviewers
 
   secrets = local.postgres_connections[each.value].secrets
-  tags    = local.postgres_connections[each.value].tags
+  tags    = local.postgres_connections_config[each.value].tags
 
   lifecycle {
     ignore_changes = [command]
@@ -65,8 +65,8 @@ resource "hoop_plugin_connection" "custom_connections_access_control" {
 
 resource "hoop_plugin_connection" "default_connections_access_control" {
   for_each = var.hoop_enabled ? {
-    for conn_name, groups in local.access_control_groups :
-    conn_name => groups
+    for conn_name in nonsensitive(keys(local.access_control_groups)) :
+    conn_name => nonsensitive(local.access_control_groups[conn_name])
     if !startswith(conn_name, "custom-")
   } : {}
 
@@ -76,7 +76,10 @@ resource "hoop_plugin_connection" "default_connections_access_control" {
 }
 
 resource "hoop_plugin_connection" "postgres_connections_access_control" {
-  for_each = var.hoop_enabled ? local.postgres_access_control_groups : {}
+  for_each = var.hoop_enabled ? {
+    for conn_name in nonsensitive(keys(local.postgres_access_control_groups)) :
+    conn_name => nonsensitive(local.postgres_access_control_groups[conn_name])
+  } : {}
 
   plugin_name   = "access_control"
   connection_id = hoop_connection.postgres_connections[each.key].id

--- a/azure/workspaces/paragon/hoop/connections.tf
+++ b/azure/workspaces/paragon/hoop/connections.tf
@@ -1,6 +1,6 @@
 # Unified Hoop connections - all connection types in a single resource
 resource "hoop_connection" "all_connections" {
-  for_each = var.hoop_enabled ? toset(keys(local.all_connections)) : []
+  for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.all_connections))) : []
 
   name     = local.all_connections[each.value].name
   type     = local.all_connections[each.value].type
@@ -26,7 +26,7 @@ resource "hoop_connection" "all_connections" {
 
 # Provider normalizes Postgres command; ignore to avoid perpetual drift.
 resource "hoop_connection" "postgres_connections" {
-  for_each = var.hoop_enabled ? toset(keys(local.postgres_connections)) : []
+  for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.postgres_connections))) : []
 
   name     = local.postgres_connections[each.value].name
   type     = local.postgres_connections[each.value].type

--- a/azure/workspaces/paragon/hoop/locals.tf
+++ b/azure/workspaces/paragon/hoop/locals.tf
@@ -61,8 +61,13 @@ locals {
           },
           try(instance_config.ssl, false) == true ? { "envvar:REDIS_TLS" = "1" } : {},
           try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {},
-          try(instance_config.password, "") != "" ? { "envvar:PASS" = instance_config.password } : {},
-          try(instance_config.user, "") != "" ? { "envvar:USER" = instance_config.user } : {}
+          {
+            for k, v in {
+              "envvar:PASS" = try(instance_config.password, null)
+              "envvar:USER" = try(instance_config.user, null)
+            } : k => v
+            if v != null && v != ""
+          }
         )
         access_mode_runbooks = "enabled"
         access_mode_exec     = "enabled"
@@ -313,4 +318,37 @@ locals {
   }
 
   all_connections = local.connections_merge
+
+  # Non-secret fields only (infra_vars is sensitive; keeps plan output readable)
+  all_connections_config = {
+    for k, v in local.all_connections : k => {
+      name                 = nonsensitive(v.name)
+      type                 = nonsensitive(v.type)
+      subtype              = nonsensitive(v.subtype)
+      command              = nonsensitive(v.command)
+      access_mode_runbooks = nonsensitive(v.access_mode_runbooks)
+      access_mode_exec     = nonsensitive(v.access_mode_exec)
+      access_mode_connect  = nonsensitive(v.access_mode_connect)
+      access_schema        = nonsensitive(v.access_schema)
+      guardrail_rules      = try(v.guardrail_rules, null) != null && length(coalesce(try(v.guardrail_rules, null), [])) > 0 ? nonsensitive(v.guardrail_rules) : null
+      reviewers            = try(v.reviewers, null) != null && length(coalesce(try(v.reviewers, null), [])) > 0 ? nonsensitive(v.reviewers) : null
+      tags                 = nonsensitive(v.tags)
+    }
+  }
+
+  postgres_connections_config = {
+    for k, v in local.postgres_connections : k => {
+      name                 = nonsensitive(v.name)
+      type                 = nonsensitive(v.type)
+      subtype              = nonsensitive(v.subtype)
+      command              = nonsensitive(v.command)
+      access_mode_runbooks = nonsensitive(v.access_mode_runbooks)
+      access_mode_exec     = nonsensitive(v.access_mode_exec)
+      access_mode_connect  = nonsensitive(v.access_mode_connect)
+      access_schema        = nonsensitive(v.access_schema)
+      guardrail_rules      = try(v.guardrail_rules, null) != null && length(coalesce(try(v.guardrail_rules, null), [])) > 0 ? nonsensitive(v.guardrail_rules) : null
+      reviewers            = try(v.reviewers, null) != null && length(coalesce(try(v.reviewers, null), [])) > 0 ? nonsensitive(v.reviewers) : null
+      tags                 = nonsensitive(v.tags)
+    }
+  }
 }

--- a/azure/workspaces/paragon/hoop/slack.tf
+++ b/azure/workspaces/paragon/hoop/slack.tf
@@ -1,5 +1,5 @@
 resource "hoop_plugin_config" "slack" {
-  count = local.slack_enabled ? 1 : 0
+  count = nonsensitive(local.slack_enabled) ? 1 : 0
 
   plugin_name = "slack"
   config = {
@@ -9,7 +9,7 @@ resource "hoop_plugin_config" "slack" {
 }
 
 resource "hoop_plugin_connection" "slack" {
-  for_each = local.slack_enabled ? local.review_required_connections : {}
+  for_each = nonsensitive(local.slack_enabled) ? toset(nonsensitive(keys(local.review_required_connections))) : toset([])
 
   plugin_name   = "slack"
   connection_id = hoop_connection.all_connections[each.key].id

--- a/gcp/workspaces/paragon/hoop/connections.tf
+++ b/gcp/workspaces/paragon/hoop/connections.tf
@@ -2,22 +2,22 @@
 resource "hoop_connection" "all_connections" {
   for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.all_connections))) : []
 
-  name     = local.all_connections[each.value].name
-  type     = local.all_connections[each.value].type
+  name     = local.all_connections_config[each.value].name
+  type     = local.all_connections_config[each.value].type
   agent_id = var.hoop_agent_id
 
-  access_mode_runbooks = local.all_connections[each.value].access_mode_runbooks
-  access_mode_exec     = local.all_connections[each.value].access_mode_exec
-  access_mode_connect  = local.all_connections[each.value].access_mode_connect
-  access_schema        = local.all_connections[each.value].access_schema
+  access_mode_runbooks = local.all_connections_config[each.value].access_mode_runbooks
+  access_mode_exec     = local.all_connections_config[each.value].access_mode_exec
+  access_mode_connect  = local.all_connections_config[each.value].access_mode_connect
+  access_schema        = local.all_connections_config[each.value].access_schema
 
-  subtype         = local.all_connections[each.value].subtype
-  command         = local.all_connections[each.value].command
-  guardrail_rules = try(local.all_connections[each.value].guardrail_rules, null) != null && length(coalesce(try(local.all_connections[each.value].guardrail_rules, null), [])) > 0 ? local.all_connections[each.value].guardrail_rules : null
-  reviewers       = try(local.all_connections[each.value].reviewers, null) != null && length(coalesce(try(local.all_connections[each.value].reviewers, null), [])) > 0 ? local.all_connections[each.value].reviewers : null
+  subtype         = local.all_connections_config[each.value].subtype
+  command         = local.all_connections_config[each.value].command
+  guardrail_rules = local.all_connections_config[each.value].guardrail_rules
+  reviewers       = local.all_connections_config[each.value].reviewers
 
   secrets = local.all_connections[each.value].secrets
-  tags    = local.all_connections[each.value].tags
+  tags    = local.all_connections_config[each.value].tags
 
   depends_on = [
     data.kubernetes_secret.hoop_cluster_admin_token
@@ -28,22 +28,22 @@ resource "hoop_connection" "all_connections" {
 resource "hoop_connection" "postgres_connections" {
   for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.postgres_connections))) : []
 
-  name     = local.postgres_connections[each.value].name
-  type     = local.postgres_connections[each.value].type
+  name     = local.postgres_connections_config[each.value].name
+  type     = local.postgres_connections_config[each.value].type
   agent_id = var.hoop_agent_id
 
-  access_mode_runbooks = local.postgres_connections[each.value].access_mode_runbooks
-  access_mode_exec     = local.postgres_connections[each.value].access_mode_exec
-  access_mode_connect  = local.postgres_connections[each.value].access_mode_connect
-  access_schema        = local.postgres_connections[each.value].access_schema
+  access_mode_runbooks = local.postgres_connections_config[each.value].access_mode_runbooks
+  access_mode_exec     = local.postgres_connections_config[each.value].access_mode_exec
+  access_mode_connect  = local.postgres_connections_config[each.value].access_mode_connect
+  access_schema        = local.postgres_connections_config[each.value].access_schema
 
-  subtype         = local.postgres_connections[each.value].subtype
-  command         = local.postgres_connections[each.value].command
-  guardrail_rules = try(local.postgres_connections[each.value].guardrail_rules, null) != null && length(coalesce(try(local.postgres_connections[each.value].guardrail_rules, null), [])) > 0 ? local.postgres_connections[each.value].guardrail_rules : null
-  reviewers       = try(local.postgres_connections[each.value].reviewers, null) != null && length(coalesce(try(local.postgres_connections[each.value].reviewers, null), [])) > 0 ? local.postgres_connections[each.value].reviewers : null
+  subtype         = local.postgres_connections_config[each.value].subtype
+  command         = local.postgres_connections_config[each.value].command
+  guardrail_rules = local.postgres_connections_config[each.value].guardrail_rules
+  reviewers       = local.postgres_connections_config[each.value].reviewers
 
   secrets = local.postgres_connections[each.value].secrets
-  tags    = local.postgres_connections[each.value].tags
+  tags    = local.postgres_connections_config[each.value].tags
 
   lifecycle {
     ignore_changes = [command]
@@ -65,8 +65,8 @@ resource "hoop_plugin_connection" "custom_connections_access_control" {
 
 resource "hoop_plugin_connection" "default_connections_access_control" {
   for_each = var.hoop_enabled ? {
-    for conn_name, groups in local.access_control_groups :
-    conn_name => groups
+    for conn_name in nonsensitive(keys(local.access_control_groups)) :
+    conn_name => nonsensitive(local.access_control_groups[conn_name])
     if !startswith(conn_name, "custom-")
   } : {}
 
@@ -76,7 +76,10 @@ resource "hoop_plugin_connection" "default_connections_access_control" {
 }
 
 resource "hoop_plugin_connection" "postgres_connections_access_control" {
-  for_each = var.hoop_enabled ? local.postgres_access_control_groups : {}
+  for_each = var.hoop_enabled ? {
+    for conn_name in nonsensitive(keys(local.postgres_access_control_groups)) :
+    conn_name => nonsensitive(local.postgres_access_control_groups[conn_name])
+  } : {}
 
   plugin_name   = "access_control"
   connection_id = hoop_connection.postgres_connections[each.key].id

--- a/gcp/workspaces/paragon/hoop/connections.tf
+++ b/gcp/workspaces/paragon/hoop/connections.tf
@@ -1,6 +1,6 @@
 # Unified Hoop connections - all connection types in a single resource
 resource "hoop_connection" "all_connections" {
-  for_each = var.hoop_enabled ? toset(keys(local.all_connections)) : []
+  for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.all_connections))) : []
 
   name     = local.all_connections[each.value].name
   type     = local.all_connections[each.value].type
@@ -26,7 +26,7 @@ resource "hoop_connection" "all_connections" {
 
 # Provider normalizes Postgres command; ignore to avoid perpetual drift.
 resource "hoop_connection" "postgres_connections" {
-  for_each = var.hoop_enabled ? toset(keys(local.postgres_connections)) : []
+  for_each = var.hoop_enabled ? toset(nonsensitive(keys(local.postgres_connections))) : []
 
   name     = local.postgres_connections[each.value].name
   type     = local.postgres_connections[each.value].type

--- a/gcp/workspaces/paragon/hoop/locals.tf
+++ b/gcp/workspaces/paragon/hoop/locals.tf
@@ -61,8 +61,13 @@ locals {
           },
           try(instance_config.ssl, false) == true ? { "envvar:REDIS_TLS" = "1" } : {},
           try(instance_config.ca_certificate, null) != null && try(instance_config.ca_certificate, "") != "" ? { "envvar:REDIS_CA_CERT" = instance_config.ca_certificate } : {},
-          try(instance_config.password, "") != "" ? { "envvar:PASS" = instance_config.password } : {},
-          try(instance_config.user, "") != "" ? { "envvar:USER" = instance_config.user } : {}
+          {
+            for k, v in {
+              "envvar:PASS" = try(instance_config.password, null)
+              "envvar:USER" = try(instance_config.user, null)
+            } : k => v
+            if v != null && v != ""
+          }
         )
         access_mode_runbooks = "enabled"
         access_mode_exec     = "enabled"
@@ -313,4 +318,37 @@ locals {
   }
 
   all_connections = local.connections_merge
+
+  # Non-secret fields only (infra_vars is sensitive; keeps plan output readable)
+  all_connections_config = {
+    for k, v in local.all_connections : k => {
+      name                 = nonsensitive(v.name)
+      type                 = nonsensitive(v.type)
+      subtype              = nonsensitive(v.subtype)
+      command              = nonsensitive(v.command)
+      access_mode_runbooks = nonsensitive(v.access_mode_runbooks)
+      access_mode_exec     = nonsensitive(v.access_mode_exec)
+      access_mode_connect  = nonsensitive(v.access_mode_connect)
+      access_schema        = nonsensitive(v.access_schema)
+      guardrail_rules      = try(v.guardrail_rules, null) != null && length(coalesce(try(v.guardrail_rules, null), [])) > 0 ? nonsensitive(v.guardrail_rules) : null
+      reviewers            = try(v.reviewers, null) != null && length(coalesce(try(v.reviewers, null), [])) > 0 ? nonsensitive(v.reviewers) : null
+      tags                 = nonsensitive(v.tags)
+    }
+  }
+
+  postgres_connections_config = {
+    for k, v in local.postgres_connections : k => {
+      name                 = nonsensitive(v.name)
+      type                 = nonsensitive(v.type)
+      subtype              = nonsensitive(v.subtype)
+      command              = nonsensitive(v.command)
+      access_mode_runbooks = nonsensitive(v.access_mode_runbooks)
+      access_mode_exec     = nonsensitive(v.access_mode_exec)
+      access_mode_connect  = nonsensitive(v.access_mode_connect)
+      access_schema        = nonsensitive(v.access_schema)
+      guardrail_rules      = try(v.guardrail_rules, null) != null && length(coalesce(try(v.guardrail_rules, null), [])) > 0 ? nonsensitive(v.guardrail_rules) : null
+      reviewers            = try(v.reviewers, null) != null && length(coalesce(try(v.reviewers, null), [])) > 0 ? nonsensitive(v.reviewers) : null
+      tags                 = nonsensitive(v.tags)
+    }
+  }
 }

--- a/gcp/workspaces/paragon/hoop/slack.tf
+++ b/gcp/workspaces/paragon/hoop/slack.tf
@@ -1,5 +1,5 @@
 resource "hoop_plugin_config" "slack" {
-  count = local.slack_enabled ? 1 : 0
+  count = nonsensitive(local.slack_enabled) ? 1 : 0
 
   plugin_name = "slack"
   config = {
@@ -9,7 +9,7 @@ resource "hoop_plugin_config" "slack" {
 }
 
 resource "hoop_plugin_connection" "slack" {
-  for_each = local.slack_enabled ? local.review_required_connections : {}
+  for_each = nonsensitive(local.slack_enabled) ? toset(nonsensitive(keys(local.review_required_connections))) : toset([])
 
   plugin_name   = "slack"
   connection_id = hoop_connection.all_connections[each.key].id


### PR DESCRIPTION
### Issues Closed

- [PARA-21338](https://useparagon.atlassian.net/browse/PARA-21338)

### Brief Summary

fix hoop sensitive terraform plan and redis auth

### Detailed Summary

After marking `infra_vars` as sensitive, Hoop Terraform started failing on `for_each` because connection maps and derived locals inherited sensitivity. Plans also showed noisy “sensitive value unchanged” diffs on non-secret connection fields, and apply failed when Redis instances had `user: null` because `envvar:USER` was sent to the Hoop provider as null.

This change keeps secrets in sensitive maps but uses `nonsensitive()` only where safe (connection keys, public metadata, access-control group names). Redis `USER`/`PASS` env vars are included only when non-null and non-empty.

### Changes

- wrap `hoop_connection` `for_each` keys with `nonsensitive(keys(...))` for `all_connections` and `postgres_connections`
- add `all_connections_config` / `postgres_connections_config` locals for non-secret fields; keep `secrets` on the sensitive source maps
- fix `hoop_plugin_connection` access-control `for_each` using `nonsensitive(keys(...))` and values
- fix Slack plugin `count`/`for_each` when `slack_enabled` and `review_required_connections` are sensitive-derived
- omit null/empty Redis `envvar:USER` and `envvar:PASS` via filtered map comprehension (fixes provider null string error)

### Unrelated Changes

- none;

### Future Work

None

### Steps to Test

1. check out `fix/hoop-for-each-nonsensitive-keys` 
2. run Terraform plan/apply on the paragon workspace with `hoop_enabled = true` (azure first, matching the reported failure)
3. confirm plan completes without invalid `for_each` errors
4. confirm hoop connections plan without spurious sensitive warnings on unchanged name/type/tags/access modes
5. confirm Redis connections without auth do not include `envvar:USER` / `envvar:PASS`; instances with auth still include them
6. verify `terraform apply` succeeds for `hoop_connection.all_connections["redis-*"]` and related plugin resources

### QA Notes

- functional behavior is unchanged except fixing null Redis auth env vars (no auth → no USER/PASS keys)
- secrets remain sensitive in state/plan output; only non-secret attributes should be visible in diffs

### Deployment Notes

- no config/tfvars changes required; Terraform-only hoop module update
- apply paragon workspace after merge (same as normal Hoop rollout)

### Screenshots

<img width="2365" height="1722" alt="image" src="https://github.com/user-attachments/assets/fe0165ac-cfdb-4f4c-b2cb-aa30f68f3259" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Hoop connection and access-control Terraform is wired across all three clouds; behavior should match prior intent but apply touches privileged access resources and relies on careful `nonsensitive()` boundaries around secrets.
> 
> **Overview**
> Fixes Hoop Terraform failures and noisy plans after **sensitive `infra_vars`** started marking connection maps as sensitive, by splitting **non-secret metadata** from secret-bearing locals and applying **`nonsensitive()`** only where Terraform needs stable, public values (connection keys, tags, access modes, plugin `for_each`).
> 
> In **AWS, Azure, and GCP** paragon `hoop` modules, `hoop_connection` resources now iterate with `nonsensitive(keys(...))` and read public fields from new **`all_connections_config`** / **`postgres_connections_config`** locals while **`secrets` still come from the original sensitive maps**. Access-control and Slack plugin resources get the same treatment for **`for_each`/`count`** (including `review_required_connections` keys).
> 
> Redis connections **stop sending null/empty `envvar:USER` and `envvar:PASS`**, which fixes Hoop provider apply errors on unauthenticated Redis instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10bfba0cb611b4615500f7ea2e01dfdd584489d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->