### PR TITLE
fix: disable EKS audit control plane logging

### DIFF
--- a/aws/workspaces/infra/cluster/cluster.tf
+++ b/aws/workspaces/infra/cluster/cluster.tf
@@ -76,6 +76,9 @@ module "eks" {
     resources        = ["secrets"]
   }
 
+  # logging
+  cluster_enabled_log_types = ["api", "authenticator"]
+
   cluster_tags = {
     Name = var.workspace
   }

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.05.18"
+version="2026.06.04"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-21834

### Brief Summary

disable eks audit logging to cut cloudwatch cost

### Detailed Summary

EKS control plane logging was implicitly using the terraform-aws-modules/eks default (`audit`, `api`, `authenticator`). On affected clusters, audit logs accounted for ~99.5% of CloudWatch ingest in `/aws/eks/<cluster>/cluster` — including spikes driven by in-cluster Kubernetes API polling (e.g. repeated Deployment GETs). Pod logs are unaffected; they go to OpenObserve via Fluent Bit.

This change explicitly sets `cluster_enabled_log_types` to `["api", "authenticator"]` so Terraform no longer re-enables audit after manual console changes, and new applies match the intended lower-cost configuration.

### Changes

- Override EKS module logging defaults to disable audit control plane logs while keeping API server and authenticator logs
- Bump installer version in `prepare.sh` to `2026.06.04`

### Unrelated Changes

N/A

### Future Work

- Investigate and reduce in-cluster K8s API polling that generated audit log volume (PARA-21834 app-side follow-up)
- Consider exposing `cluster_enabled_log_types` as a root infra variable for per-customer tuning
- Consider defaulting to `[]` if API/authenticator logs prove unnecessary in practice

### Steps to Test

- `cd aws/workspaces/infra && terraform init -backend=false && terraform validate`
- Run `terraform plan` on an existing infra workspace and confirm `enabled_cluster_log_types` removes `audit` (`- "audit"`, not `+ "audit"`)
- After apply, verify in AWS Console → EKS → Manage logging: **Audit** unchecked; **API server** and **Authenticator** checked
- Monitor CloudWatch `IncomingBytes` on `/aws/eks/<cluster>/cluster` over 24–48h and confirm a substantial drop

### QA Notes

Existing clusters that had audit disabled manually in the console should now show Terraform in sync (no drift re-adding audit). EU and US EKS clusters should be checked independently if both exist.

### Deployment Notes

Requires `terraform apply` on the **infra** workspace for each affected AWS account/region. No Paragon app or Helm changes required for this fix alone.

### Screenshots

N/A