### PR TITLE
PARA-21241: improve chart and cluster capacity after rightsizing SEVs

### DIFF
--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -142,7 +142,7 @@ variable "eks_min_node_count" {
 variable "eks_max_node_count" {
   description = "The maximum number of nodes to run in the Kubernetes cluster."
   type        = number
-  default     = 30
+  default     = 50
 }
 
 variable "eks_admin_arns" {

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -211,7 +211,7 @@ variable "k8s_min_node_count" {
 variable "k8s_max_node_count" {
   description = "Maximum number of node Kubernetes can scale up to."
   type        = number
-  default     = 20
+  default     = 50
 }
 
 variable "k8s_spot_instance_percent" {

--- a/charts/paragon-monitoring/charts/prometheus/values.yaml
+++ b/charts/paragon-monitoring/charts/prometheus/values.yaml
@@ -62,10 +62,10 @@ ingress:
 
 resources:
   limits:
-    memory: 2Gi
+    memory: 2048Mi
   requests:
     cpu: 200m
-    memory: 1Gi
+    memory: 1024Mi
 
 autoscaling:
   enabled: false

--- a/charts/paragon-onprem/charts/account/values.yaml
+++ b/charts/paragon-onprem/charts/account/values.yaml
@@ -34,7 +34,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/api-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 800Mi
+    memory: 1024Mi
   requests:
-    cpu: 100m
-    memory: 800Mi
+    cpu: 200m
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/cerberus/values.yaml
+++ b/charts/paragon-onprem/charts/cerberus/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 300Mi
+    memory: 400Mi
   requests:
-    cpu: 100m
-    memory: 300Mi
+    cpu: 150m
+    memory: 400Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/connect/values.yaml
+++ b/charts/paragon-onprem/charts/connect/values.yaml
@@ -26,15 +26,15 @@ service:
 
 resources:
   limits:
-    memory: 400Mi
+    memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 400Mi
+    cpu: 150m
+    memory: 512Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/dashboard/values.yaml
+++ b/charts/paragon-onprem/charts/dashboard/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 400Mi
+    memory: 512Mi
   requests:
-    cpu: 100m
-    memory: 400Mi
+    cpu: 250m
+    memory: 512Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 2
+  maxReplicas: 10
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/flipt/values.yaml
+++ b/charts/paragon-onprem/charts/flipt/values.yaml
@@ -106,7 +106,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 1
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -24,7 +24,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
   behavior:

--- a/charts/paragon-onprem/charts/passport/values.yaml
+++ b/charts/paragon-onprem/charts/passport/values.yaml
@@ -24,7 +24,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 700Mi
+    memory: 900Mi
   requests:
-    cpu: 100m
-    memory: 700Mi
+    cpu: 200m
+    memory: 900Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 700Mi
+    memory: 900Mi
   requests:
-    cpu: 100m
-    memory: 700Mi
+    cpu: 200m
+    memory: 900Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
@@ -24,7 +24,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -24,7 +24,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 600Mi
+    memory: 800Mi
   requests:
     cpu: 100m
-    memory: 600Mi
+    memory: 800Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 800Mi
+    memory: 1024Mi
   requests:
-    cpu: 100m
-    memory: 800Mi
+    cpu: 200m
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 500Mi
+    memory: 1024Mi
   requests:
     cpu: 100m
-    memory: 500Mi
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 800Mi
+    memory: 1024Mi
   requests:
-    cpu: 100m
-    memory: 800Mi
+    cpu: 200m
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 700Mi
+    memory: 1024Mi
   requests:
-    cpu: 100m
-    memory: 700Mi
+    cpu: 200m
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 1000Mi
+    memory: 1200Mi
   requests:
-    cpu: 200m
-    memory: 1000Mi
+    cpu: 300m
+    memory: 1200Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -24,7 +24,7 @@ resources:
 autoscaling:
   enabled: false
   # minReplicas: 4
-  # maxReplicas: 10
+  # maxReplicas: 20
   # targetCPUUtilizationPercentage: 75
   # targetMemoryUtilizationPercentage: 75
 

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -16,15 +16,15 @@ service:
 
 resources:
   limits:
-    memory: 600Mi
+    memory: 800Mi
   requests:
     cpu: 200m
-    memory: 600Mi
+    memory: 800Mi
 
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 10
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/gcp/workspaces/infra/variables.tf
+++ b/gcp/workspaces/infra/variables.tf
@@ -253,7 +253,7 @@ variable "k8s_min_node_count" {
 variable "k8s_max_node_count" {
   description = "Maximum number of node Kubernetes can scale up to."
   type        = number
-  default     = 20
+  default     = 50
 }
 
 variable "k8s_spot_instance_percent" {

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.06.04"
+version="2026.06.10"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

PARA-21241

### Brief Summary

raise chart and cluster capacity after sevs

### Detailed Summary

PR #146 reduced default chart resources for cost savings, but subsequent HPA-maxed and pod-restart SEVs showed several services were undersized and clusters could run out of schedulable capacity when HPAs scaled simultaneously (e.g. SEV-944 cluster pressure on Pipedrive EU). This PR raises per-pod memory/CPU defaults on affected `paragon-onprem` charts, increases HPA `maxReplicas` headroom, and bumps default cluster max node counts so node pools can absorb higher replica counts. Chart values stay at or below pre-PR #146 memory except where incident mitigations required more (e.g. worker-eventlogs OOM at 500Mi).

Analysis: [Chart Resizing (Notion)](https://app.notion.com/p/useparagon/Chart-Resizing-37461d1eb9a880b6887af0aa6ff77d87)

### Changes

- Increase memory request/limit on SEV-affected services: worker-triggerkit, api-triggerkit, worker-actionkit, worker-actions, worker-triggers, worker-eventlogs, worker-deployments, worker-crons, dashboard, connect, cerberus, worker-proxy, and zeus
- Raise CPU requests where CPU pressure contributed to HPA alerts (dashboard, worker kits, etc.); no CPU limits added
- Bump HPA `maxReplicas` from 10 to 20 across autoscaling-enabled on-prem charts (dashboard 2 → 10)
- Raise default cluster max node counts in infra Terraform: AWS `eks_max_node_count` 30 → 50; Azure/GCP `k8s_max_node_count` 20 → 50
- Normalize prometheus chart memory units from Gi to Mi (equivalent values)

### Unrelated Changes

N/A

### Future Work

- Consider customer-specific overrides only where single-tenant usage exceeds defaults

### Steps to Test

- [ ] Run `./prepare.sh -p aws -t <tag>` and `helm lint` on prepared charts under `aws/workspaces/paragon/charts/`
- [ ] `terraform validate` in `aws/workspaces/infra`, `azure/workspaces/infra`, and `gcp/workspaces/infra` (confirm `eks_max_node_count` / `k8s_max_node_count` defaults)
- [ ] Deploy to a non-prod enterprise environment and verify pod resources match updated defaults (`kubectl describe deploy -n paragon`)
- [ ] Confirm HPA objects show `maxReplicas: 20` (or 10 for dashboard) after upgrade
- [ ] Spot-check worker-eventlogs and worker-triggerkit under load — no OOMKilled restarts, HPA scales before hitting max

### QA Notes

Baseline pod memory cost increases modestly (~4–5Gi cluster-wide at minReplicas=2 for changed services) but remains well below pre-PR #146 defaults. Higher max node counts increase theoretical cluster ceiling cost but do not add nodes until the cluster autoscaler scales out. Most pod-restart SEVs were Postgres/maintenance related and will not be fixed by this change alone.

### Deployment Notes

Requires standard chart version bump and enterprise installer deploy to customer clusters. Infra workspaces must be applied for max node count changes to take effect on existing clusters (customers with explicit `*_max_node_count` overrides in tfvars are unaffected). Existing customer resource overrides in tfvars take precedence over chart defaults.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default cluster max node count and pod/HPA sizing for new or default-config deploys, increasing potential cost and scale-out behavior without touching app logic or auth.
> 
> **Overview**
> Raises default **Kubernetes capacity** after post-rightsizing SEVs: Terraform `eks_max_node_count` / `k8s_max_node_count` defaults go to **50** on AWS, Azure, and GCP so node pools can absorb higher replica counts.
> 
> **`paragon-onprem` chart defaults** are tuned for services that hit HPA max or OOM/restarts: memory request/limit increases (request still equals limit), selective **CPU request** bumps where CPU pressure drove alerts, and **HPA `maxReplicas`** raised from 10 to **20** on most autoscaling charts (**dashboard** 2 → **10**). **`worker-workflows`** only updates the commented `maxReplicas` example (autoscaling stays off).
> 
> **Prometheus** monitoring chart memory is expressed in **Mi** instead of **Gi** with equivalent sizes. **`prepare.sh`** chart semver is bumped to `2026.06.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d1852965593ad17a427b82e846a2e8c57dd609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->