### PR TITLE
fix/PARA-20911/managed-sync-trial-disabled

### DIFF
--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -85,6 +85,7 @@ locals {
   managed_sync_secrets = {
     HOST_ENV  = "AWS_K8"
     LOG_LEVEL = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
+    TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -108,6 +108,7 @@ locals {
   managed_sync_secrets = {
     HOST_ENV  = "AZURE_K8"
     LOG_LEVEL = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
+    TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public

--- a/gcp/workspaces/paragon/helm-config/secrets.tf
+++ b/gcp/workspaces/paragon/helm-config/secrets.tf
@@ -94,6 +94,7 @@ locals {
   managed_sync_secrets = {
     HOST_ENV  = "GCP_K8"
     LOG_LEVEL = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
+    TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public


### PR DESCRIPTION
### Issues Closed

- [PARA-20911](https://useparagon.atlassian.net/browse/PARA-20911)

### Brief Summary

set trial_disabled in managed sync secrets

### Detailed Summary

Enterprise on-prem managed sync installs were blocked by trial checks because `paragon-managed-sync-secrets` never included `TRIAL_DISABLED`. Added `TRIAL_DISABLED=true` to `managed_sync_secrets` in AWS, Azure, and GCP helm-config so it flows into the k8s secret on deploy. Defaults to `"true"` with override via  `values.yaml`.

### Changes

- add `TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")` to `managed_sync_secrets` in `aws/workspaces/paragon/helm-config/secrets.tf`
- add same to `azure/workspaces/paragon/helm-config/secrets.tf`
- add same to `gcp/workspaces/paragon/helm-config/secrets.tf`

### Unrelated Changes

None.

### Future Work

None required. Customers can override via `base_helm_values.global.env["TRIAL_DISABLED"]` if needed.

### Steps to Test

1. Deploy paragon workspace with `managed_sync_enabled = true`
2. Confirm secret has key:
` kubectl get secret paragon-managed-sync-secrets -n paragon -o jsonpath='{.data.TRIAL_DISABLED}' | base64 -d`
Expect output: `true`
3. Run terraform validate in each */workspaces/paragon/helm-config module

## QA Notes

- Fix applies to new deploys / terraform applies that recreate paragon-managed-sync-secrets. 
- Existing clusters need terraform apply (or secret patch) to pick up the new key. Related to SEV-823 (managed sync blocked by trial status).

Deployment Notes

No manual config changes required. Standard paragon workspace terraform apply will set the secret. Applies to AWS, Azure, and GCP.

[PARA-20911]: https://useparagon.atlassian.net/browse/PARA-20911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
