### PR TITLE
upgrade msk kafka version

### DIFF
--- a/aws/workspaces/infra/kafka/msk.tf
+++ b/aws/workspaces/infra/kafka/msk.tf
@@ -94,7 +94,7 @@ resource "aws_msk_cluster" "kafka" {
 }
 
 resource "aws_msk_configuration" "kafka" {
-  name = "${var.workspace}-config"
+  name = "${var.workspace}-config-${replace(var.msk_kafka_version, ".", "-")}"
 
   kafka_versions = [var.msk_kafka_version]
 
@@ -106,6 +106,10 @@ num.partitions = 3
 default.replication.factor = ${ceil(var.msk_kafka_num_broker_nodes / 2)}
 min.insync.replicas = ${ceil(var.msk_kafka_num_broker_nodes / 2)}
 PROPERTIES
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_appautoscaling_target" "kafka" {

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -268,9 +268,7 @@ variable "managed_sync_enabled" {
 variable "msk_kafka_version" {
   description = "The Kafka version for the MSK cluster."
   type        = string
-  // NOTE: to use a small instance type like `kafka.t3.small`, we need to use an older version that uses zookeeper
-  // we're default to an older version to keep costs low, but we can override this if we use a supported larger instance type
-  default = "3.6.0"
+  default = "3.9.x"
 }
 
 variable "msk_kafka_num_broker_nodes" {


### PR DESCRIPTION
### Issues Closed

[PARA-22114](https://useparagon.atlassian.net/browse/PARA-22114)

### Brief Summary

bump MSK Kafka default version to 3.9.x

### Detailed Summary

The default Kafka version for MSK was pinned to 3.6.0 because older Kafka versions (Zookeeper-based) were the only ones that supported small instance types like kafka.t3.small. That kept costs down but left us on an old version. We're no longer tied to that constraint, so this just bumps the default to 3.9.x and removes the comment explaining the workaround.

### Changes

Updated msk_kafka_version default from 3.6.0 to 3.9.x in managed-sync/variables.tf
Removed the comment explaining why an older version was needed for kafka.t3.small support

### Steps to Test
1. Confirm the kafka-exporter update ticket is complete and the new image is deployed to staging.
2. Dry run (staging) — Trigger the [deploy managed sync](https://github.com/useparagon-internal/infrastructure/actions/workflows/deploy-managed-sync.yaml) GitHub workflow with PLATFORM_ENV: staging, DRY_RUN: true. Review the Terraform plan output and confirm the only change is kafka_version: "3.6.0" → "3.9.x" on aws_msk_cluster.kafka and aws_msk_configuration.kafka.
3. Apply to staging — Re-trigger the workflow with PLATFORM_ENV: staging, DRY_RUN: false. Monitor the MSK console until all 3 brokers return to ACTIVE (expect ~15–30 min per broker).
4. Run curl http://<api-sync-staging>/healthz and verify a 200 response.
5. Check CloudWatch — confirm no consumer lag spikes or connection errors in the 30 minutes following the upgrade.
6. Check Prometheus/Grafana — confirm kafka-exporter metrics (kafka_brokers, kafka_topic_partitions, consumer group lag) are populated and up-to-date.
7. Apply to production — Trigger the workflow with PLATFORM_ENV: production, DRY_RUN: true first to review the plan, then re-trigger with DRY_RUN: false.


[PARA-22114]: https://useparagon.atlassian.net/browse/PARA-22114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changing the MSK Kafka version triggers cluster/configuration updates and rolling broker restarts on core messaging infrastructure; downtime or consumer lag is possible if upgrades are applied without the staged dry-run process described in the PR.
> 
> **Overview**
> Bumps the default **`msk_kafka_version`** from `3.6.0` to **`3.9.x`** and drops the old comment about staying on Zookeeper-era versions for `kafka.t3.small`.
> 
> To support in-place version upgrades in Terraform, **`aws_msk_configuration.kafka`** now uses a versioned name (`${workspace}-config-${version with dots as dashes}`) and a **`create_before_destroy`** lifecycle so a new configuration can be created before the cluster switches off the old one.
> 
> Applying this will plan updates to both **`aws_msk_cluster.kafka`** and the MSK configuration revision—expect a rolling broker upgrade in AWS when not using the previous default explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abaf7dd9d1ed43d5687832cfa2a7c23a2ae7a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->