### PR TITLE
poc(karpenter): added POC test code to enable karpenter in AWS

### DIFF
--- a/aws/workspaces/infra/cluster/autoscaling.tf
+++ b/aws/workspaces/infra/cluster/autoscaling.tf
@@ -21,6 +21,8 @@ resource "aws_autoscaling_group_tag" "cluster_autoscaler_label_tags" {
 }
 
 module "cluster_autoscaler" {
+  count = var.enable_karpenter ? 0 : 1
+
   source  = "lablabs/eks-cluster-autoscaler/aws"
   version = "2.2.0"
 

--- a/aws/workspaces/infra/cluster/variables.tf
+++ b/aws/workspaces/infra/cluster/variables.tf
@@ -70,6 +70,12 @@ variable "create_autoscaling_linked_role" {
   type        = bool
 }
 
+variable "enable_karpenter" {
+  description = "When true, disables the lablabs cluster-autoscaler submodule (Karpenter replaces CA once installed from the paragon workspace)."
+  type        = bool
+  default     = false
+}
+
 data "aws_caller_identity" "current" {}
 
 locals {

--- a/aws/workspaces/infra/karpenter-discovery.tf
+++ b/aws/workspaces/infra/karpenter-discovery.tf
@@ -1,0 +1,17 @@
+# Subnets and the EKS cluster primary security group must carry karpenter.sh/discovery so
+# EC2NodeClass objects (created from the paragon workspace) can select them.
+resource "aws_ec2_tag" "karpenter_discovery_subnet" {
+  for_each = var.enable_karpenter ? toset(module.network.private_subnet[*].id) : []
+
+  resource_id = each.value
+  key         = "karpenter.sh/discovery"
+  value       = module.cluster.eks_cluster.name
+}
+
+resource "aws_ec2_tag" "karpenter_discovery_cluster_sg" {
+  count = var.enable_karpenter ? 1 : 0
+
+  resource_id = module.cluster.eks_cluster.sg_id
+  key         = "karpenter.sh/discovery"
+  value       = module.cluster.eks_cluster.name
+}

--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -121,6 +121,27 @@ module "cluster" {
   eks_spot_node_instance_type     = local.eks_spot_node_instance_type
   k8s_version                     = var.k8s_version
 
+  enable_karpenter = var.enable_karpenter
+
   vpc_id             = module.network.vpc.id
   private_subnet_ids = module.network.private_subnet[*].id
+}
+
+module "karpenter" {
+  count   = var.enable_karpenter ? 1 : 0
+  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
+  version = "20.26.0"
+
+  cluster_name = module.cluster.eks_cluster.name
+
+  enable_irsa                     = true
+  enable_pod_identity             = false
+  irsa_oidc_provider_arn          = module.cluster.eks_cluster.oidc_provider_arn
+  enable_v1_permissions           = true
+  enable_spot_termination         = var.karpenter_enable_spot_interruption_queue
+  create_pod_identity_association = false
+
+  tags = local.default_tags
+
+  depends_on = [module.cluster]
 }

--- a/aws/workspaces/infra/outputs.tf
+++ b/aws/workspaces/infra/outputs.tf
@@ -66,3 +66,14 @@ output "cluster_name" {
   description = "The name of the EKS cluster."
   value       = module.cluster.eks_cluster.name
 }
+
+output "karpenter" {
+  description = "IAM and queue outputs for wiring the paragon workspace when enable_karpenter is true. Copy into paragon tfvars (see docs/aws-karpenter-poc.md)."
+  value = var.enable_karpenter ? {
+    controller_role_arn     = module.karpenter[0].iam_role_arn
+    interruption_queue_name = module.karpenter[0].queue_name
+    node_iam_role_name      = module.karpenter[0].node_iam_role_name
+    node_iam_role_arn       = module.karpenter[0].node_iam_role_arn
+    interruption_queue_url  = module.karpenter[0].queue_url
+  } : null
+}

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -291,6 +291,19 @@ variable "msk_instance_type" {
   default     = "kafka.t3.small"
 }
 
+# Karpenter (AWS EKS node autoscaling / provisioning). Default off; see docs/aws-karpenter-poc.md.
+variable "enable_karpenter" {
+  description = "When true, provisions the terraform-aws-modules/eks karpenter submodule (controller IRSA, node role, interruption queue), tags subnets/SGs for discovery, and disables the in-cluster Cluster Autoscaler IAM/Helm wiring in favor of Karpenter installed from the paragon workspace."
+  type        = bool
+  default     = false
+}
+
+variable "karpenter_enable_spot_interruption_queue" {
+  description = "When enable_karpenter is true, create the SQS queue and EventBridge rules for native spot interruption handling (recommended; required by the upstream karpenter submodule access_entry depends_on chain)."
+  type        = bool
+  default     = true
+}
+
 locals {
   # hash of account ID to help ensure uniqueness of resources like S3 bucket names
   hash        = substr(sha256(data.aws_caller_identity.current.account_id), 0, 8)

--- a/aws/workspaces/paragon/helm/karpenter.tf
+++ b/aws/workspaces/paragon/helm/karpenter.tf
@@ -1,0 +1,135 @@
+locals {
+  karpenter_helm_values = yamlencode({
+    serviceAccount = {
+      annotations = {
+        "eks.amazonaws.com/role-arn" = var.karpenter_controller_role_arn
+      }
+    }
+    settings = merge(
+      { clusterName = var.cluster_name },
+      var.karpenter_interruption_queue_name != null && var.karpenter_interruption_queue_name != "" ? {
+        interruptionQueue = var.karpenter_interruption_queue_name
+      } : {}
+    )
+    replicas = 2
+  })
+}
+
+resource "kubernetes_namespace" "karpenter" {
+  count = var.enable_karpenter ? 1 : 0
+
+  metadata {
+    name = "karpenter"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+resource "helm_release" "karpenter" {
+  count = var.enable_karpenter ? 1 : 0
+
+  name             = "karpenter"
+  description      = "Karpenter node provisioning controller"
+  chart            = "karpenter"
+  version          = var.karpenter_chart_version
+  repository       = "oci://public.ecr.aws/karpenter"
+  namespace        = kubernetes_namespace.karpenter[0].metadata[0].name
+  create_namespace = false
+  atomic           = true
+  cleanup_on_fail  = true
+  force_update     = true
+  timeout          = 600
+
+  values = [local.karpenter_helm_values]
+
+  depends_on = [
+    helm_release.ingress,
+    kubernetes_namespace.karpenter
+  ]
+}
+
+resource "kubernetes_manifest" "karpenter_ec2_node_class" {
+  count = var.enable_karpenter ? 1 : 0
+
+  manifest = {
+    apiVersion = "karpenter.k8s.aws/v1"
+    kind       = "EC2NodeClass"
+    metadata = {
+      name = "default"
+    }
+    spec = {
+      role = var.karpenter_node_iam_role_name
+      amiSelectorTerms = [
+        {
+          alias = "al2023@latest"
+        }
+      ]
+      subnetSelectorTerms = [
+        {
+          tags = {
+            "karpenter.sh/discovery" = var.cluster_name
+          }
+        }
+      ]
+      securityGroupSelectorTerms = [
+        {
+          tags = {
+            "karpenter.sh/discovery" = var.cluster_name
+          }
+        }
+      ]
+    }
+  }
+
+  depends_on = [helm_release.karpenter]
+}
+
+resource "kubernetes_manifest" "karpenter_node_pool_default" {
+  count = var.enable_karpenter ? 1 : 0
+
+  manifest = {
+    apiVersion = "karpenter.sh/v1"
+    kind       = "NodePool"
+    metadata = {
+      name = "default"
+    }
+    spec = {
+      limits = {
+        cpu = "1000"
+      }
+      disruption = {
+        consolidationPolicy = "WhenEmptyOrUnderutilized"
+        consolidateAfter    = "5m"
+        budgets = [
+          {
+            nodes = "10%"
+          }
+        ]
+      }
+      template = {
+        spec = {
+          requirements = [
+            {
+              key      = "kubernetes.io/arch"
+              operator = "In"
+              values   = ["amd64"]
+            },
+            {
+              key      = "karpenter.sh/capacity-type"
+              operator = "In"
+              values   = ["on-demand"]
+            }
+          ]
+          nodeClassRef = {
+            group = "karpenter.k8s.aws"
+            kind  = "EC2NodeClass"
+            name  = "default"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.karpenter_ec2_node_class]
+}

--- a/aws/workspaces/paragon/helm/variables.tf
+++ b/aws/workspaces/paragon/helm/variables.tf
@@ -137,6 +137,36 @@ variable "managed_sync_version" {
   type        = string
 }
 
+variable "enable_karpenter" {
+  description = "When true, installs Karpenter controller and baseline NodePool/EC2NodeClass."
+  type        = bool
+  default     = false
+}
+
+variable "karpenter_controller_role_arn" {
+  description = "IRSA role ARN for the Karpenter controller."
+  type        = string
+  default     = ""
+}
+
+variable "karpenter_node_iam_role_name" {
+  description = "IAM role name for nodes launched by Karpenter (EC2NodeClass spec.role)."
+  type        = string
+  default     = ""
+}
+
+variable "karpenter_interruption_queue_name" {
+  description = "SQS queue name for Karpenter interruption handling (optional)."
+  type        = string
+  default     = null
+}
+
+variable "karpenter_chart_version" {
+  description = "Karpenter Helm chart version."
+  type        = string
+  default     = "1.8.1"
+}
+
 locals {
   chart_names     = var.monitors_enabled ? ["paragon-logging", "paragon-monitoring", "paragon-onprem"] : ["paragon-logging", "paragon-onprem"]
   chart_directory = "../charts"

--- a/aws/workspaces/paragon/karpenter-checks.tf
+++ b/aws/workspaces/paragon/karpenter-checks.tf
@@ -1,0 +1,9 @@
+check "karpenter_paragon_inputs" {
+  assert {
+    condition = !var.enable_karpenter || (
+      startswith(var.karpenter_controller_role_arn, "arn:aws:iam::") &&
+      length(var.karpenter_node_iam_role_name) > 0
+    )
+    error_message = "When enable_karpenter is true, set karpenter_controller_role_arn (IAM role ARN) and karpenter_node_iam_role_name from the infra workspace output `terraform output -json karpenter` (see docs/aws-karpenter-poc.md)."
+  }
+}

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -40,6 +40,12 @@ module "helm" {
   public_microservices   = local.public_microservices
   public_monitors        = local.public_monitors
   workspace              = local.workspace
+
+  enable_karpenter                  = var.enable_karpenter
+  karpenter_controller_role_arn     = var.karpenter_controller_role_arn
+  karpenter_node_iam_role_name      = var.karpenter_node_iam_role_name
+  karpenter_interruption_queue_name = var.karpenter_interruption_queue_name
+  karpenter_chart_version           = var.karpenter_chart_version
 }
 
 module "managed_sync_config" {

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -328,6 +328,36 @@ variable "managed_sync_version" {
   default     = "latest"
 }
 
+variable "enable_karpenter" {
+  description = "When true, installs the Karpenter controller Helm chart and baseline EC2NodeClass/NodePool in the karpenter namespace. Requires IAM values from the infra workspace (terraform output karpenter) — see docs/aws-karpenter-poc.md."
+  type        = bool
+  default     = false
+}
+
+variable "karpenter_controller_role_arn" {
+  description = "IRSA role ARN for the Karpenter controller service account (from infra output karpenter.controller_role_arn)."
+  type        = string
+  default     = ""
+}
+
+variable "karpenter_node_iam_role_name" {
+  description = "IAM role name (not ARN) for EC2 instances launched by Karpenter (from infra output karpenter.node_iam_role_name)."
+  type        = string
+  default     = ""
+}
+
+variable "karpenter_interruption_queue_name" {
+  description = "SQS queue name for spot interruption handling (from infra output karpenter.interruption_queue_name). Leave null/empty if the infra queue was not created."
+  type        = string
+  default     = null
+}
+
+variable "karpenter_chart_version" {
+  description = "Karpenter Helm chart version (OCI public.ecr.aws/karpenter/karpenter)."
+  type        = string
+  default     = "1.8.1"
+}
+
 locals {
   # hash of account ID to help ensure uniqueness of resources like S3 bucket names
   hash        = substr(sha256(data.aws_caller_identity.current.account_id), 0, 8)

--- a/aws/workspaces/paragon/versions.tf
+++ b/aws/workspaces/paragon/versions.tf
@@ -1,0 +1,22 @@
+# Root required_providers so `provider "hoop"` resolves to hoophq/hoop (not hashicorp/hoop).
+# Child modules (alb, helm, hoop, uptime) declare additional providers.
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0, ~> 5.70"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.12.0"
+    }
+    hoop = {
+      source  = "hoophq/hoop"
+      version = ">= 0.0.19"
+    }
+  }
+}

--- a/charts/paragon-onprem/values.yaml
+++ b/charts/paragon-onprem/values.yaml
@@ -52,6 +52,9 @@ subchart:
   worker-workflows:
     enabled: true
 
+# Karpenter: optional node selectors / tolerations for workloads when mixing Karpenter nodes with
+# managed node groups belong in environment-specific Helm value overlays (not in this base chart).
+
 restart:
   enabled: true
   schedule: 0 14 * * * # everyday at 9am EST


### PR DESCRIPTION
### Issues Closed

- PARA-14479

### Brief Summary

optional karpenter path for aws eks behind feature flag

### Detailed Summary

This POC adds an optional, default-off Karpenter integration path for AWS EKS installations, gated by `enable_karpenter`. The spike goal (PARA-14479) is to validate that we can provision Karpenter alongside the existing enterprise Terraform/Helm layout without forcing every customer onto a new autoscaling model.

When enabled, the **infra** workspace provisions AWS-side prerequisites (controller IRSA, node IAM role, optional Spot interruption queue, discovery tags) via the upstream `terraform-aws-modules/eks/aws//modules/karpenter` submodule and disables the existing `lablabs/eks-cluster-autoscaler` wiring so two autoscalers do not compete. The **paragon** workspace installs the Karpenter controller from the official OCI Helm chart and applies baseline `EC2NodeClass` / `NodePool` CRs. Managed node groups are left in place for now; this is a test harness, not a full CA/MNG migration.

### Changes

**Infra workspace (`aws/workspaces/infra`)**
- Add `enable_karpenter` (default `false`) and `karpenter_enable_spot_interruption_queue` (default `true`) variables.
- Add conditional `module "karpenter"` using `terraform-aws-modules/eks/aws//modules/karpenter` v20.26.0 (IRSA, v1 permissions, optional SQS interruption queue).
- Add `karpenter-discovery.tf` to tag private subnets and the EKS cluster primary security group with `karpenter.sh/discovery = <cluster_name>`.
- Pass `enable_karpenter` into the cluster submodule; skip `lablabs/eks-cluster-autoscaler` when Karpenter is on.
- Export `output "karpenter"` (controller role ARN, node role name/ARN, interruption queue name/URL) for paragon tfvars wiring.

**Paragon workspace (`aws/workspaces/paragon`)**
- Add Karpenter tfvars (`enable_karpenter`, controller role ARN, node role name, interruption queue name, chart version) and pass them into the helm submodule.
- Add `karpenter-checks.tf` Terraform `check` block to fail fast when Karpenter is enabled without required IAM inputs.
- Add `versions.tf` root `required_providers` (fixes `terraform init` resolving `hashicorp/hoop` instead of `hoophq/hoop`).

**Helm submodule (`aws/workspaces/paragon/helm`)**
- Add `karpenter.tf`: `karpenter` namespace, OCI Helm release (`public.ecr.aws/karpenter/karpenter` v1.8.1 default), IRSA service-account annotation, optional `settings.interruptionQueue`.
- Add baseline `EC2NodeClass` `default` (`al2023@latest`, discovery tag selectors) and `NodePool` `default` (on-demand, amd64, POC disruption budgets).

**Charts**
- Add comment in `charts/paragon-onprem/values.yaml` noting that node selectors/tolerations for mixed Karpenter/MNG setups belong in env-specific overlays.

### Unrelated Changes

- `aws/workspaces/paragon/versions.tf` is required for reliable `terraform init` on the paragon workspace (hoop provider source resolution). It is not Karpenter-specific but was needed to validate the paragon workspace after adding Karpenter resources.

### Future Work

- Document apply/rollback runbook in-repo (`docs/aws-karpenter-poc.md` planned as follow-up).
- Tune `NodePool` disruption controls (`expireAfter`, `consolidationPolicy`, budgets) for production—not POC defaults.
- Add Spot `NodePool`(s) once interruption queue behavior is validated in a real cluster.
- Migration runbook: cordon/drain MNG, shift workload selectors, scale MNG to zero before relying on Karpenter-only capacity.
- Azure/GKE paths remain out of scope for this POC (see PARA-14479 spike doc).

### Steps to Test

1. **Infra** — in a non-prod tfvars file, set `enable_karpenter = true`, then `terraform plan` / `terraform apply`.
2. Capture outputs: `terraform output karpenter` from `aws/workspaces/infra`.
3. **Paragon** — set matching tfvars:
   - `enable_karpenter = true`
   - `karpenter_controller_role_arn` = `controller_role_arn` from infra output
   - `karpenter_node_iam_role_name` = `node_iam_role_name` from infra output
   - `karpenter_interruption_queue_name` = `interruption_queue_name` (if created)
4. `terraform plan` / `terraform apply` the paragon workspace.
5. Verify in-cluster:
   - `kubectl get pods -n karpenter`
   - `kubectl get ec2nodeclass,nodepool`
   - Schedule a test pod that triggers provisioning (or confirm controller is healthy and CRDs exist).
6. If `kubernetes_manifest` fails on first apply (CRDs not ready), re-run `terraform apply`.
7. **Rollback test** — set `enable_karpenter = false` in paragon, apply, then infra, apply; confirm CA submodule is restored and Karpenter resources are removed.

Local validation (no cluster required):
```bash
cd aws/workspaces/infra && terraform init -backend=false && terraform validate
cd aws/workspaces/paragon && terraform init -backend=false && terraform validate
```

### QA Notes

- **Default-off**: existing deployments are unchanged unless `enable_karpenter = true` is explicitly set in both workspaces.
- **Two-step apply**: infra must be applied before paragon; paragon requires IAM values from infra outputs.
- **Dual capacity**: managed node groups remain; Karpenter adds a second provisioning path. Do not expect MNG to scale down automatically.
- **POC NodePool** is on-demand only with conservative consolidation defaults—not production-tuned.
- Re-apply paragon once if CRD/manifest timing causes a first-apply failure.

### Deployment Notes

**Infra tfvars (when enabling):**
```hcl
enable_karpenter = true
karpenter_enable_spot_interruption_queue = true  # recommended; default
```

**Paragon tfvars (after infra apply):**
```hcl
enable_karpenter                  = true
karpenter_controller_role_arn     = "<from terraform output karpenter>"
karpenter_node_iam_role_name      = "<from terraform output karpenter>"
karpenter_interruption_queue_name = "<from terraform output karpenter>"
karpenter_chart_version           = "1.8.1"  # default
```

Apply order: **infra → read `terraform output karpenter` → paragon**.

Disabling Cluster Autoscaler IAM/Helm in infra when Karpenter is enabled is intentional—do not re-enable CA without disabling Karpenter first.

### Screenshots

N/A — infrastructure/Terraform POC; verification is via `terraform plan/apply` and `kubectl` checks above.