### PR TITLE
fix/PARA-22424/s3-acl-error-on-news-deployments

### DIFF
--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -6,20 +6,23 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.70 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.12.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | ./bastion | n/a |
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ./cloudtrail | n/a |
 | <a name="module_cluster"></a> [cluster](#module\_cluster) | ./cluster | n/a |
@@ -32,13 +35,13 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_app_bucket_expiration"></a> [app\_bucket\_expiration](#input\_app\_bucket\_expiration) | The number of days to retain S3 app data before deleting | `number` | `90` | no |
 | <a name="input_auditlogs_lock_enabled"></a> [auditlogs\_lock\_enabled](#input\_auditlogs\_lock\_enabled) | Whether to enable S3 Object Lock for the audit logs bucket. | `bool` | `false` | no |
 | <a name="input_auditlogs_retention_days"></a> [auditlogs\_retention\_days](#input\_auditlogs\_retention\_days) | The number of days to retain audit logs before deletion. | `number` | `365` | no |
@@ -47,6 +50,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_aws_secret_access_key"></a> [aws\_secret\_access\_key](#input\_aws\_secret\_access\_key) | AWS Secret Access Key for AWS account to provision resources on. | `string` | n/a | yes |
 | <a name="input_aws_session_token"></a> [aws\_session\_token](#input\_aws\_session\_token) | AWS session token. | `string` | `null` | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Number of AZs to cover in a given region. | `number` | `2` | no |
+| <a name="input_cdn_bucket_acl_reset"></a> [cdn\_bucket\_acl\_reset](#input\_cdn\_bucket\_acl\_reset) | Reset the CDN S3 bucket ACL to private before BucketOwnerEnforced. Defaults to false; set true once when migrating a legacy CDN bucket with existing ACL grants, then remove. | `bool` | `false` | no |
 | <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Account `Cloudflare Tunnel`, `Access: Organizations, Identity Providers, and Groups`, `Access: Apps and Policies` and Zone `DNS` | `string` | `"dummy-cloudflare-tokens-must-be-40-chars"` | no |
 | <a name="input_cloudflare_tunnel_account_id"></a> [cloudflare\_tunnel\_account\_id](#input\_cloudflare\_tunnel\_account\_id) | Account ID for Cloudflare account | `string` | `""` | no |
 | <a name="input_cloudflare_tunnel_email_domain"></a> [cloudflare\_tunnel\_email\_domain](#input\_cloudflare\_tunnel\_email\_domain) | Email domain for Cloudflare access | `string` | `"useparagon.com"` | no |
@@ -57,7 +61,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_disable_cloudtrail"></a> [disable\_cloudtrail](#input\_disable\_cloudtrail) | Used to specify that Cloudtrail is disabled. | `bool` | `true` | no |
 | <a name="input_disable_deletion_protection"></a> [disable\_deletion\_protection](#input\_disable\_deletion\_protection) | Used to disable deletion protection on RDS and S3 resources. | `bool` | `false` | no |
 | <a name="input_eks_admin_arns"></a> [eks\_admin\_arns](#input\_eks\_admin\_arns) | Array of ARNs for IAM users or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard. | `list(string)` | `[]` | no |
-| <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `30` | no |
+| <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `50` | no |
 | <a name="input_eks_min_node_count"></a> [eks\_min\_node\_count](#input\_eks\_min\_node\_count) | The minimum number of nodes to run in the Kubernetes cluster. | `number` | `4` | no |
 | <a name="input_eks_ondemand_node_instance_type"></a> [eks\_ondemand\_node\_instance\_type](#input\_eks\_ondemand\_node\_instance\_type) | The compute instance type to use for Kubernetes nodes. | `string` | `"m6a.xlarge"` | no |
 | <a name="input_eks_spot_instance_percent"></a> [eks\_spot\_instance\_percent](#input\_eks\_spot\_instance\_percent) | The percentage of spot instances to use for Kubernetes nodes. | `number` | `75` | no |
@@ -89,7 +93,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_auditlogs_bucket"></a> [auditlogs\_bucket](#output\_auditlogs\_bucket) | The bucket used to store audit logs. |
 | <a name="output_bastion"></a> [bastion](#output\_bastion) | Bastion server connection info. |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the EKS cluster. |
@@ -100,6 +104,18 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="output_redis"></a> [redis](#output\_redis) | Connection information for Redis. |
 | <a name="output_workspace"></a> [workspace](#output\_workspace) | The resource group that all resources are associated with. |
 <!-- END_TF_DOCS -->
+
+## CDN bucket migration
+
+The CDN S3 bucket (`<workspace>-cdn`) uses `BucketOwnerEnforced` object ownership. AWS rejects `PutBucketOwnershipControls` while the bucket ACL still grants other principals (for example legacy `public-read` or CloudFront OAI grants).
+
+`cdn_bucket_acl_reset` defaults to `false`. Set it to `true` once when applying ownership controls to an existing CDN bucket with legacy ACLs, then remove it from tfvars after a successful apply.
+
+```hcl
+cdn_bucket_acl_reset = true
+```
+
+After `BucketOwnerEnforced` is active, ACL updates are ignored via `lifecycle.ignore_changes` to avoid S3 API errors on subsequent applies.
 
 ## Updates
 

--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -63,9 +63,10 @@ module "storage" {
   app_bucket_expiration    = var.app_bucket_expiration
   auditlogs_retention_days = var.auditlogs_retention_days
   auditlogs_lock_enabled   = var.auditlogs_lock_enabled
-  managed_sync_enabled     = var.managed_sync_enabled
+  managed_sync_enabled   = var.managed_sync_enabled
 
-  migrated = var.migrated_workspace != null
+  migrated             = var.migrated_workspace != null
+  cdn_bucket_acl_reset = var.cdn_bucket_acl_reset
 }
 
 module "kafka" {

--- a/aws/workspaces/infra/storage/s3-cdn.tf
+++ b/aws/workspaces/infra/storage/s3-cdn.tf
@@ -34,6 +34,7 @@ resource "aws_s3_bucket_public_access_block" "cdn" {
 # Reset bucket ACL to owner-only before BucketOwnerEnforced; AWS rejects PutBucketOwnershipControls
 # while the bucket ACL still grants other principals (e.g. legacy public-read or OAI grants).
 resource "aws_s3_bucket_acl" "cdn" {
+  count  = var.cdn_bucket_acl_reset ? 1 : 0
   bucket = aws_s3_bucket.cdn.id
   acl    = "private"
 
@@ -52,7 +53,10 @@ resource "aws_s3_bucket_ownership_controls" "cdn" {
     object_ownership = "BucketOwnerEnforced"
   }
 
-  depends_on = [aws_s3_bucket_acl.cdn]
+  depends_on = [
+    aws_s3_bucket_public_access_block.cdn,
+    aws_s3_bucket_acl.cdn,
+  ]
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cdn" {

--- a/aws/workspaces/infra/storage/variables.tf
+++ b/aws/workspaces/infra/storage/variables.tf
@@ -31,3 +31,9 @@ variable "migrated" {
   type        = bool
   default     = false
 }
+
+variable "cdn_bucket_acl_reset" {
+  description = "Reset the CDN S3 bucket ACL to private before BucketOwnerEnforced."
+  type        = bool
+  default     = false
+}

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -259,6 +259,12 @@ variable "migrated_passwords" {
   default     = {}
 }
 
+variable "cdn_bucket_acl_reset" {
+  description = "Reset the CDN S3 bucket ACL to private before BucketOwnerEnforced. Defaults to false; set true once when migrating a legacy CDN bucket with existing ACL grants, then remove."
+  type        = bool
+  default     = false
+}
+
 variable "managed_sync_enabled" {
   description = "Whether to enable managed sync."
   type        = bool

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -353,7 +353,9 @@ variable "waf_rate_limit_global" {
   nullable    = true
 
   validation {
-    condition     = var.waf_rate_limit_global == null || var.waf_rate_limit_global == 0 || var.waf_rate_limit_global >= 100
+    condition = var.waf_rate_limit_global == null ? true : (
+      var.waf_rate_limit_global == 0 || var.waf_rate_limit_global >= 100
+    )
     error_message = "waf_rate_limit_global must be null, 0 (disabled), or >= 100 (AWS WAF minimum)."
   }
 }


### PR DESCRIPTION
### Issues Closed

- [PARA-22424](https://useparagon.atlassian.net/browse/PARA-22424)

### Brief Summary

optional cdn s3 acl reset for greenfield deploys

### Detailed Summary

Greenfield AWS infra deployments were failing when Terraform tried to manage the CDN S3 bucket ACL before applying `BucketOwnerEnforced` object ownership. New buckets do not need an ACL reset, but legacy buckets with existing ACL grants (e.g. public-read or CloudFront OAI) require resetting the ACL to `private` first — otherwise AWS rejects `PutBucketOwnershipControls`.

This PR makes the CDN bucket ACL reset conditional via a new `cdn_bucket_acl_reset` variable (default `false`). Greenfield deployments skip the ACL resource and apply ownership controls directly. Legacy migrations opt in by setting `cdn_bucket_acl_reset = true` once, then removing it from tfvars after a successful apply.

Also fixes a WAF validation bug where `waf_rate_limit_global = null` incorrectly failed the validation block.

### Changes

- Add `cdn_bucket_acl_reset` variable to infra and storage modules (default `false`)
- Make `aws_s3_bucket_acl.cdn` conditional with `count = var.cdn_bucket_acl_reset ? 1 : 0`
- Keep `aws_s3_bucket_ownership_controls.cdn` always applying `BucketOwnerEnforced`
- Wire variable through `modules.tf` into the storage module
- Document migration workflow in `aws/workspaces/infra/README.md` (terraform-docs + CDN bucket migration section)
- Fix `waf_rate_limit_global` validation to allow `null` without evaluating numeric comparisons

### Unrelated Changes

- WAF `waf_rate_limit_global` validation fix in `aws/workspaces/paragon/variables.tf` (null-safe condition)
- README terraform-docs regeneration (table formatting, additional provider requirements, `eks_max_node_count` default doc sync)

### Future Work

- Consider applying the same conditional ACL pattern to other S3 buckets if similar errors appear on legacy migrations
- Address S3 lifecycle `filter`/`prefix` warnings flagged by AWS provider (currently warnings only, will become errors in a future provider version)

### Steps to Test

**Greenfield (default behavior):**
1. `cd aws/workspaces/infra && terraform init -backend=false && terraform validate`
2. `terraform plan` with no `cdn_bucket_acl_reset` in tfvars
3. Confirm plan shows no `aws_s3_bucket_acl.cdn` resource and `aws_s3_bucket_ownership_controls.cdn` applies `BucketOwnerEnforced`
4. `terraform apply` on a new workspace — CDN bucket should provision without ACL errors

**Legacy migration:**
1. Set `cdn_bucket_acl_reset = true` in `vars.auto.tfvars`
2. `terraform plan` — confirm `aws_s3_bucket_acl.cdn[0]` is created before ownership controls
3. `terraform apply` on an existing CDN bucket with legacy ACLs
4. Remove `cdn_bucket_acl_reset` from tfvars and re-apply — ACL resource should be destroyed, ownership controls remain

**WAF validation:**
1. `cd aws/workspaces/paragon && terraform validate`
2. Confirm `waf_rate_limit_global = null` (default) passes validation

### QA Notes

- Existing deployments with `aws_s3_bucket_acl.cdn` already in state may show a state migration to `aws_s3_bucket_acl.cdn[0]` or destruction of the ACL resource when `cdn_bucket_acl_reset = false`. Review the plan carefully before applying.
- `cdn_bucket_acl_reset = true` is a one-time migration flag — remove it from tfvars after the first successful apply to keep configs clean.
- No Paragon application changes; this is infra Terraform only.

### Deployment Notes

- No config changes required for greenfield deployments (default `false`).
- For existing CDN buckets migrating to `BucketOwnerEnforced`, add to `aws/workspaces/infra/vars.auto.tfvars`:

  ```hcl
  cdn_bucket_acl_reset = true
  ```
  Remove after first successful apply.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CDN S3 ownership/ACL Terraform that can change state or block applies on existing buckets; legacy migrations need a deliberate one-time flag and plan review.
> 
> **Overview**
> Fixes greenfield AWS infra failures by making the CDN bucket **private ACL reset** opt-in via **`cdn_bucket_acl_reset`** (default **`false`**). **`aws_s3_bucket_acl.cdn`** is created only when that flag is **`true`**; **`BucketOwnerEnforced`** ownership controls still apply on every deploy. The flag is wired from the infra root into the storage module, and the README documents the one-time legacy migration workflow.
> 
> Also makes **`waf_rate_limit_global`** validation null-safe in the paragon workspace so the default **`null`** (disabled) passes **`terraform validate`**. README terraform-docs output was regenerated (table formatting and doc sync).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6dc22e73c42b1b3a4a061f81d0235c22b4d951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PARA-22424]: https://useparagon.atlassian.net/browse/PARA-22424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ