### PR TITLE
feat: AWS on-prem migration infrastructure support

### DIFF
--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -6,20 +6,20 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.70 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | ./bastion | n/a |
 | <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | ./cloudtrail | n/a |
 | <a name="module_cluster"></a> [cluster](#module\_cluster) | ./cluster | n/a |
@@ -32,13 +32,13 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_app_bucket_expiration"></a> [app\_bucket\_expiration](#input\_app\_bucket\_expiration) | The number of days to retain S3 app data before deleting | `number` | `90` | no |
 | <a name="input_auditlogs_lock_enabled"></a> [auditlogs\_lock\_enabled](#input\_auditlogs\_lock\_enabled) | Whether to enable S3 Object Lock for the audit logs bucket. | `bool` | `false` | no |
 | <a name="input_auditlogs_retention_days"></a> [auditlogs\_retention\_days](#input\_auditlogs\_retention\_days) | The number of days to retain audit logs before deletion. | `number` | `365` | no |
@@ -57,7 +57,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_disable_cloudtrail"></a> [disable\_cloudtrail](#input\_disable\_cloudtrail) | Used to specify that Cloudtrail is disabled. | `bool` | `true` | no |
 | <a name="input_disable_deletion_protection"></a> [disable\_deletion\_protection](#input\_disable\_deletion\_protection) | Used to disable deletion protection on RDS and S3 resources. | `bool` | `false` | no |
 | <a name="input_eks_admin_arns"></a> [eks\_admin\_arns](#input\_eks\_admin\_arns) | Array of ARNs for IAM users or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard. | `list(string)` | `[]` | no |
-| <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `30` | no |
+| <a name="input_eks_max_node_count"></a> [eks\_max\_node\_count](#input\_eks\_max\_node\_count) | The maximum number of nodes to run in the Kubernetes cluster. | `number` | `50` | no |
 | <a name="input_eks_min_node_count"></a> [eks\_min\_node\_count](#input\_eks\_min\_node\_count) | The minimum number of nodes to run in the Kubernetes cluster. | `number` | `4` | no |
 | <a name="input_eks_ondemand_node_instance_type"></a> [eks\_ondemand\_node\_instance\_type](#input\_eks\_ondemand\_node\_instance\_type) | The compute instance type to use for Kubernetes nodes. | `string` | `"m6a.xlarge"` | no |
 | <a name="input_eks_spot_instance_percent"></a> [eks\_spot\_instance\_percent](#input\_eks\_spot\_instance\_percent) | The percentage of spot instances to use for Kubernetes nodes. | `number` | `75` | no |
@@ -76,8 +76,12 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_msk_kafka_num_broker_nodes"></a> [msk\_kafka\_num\_broker\_nodes](#input\_msk\_kafka\_num\_broker\_nodes) | The number of broker nodes for the MSK cluster. | `number` | `2` | no |
 | <a name="input_msk_kafka_version"></a> [msk\_kafka\_version](#input\_msk\_kafka\_version) | The Kafka version for the MSK cluster. | `string` | `"3.6.0"` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of organization to include in resource names. | `string` | n/a | yes |
+| <a name="input_rds_allocated_storage"></a> [rds\_allocated\_storage](#input\_rds\_allocated\_storage) | Initial allocated storage (GiB) for each Postgres RDS instance. | `number` | `20` | no |
 | <a name="input_rds_final_snapshot_enabled"></a> [rds\_final\_snapshot\_enabled](#input\_rds\_final\_snapshot\_enabled) | Specifies that RDS instances should perform a final snapshot before being deleted. | `bool` | `true` | no |
+| <a name="input_rds_gp3_iops"></a> [rds\_gp3\_iops](#input\_rds\_gp3\_iops) | gp3 IOPS for Postgres; null uses size-based baseline (3000 below 400 GiB, 12000 at/above). Set with rds\_gp3\_storage\_throughput to override; only valid when rds\_allocated\_storage >= 400 GiB. | `number` | `null` | no |
+| <a name="input_rds_gp3_storage_throughput"></a> [rds\_gp3\_storage\_throughput](#input\_rds\_gp3\_storage\_throughput) | gp3 throughput (MiB/s); null uses size-based baseline (125 below 400 GiB, 500 at/above). Use a valid pair with rds\_gp3\_iops when overriding. | `number` | `null` | no |
 | <a name="input_rds_instance_class"></a> [rds\_instance\_class](#input\_rds\_instance\_class) | The RDS instance class type used for Postgres. | `string` | `"db.t4g.small"` | no |
+| <a name="input_rds_max_allocated_storage"></a> [rds\_max\_allocated\_storage](#input\_rds\_max\_allocated\_storage) | Maximum storage (GiB) for autoscaling on each Postgres RDS instance. | `number` | `1000` | no |
 | <a name="input_rds_multi_az"></a> [rds\_multi\_az](#input\_rds\_multi\_az) | Whether or not to enable multi-AZ in each RDS instance. | `bool` | `true` | no |
 | <a name="input_rds_multiple_instances"></a> [rds\_multiple\_instances](#input\_rds\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
 | <a name="input_rds_postgres_version"></a> [rds\_postgres\_version](#input\_rds\_postgres\_version) | Postgres version for the database. | `string` | `"14"` | no |
@@ -89,7 +93,7 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_auditlogs_bucket"></a> [auditlogs\_bucket](#output\_auditlogs\_bucket) | The bucket used to store audit logs. |
 | <a name="output_bastion"></a> [bastion](#output\_bastion) | Bastion server connection info. |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the EKS cluster. |

--- a/aws/workspaces/infra/cloudtrail/s3.tf
+++ b/aws/workspaces/infra/cloudtrail/s3.tf
@@ -170,6 +170,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
     id     = "abort-incomplete"
     status = "Enabled"
 
+    filter {}
+
     abort_incomplete_multipart_upload {
       days_after_initiation = 1
     }
@@ -178,6 +180,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
   rule {
     id     = "transition-to-glacier"
     status = "Enabled"
+
+    filter {}
 
     transition {
       days          = 7
@@ -188,6 +192,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
   rule {
     id     = "expire"
     status = "Enabled"
+
+    filter {}
 
     expiration {
       days = 365

--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -25,6 +25,10 @@ module "postgres" {
   workspace                   = local.workspace
   aws_region                  = var.aws_region
   rds_instance_class          = var.rds_instance_class
+  rds_gp3_iops                = var.rds_gp3_iops
+  rds_gp3_storage_throughput  = var.rds_gp3_storage_throughput
+  rds_allocated_storage       = var.rds_allocated_storage
+  rds_max_allocated_storage   = var.rds_max_allocated_storage
   rds_multi_az                = var.rds_multi_az
   rds_multiple_instances      = var.rds_multiple_instances
   rds_postgres_version        = var.rds_postgres_version

--- a/aws/workspaces/infra/network/logs.tf
+++ b/aws/workspaces/infra/network/logs.tf
@@ -38,6 +38,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
     id     = "abort-incomplete"
     status = "Enabled"
 
+    filter {}
+
     abort_incomplete_multipart_upload {
       days_after_initiation = 1
     }
@@ -46,6 +48,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
   rule {
     id     = "transition-to-glacier"
     status = "Enabled"
+
+    filter {}
 
     transition {
       days          = 7
@@ -56,6 +60,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "flow_logs" {
   rule {
     id     = "expire"
     status = "Enabled"
+
+    filter {}
 
     expiration {
       days = 365

--- a/aws/workspaces/infra/postgres/rds.tf
+++ b/aws/workspaces/infra/postgres/rds.tf
@@ -1,5 +1,14 @@
 locals {
   postgres_family = "postgres${split(".", var.rds_postgres_version)[0]}" // e.g. `postgres11`, `postgres12`, etc
+
+  # gp3 baseline depends on allocated size: PostgreSQL stripes at >= 400 GiB (12k IOPS / 500 MiB/s).
+  # Custom values must be set as a valid pair; if only one is set, fall back to the size-appropriate baseline.
+  rds_gp3_custom                       = var.rds_gp3_iops != null && var.rds_gp3_storage_throughput != null
+  rds_gp3_striped                      = var.rds_allocated_storage >= 400
+  rds_gp3_baseline_iops                = local.rds_gp3_striped ? 12000 : 3000
+  rds_gp3_baseline_tp                  = local.rds_gp3_striped ? 500 : 125
+  rds_gp3_iops_effective               = local.rds_gp3_custom ? var.rds_gp3_iops : local.rds_gp3_baseline_iops
+  rds_gp3_storage_throughput_effective = local.rds_gp3_custom ? var.rds_gp3_storage_throughput : local.rds_gp3_baseline_tp
 }
 
 resource "random_string" "postgres_root_username" {
@@ -111,8 +120,11 @@ resource "aws_db_instance" "postgres" {
   parameter_group_name = aws_db_parameter_group.postgres.name
   storage_type         = "gp3"
 
-  allocated_storage           = 20
-  max_allocated_storage       = 1000
+  iops               = local.rds_gp3_iops_effective
+  storage_throughput = local.rds_gp3_storage_throughput_effective
+
+  allocated_storage           = var.rds_allocated_storage
+  max_allocated_storage       = var.rds_max_allocated_storage
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = true
   availability_zone           = var.rds_multi_az ? null : var.availability_zones.names[0]

--- a/aws/workspaces/infra/postgres/variables.tf
+++ b/aws/workspaces/infra/postgres/variables.tf
@@ -33,6 +33,30 @@ variable "rds_instance_class" {
   description = "The RDS instance class type used for Postgres."
 }
 
+variable "rds_gp3_iops" {
+  description = "gp3 provisioned IOPS for all RDS instances. Null uses size-based baseline (3000 below 400 GiB, 12000 at/above)."
+  type        = number
+  default     = null
+  nullable    = true
+}
+
+variable "rds_gp3_storage_throughput" {
+  description = "gp3 throughput (MiB/s). Null uses size-based baseline (125 below 400 GiB, 500 at/above). Must form a valid pair with rds_gp3_iops when overriding."
+  type        = number
+  default     = null
+  nullable    = true
+}
+
+variable "rds_allocated_storage" {
+  description = "Initial allocated storage (GiB) for each Postgres RDS instance."
+  type        = number
+}
+
+variable "rds_max_allocated_storage" {
+  description = "Maximum storage (GiB) for autoscaling on each Postgres RDS instance."
+  type        = number
+}
+
 variable "disable_deletion_protection" {
   description = "Whether to disable deletion protection."
   type        = bool

--- a/aws/workspaces/infra/storage/s3-app.tf
+++ b/aws/workspaces/infra/storage/s3-app.tf
@@ -49,17 +49,33 @@ resource "aws_s3_bucket_lifecycle_configuration" "app" {
   bucket = aws_s3_bucket.app.id
 
   rule {
-    id = "expiration"
+    id     = "expiration"
+    status = "Enabled"
+
+    filter {}
 
     expiration {
       days = var.app_bucket_expiration
     }
 
-    noncurrent_version_expiration {
-      noncurrent_days = var.app_bucket_expiration
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+
+  rule {
+    id     = "delete-markers"
     status = "Enabled"
+
+    filter {}
+
+    expiration {
+      expired_object_delete_marker = true
+    }
   }
 }
 

--- a/aws/workspaces/infra/storage/s3-auditlogs.tf
+++ b/aws/workspaces/infra/storage/s3-auditlogs.tf
@@ -62,16 +62,32 @@ resource "aws_s3_bucket_lifecycle_configuration" "auditlogs" {
   bucket = aws_s3_bucket.auditlogs.id
 
   rule {
-    id = "expiration"
+    id     = "expiration"
+    status = "Enabled"
+
+    filter {}
 
     expiration {
       days = var.auditlogs_retention_days
     }
 
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+
     noncurrent_version_expiration {
       noncurrent_days = var.auditlogs_retention_days
     }
+  }
 
+  rule {
+    id     = "delete-markers"
     status = "Enabled"
+
+    filter {}
+
+    expiration {
+      expired_object_delete_marker = true
+    }
   }
 }

--- a/aws/workspaces/infra/storage/s3-cdn.tf
+++ b/aws/workspaces/infra/storage/s3-cdn.tf
@@ -72,3 +72,33 @@ resource "aws_s3_bucket_versioning" "cdn" {
     status = "Enabled"
   }
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "cdn" {
+  bucket = aws_s3_bucket.cdn.id
+
+  rule {
+    id     = "cleanup"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+
+  rule {
+    id     = "delete-markers"
+    status = "Enabled"
+
+    filter {}
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}

--- a/aws/workspaces/infra/storage/s3-logs.tf
+++ b/aws/workspaces/infra/storage/s3-logs.tf
@@ -72,9 +72,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
     id     = "abort-incomplete"
     status = "Enabled"
 
-    filter {
-      prefix = "files/"
-    }
+    filter {}
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 1
@@ -82,11 +80,37 @@ resource "aws_s3_bucket_lifecycle_configuration" "logs" {
   }
 
   rule {
-    id     = "expire"
+    id     = "expire-files"
     status = "Enabled"
 
     filter {
       prefix = "files/"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+
+  rule {
+    id     = "expire-s3-access-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "s3/"
+    }
+
+    expiration {
+      days = 365
+    }
+  }
+
+  rule {
+    id     = "expire-alb-access-logs"
+    status = "Enabled"
+
+    filter {
+      prefix = "access_logs/"
     }
 
     expiration {

--- a/aws/workspaces/infra/storage/s3-managed-sync.tf
+++ b/aws/workspaces/infra/storage/s3-managed-sync.tf
@@ -56,17 +56,33 @@ resource "aws_s3_bucket_lifecycle_configuration" "managed_sync" {
   bucket = aws_s3_bucket.managed_sync[0].id
 
   rule {
-    id = "expiration"
+    id     = "expiration"
+    status = "Enabled"
+
+    filter {}
 
     expiration {
       days = var.app_bucket_expiration
     }
 
-    noncurrent_version_expiration {
-      noncurrent_days = var.app_bucket_expiration
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
     }
 
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+
+  rule {
+    id     = "delete-markers"
     status = "Enabled"
+
+    filter {}
+
+    expiration {
+      expired_object_delete_marker = true
+    }
   }
 }
 

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -85,6 +85,46 @@ variable "rds_final_snapshot_enabled" {
   default     = true
 }
 
+variable "rds_gp3_iops" {
+  description = "gp3 IOPS for Postgres; null uses size-based baseline (3000 below 400 GiB, 12000 at/above). Set with rds_gp3_storage_throughput to override; only valid when rds_allocated_storage >= 400 GiB."
+  type        = number
+  default     = null
+  nullable    = true
+
+  validation {
+    condition     = var.rds_gp3_iops == null || var.rds_allocated_storage >= 400
+    error_message = "rds_gp3_iops can only be set when rds_allocated_storage is >= 400 GiB (PostgreSQL gp3 minimum at that size is 12000)."
+  }
+}
+
+variable "rds_gp3_storage_throughput" {
+  description = "gp3 throughput (MiB/s); null uses size-based baseline (125 below 400 GiB, 500 at/above). Use a valid pair with rds_gp3_iops when overriding."
+  type        = number
+  default     = null
+  nullable    = true
+
+  validation {
+    condition = var.rds_gp3_iops == null || var.rds_gp3_storage_throughput == null || (
+      var.rds_allocated_storage < 400 || (
+        coalesce(var.rds_gp3_iops, 12000) >= 12000 && coalesce(var.rds_gp3_storage_throughput, 500) >= 500
+      )
+    )
+    error_message = "For rds_allocated_storage >= 400 GiB, gp3 requires at least 12000 IOPS and 500 MiB/s throughput."
+  }
+}
+
+variable "rds_allocated_storage" {
+  description = "Initial allocated storage (GiB) for each Postgres RDS instance."
+  type        = number
+  default     = 20
+}
+
+variable "rds_max_allocated_storage" {
+  description = "Maximum storage (GiB) for autoscaling on each Postgres RDS instance."
+  type        = number
+  default     = 1000
+}
+
 # elasticache
 variable "elasticache_node_type" {
   description = "The ElastiCache node type used for Redis."

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -353,7 +353,7 @@ variable "waf_rate_limit_global" {
   nullable    = true
 
   validation {
-    condition     = var.waf_rate_limit_global == null || var.waf_rate_limit_global == 0 || var.waf_rate_limit_global >= 100
+    condition     = var.waf_rate_limit_global == null || var.waf_rate_limit_global == 0 || coalesce(var.waf_rate_limit_global, 100) >= 100
     error_message = "waf_rate_limit_global must be null, 0 (disabled), or >= 100 (AWS WAF minimum)."
   }
 }

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -24,7 +24,7 @@ resources:
 autoscaling:
   enabled: true
   minReplicas: 2
-  maxReplicas: 2
+  maxReplicas: 20
   targetCPUUtilizationPercentage: 75
   targetMemoryUtilizationPercentage: 75
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.06.10"
+version="2026.06.18"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-20180

### Brief Summary

aws infra tuning for large database migrations

### Detailed Summary

Adds Terraform controls and fixes needed when running large on-prem to AWS migrations: configurable RDS gp3 storage and IOPS with correct size-based baselines, broader S3 lifecycle coverage across infra buckets, and a WAF variable validation fix. Also bumps the release service HPA ceiling and chart version for the migration window.

### Changes

- Make RDS allocated storage, max autoscaling storage, and optional gp3 IOPS/throughput configurable from the infra workspace, with size-aware baselines (3000/125 below 400 GiB; 12000/500 at or above)
- Add variable validation so custom gp3 settings are only allowed when storage size and AWS minimums are satisfied
- Standardize S3 lifecycle rules across app, CDN, audit logs, managed sync, CloudTrail, flow logs, and logs buckets: required `filter` blocks, multipart upload cleanup, delete-marker cleanup, and retention for server access log prefixes
- Fix `waf_rate_limit_global` validation when the value is null (Terraform does not short-circuit `||`)
- Raise release service `maxReplicas` from 2 to 20
- Bump chart version in `prepare.sh` to 2026.06.18

### Unrelated Changes

- Terraform docs regeneration in `aws/workspaces/infra/README.md` (formatting and input table updates)

### Future Work

- Consider extracting shared S3 lifecycle rule patterns into a reusable Terraform module or local block to reduce duplication across bucket configs

### Steps to Test

1. Run `terraform validate` in `aws/workspaces/infra` and `aws/workspaces/paragon`
2. Run `terraform plan` on an infra workspace with default RDS settings (< 400 GiB) and confirm gp3 IOPS/throughput baseline is 3000/125
3. Run `terraform plan` with `rds_allocated_storage >= 400` and null gp3 overrides; confirm baseline is 12000/500
4. Run `terraform plan` with both `rds_gp3_iops` and `rds_gp3_storage_throughput` set above baseline and confirm no validation errors
5. Confirm `terraform plan` shows no `Invalid Attribute Combination` warnings on S3 lifecycle resources
6. Confirm `waf_rate_limit_global = null` plans cleanly in the paragon workspace

### QA Notes

RDS gp3 IOPS/throughput changes are online modifications (no instance replacement). S3 lifecycle updates are non-destructive and only affect future expirations.

### Deployment Notes

Workspaces that need larger initial RDS storage or elevated gp3 performance should set `rds_allocated_storage`, `rds_max_allocated_storage`, and optionally `rds_gp3_iops` / `rds_gp3_storage_throughput` in their workspace tfvars. At >= 400 GiB allocated storage, AWS requires a minimum of 12000 IOPS and 500 MiB/s throughput.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> RDS gp3 and storage changes affect production databases (online modify, but mis-tuned tfvars could cause plan/apply failures or cost); S3 lifecycle changes alter future retention and could expire objects sooner in some buckets (e.g. noncurrent versions at 30 days).
> 
> **Overview**
> Terraform for large on-prem → AWS migrations gains **workspace-level RDS controls**: initial and max storage, optional gp3 IOPS/throughput, size-aware defaults (3000/125 below 400 GiB; 12000/500 at or above), and validation so overrides match AWS minimums. Postgres instances now set explicit `iops` and `storage_throughput` instead of hard-coded 20 GiB / 1000 GiB caps only.
> 
> **S3 lifecycle** is updated across infra buckets: required empty `filter` blocks, multipart abort cleanup, delete-marker expiration where versioning applies, a new CDN lifecycle, and separate 365-day expiry for `s3/` and `access_logs/` prefixes on the logs bucket. App and managed-sync buckets use a fixed 30-day noncurrent version retention instead of matching app expiration.
> 
> The paragon workspace fixes **`waf_rate_limit_global`** validation when the value is `null`. The release chart raises HPA **`maxReplicas` from 2 to 20**, and **`prepare.sh`** bumps the chart version to `2026.06.18`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c9cf03b8489cb6588722f67a2e21db06b06c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->