### PR TITLE
Feat/postgres per instance config

### DIFF
--- a/azure/workspaces/infra/.terraform.lock.hcl
+++ b/azure/workspaces/infra/.terraform.lock.hcl
@@ -25,42 +25,42 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
 }
 
 provider "registry.terraform.io/hashicorp/azuread" {
-  version     = "3.8.0"
-  constraints = "~> 3.0"
+  version     = "3.0.2"
+  constraints = "~> 3.0.2"
   hashes = [
-    "h1:E2YWNE3Qry4bQMlmmZ33X4hLY5hOGrEZrlRg4anI2uw=",
-    "zh:0d26cfbf9417acd1c2295ccd5b0052abeac85ad1c3f6422ff09bf6a1ce16f00d",
-    "zh:144d4ea92fed541a6376bc76ad65ba4738dfd7bcab4c9d6cc20d35001338d06d",
+    "h1:yQqvUtgtrYKGpIygdM8P6N+pvMWJJWIsVdPow29VE20=",
+    "zh:16e724b80a9004c7978c30f69a73c98ff63eb8a03937dd44c2a8f0ea0438b7a3",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
-    "zh:2061d2cb64d8167d0af37e6610d0dc051977bd1ccc0e5cdd5ab02525ee239f96",
-    "zh:75562fdc3b313b7e538907199bfa588a1fcbc40113b0f3b7bfb496fbc358a32f",
-    "zh:78bef022ae9b1b0c636b7dd32bcda13fb273023f3a888cc005f3aa20e365b417",
-    "zh:ad8dbee59843154f8e93b24db9939a4257d13c7c86331eb93f1691294bc4e31f",
-    "zh:b3d83d7ac57073631704336a188cb746c473f728fc7ccb76abecb520e83fdf65",
-    "zh:c0bf9e0be73843de9089597be2720e4093b3ba320fbad99ab86da47681e77949",
-    "zh:c9a4c27d2b0800d3f4ece19d66c1fa574f7cd4ff66277af8f120d65e8f03f48e",
-    "zh:cd9ad8c848e17d9824045c33132cc0e87aa4d58cdb7bee6c0f6c3f9bc27892d5",
-    "zh:fbcafc21cdd19451274b905f9ee8a5b758ca63cc231e7544c815642e4a399c6d",
+    "zh:2bbbf13713ca4767267b889471c9fc14a56a8fdf5d1013da3ca78667e3caec64",
+    "zh:409ccb05431d643a079da082d89db2d95d6afed4769997ac537c8b7de3bff867",
+    "zh:53e4bca0f5d015380f7f524f36344afe6211ccaf614bfc69af73ca64a9f47d6c",
+    "zh:5780be2c1981d090604d7fa4cef675462f17f40e7f3dc501a031488e87a35b8f",
+    "zh:850e61a1b3e64c752c418526ccf48653514c861b36f5feb631619f906f7e99a0",
+    "zh:8c3565bfcea006a734149cc080452a9daf7d2a9d5362eb7e0a088b6c0d7f0f03",
+    "zh:908b9e6ad49d5d21173ecefc7924902047611be93bbf8e7d021aa9563358396f",
+    "zh:a2a79765c029bc58966eff61cb6e9b0ee14d2ac52b0a22fc7dfa35c9a49af669",
+    "zh:c7f56cbe8743e9ba81fce871bc97d9c07abe86770d9ee7ffefbf3882a61ba89a",
+    "zh:d4dba80e33421b30d81c62611fb7fc62ad39afecc6484436e635913cd8553e67",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "4.76.0"
+  version     = "4.77.0"
   constraints = "~> 4.0"
   hashes = [
-    "h1:4VD01UBYjsa3w7zeEBKnDtwClwpsPw6Dk+V9evhiKqU=",
-    "zh:07bb3a087abca8bd14cc28e3d3d4abb71e0ed711ecec65e7c0a2f1a97b948cf4",
-    "zh:0fa6640b5d6c0b0fe0b7fa25cebc0091b7dda2efd83ec0347c5a50dfce0957bc",
-    "zh:3c8618c8a5ab07fadfcb53ecf614f7b99e25bb6c407cf0af703a6b0647d4461d",
-    "zh:5f23fdda6ff290bc99b25b68f612bf67fbb503b04b1e38664e66d3204a51e99e",
-    "zh:68e6794cbe5e3b021657035c2465767b8296beed6c9acc8a9e032c4b90ba5746",
+    "h1:lrjSzKKlvAii6M+XibQJTovS8jzEQ2HUllERqqkjMLo=",
+    "zh:0eb2273aec14d6a0b308fbf796295305eaef8bf4b8f294d9b60eba884e7b5da2",
+    "zh:1c74d524d2c3154922761508197d12b86f3730e466582c31a1f460a3b0a08c48",
+    "zh:358cda15fa1dcb22aedf467b4cf319ff44c3fbcd0ff42041476ff63b9968cfc1",
+    "zh:40317479e968133bb424f118089ce75ba2672b71dbf286b81b1ea47aeb96f657",
+    "zh:730b7fc2285d04132a70ed50c0b6066e6ed107068f6e335727f4b59cde5fb247",
+    "zh:76ecea220fdfbc7016ccb6178d1c6358929e99c11b49e668a9bf4bc76bf8a541",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8a51dad112248d3fdfb19cdd65a182bd6a37e7fb7f1af801ab72a962813b5188",
-    "zh:945ff59c36de8c2128487f4ae0838655feef7c869112430ffa24ea69ff483b76",
-    "zh:b7306af0ecc8ad78771c17e0e911dd7a561251e4255ffe80516f0654a53f42bb",
-    "zh:c584de4858fc4ece330f1986f371acd235a5444e9b14ecea177779b1214539e0",
-    "zh:daa3675af21f8cdf330532af0b420287388f62ac57eaf0bd4c48e732d1052f35",
-    "zh:e76d972712b48a689f8deae41a3ad796c31d8b3798074d66c6f68e2b3b0aaa1f",
+    "zh:a36904512ef6bc7bdc8b87867b6fe307f370524b48a73055b382757f8ef165a5",
+    "zh:c2329af283adee199597152ba85cb7fcf1581a326ed428565412cc68a7a81a24",
+    "zh:d597d9bf0fda82617c4219d0025ebb64226e00bc6767fc70780b2773067d2f19",
+    "zh:ec319be347acd1f29fd60106a70617d60fe8543fb01f9a17b3ca249f3bf415fd",
+    "zh:f8b19aa7c0e7a4ab6a3b3ad86c712492f7361b04000b78f1bfea4ff882feceb6",
   ]
 }
 

--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -140,7 +140,7 @@ One map drives every PostgreSQL flexible server (`for_each` in `./postgres`). Gl
 | `postgres_redundant` | `false` | Shorthand: sets `hermes.redundant = true` (or `paragon` when single-instance) |
 | `postgres_instances` | `null` | Per-key overrides (`sku`, `redundant`) |
 
-`postgres_multiple_instances` and `managed_sync_enabled` still filter which keys deploy (same as before).
+`postgres_multiple_instances` and `managed_sync_enabled` still filter which keys deploy (same as before). With `postgres_multiple_instances = true`, only `cerberus`, `eventlogs`, `hermes`, `triggerkit`, `zeus` (and `managed_sync` when enabled) deploy — `paragon` deploys only when `postgres_multiple_instances = false`.
 
 Built-in default map (used when `postgres_instances` is null):
 

--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -129,49 +129,6 @@ Confirm SKU availability in the target region before apply.
 
 Requires `azurerm` provider `>= 4.60` in `main.tf` (see `main.tf.example`).
 
-## PostgreSQL per-instance tuning
-
-One map drives every PostgreSQL flexible server (`for_each` in `./postgres`). Globals set defaults; per-instance overrides merge on top (same pattern as `redis_managed_instances`).
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `postgres_sku_name` | `GP_Standard_D2ds_v5` | SKU for primary instances (`hermes`, `paragon`) |
-| `postgres_base_sku_name` | `B_Standard_B2s` | SKU for secondary instances |
-| `postgres_redundant` | `false` | Shorthand: sets `hermes.redundant = true` (or `paragon` when single-instance) |
-| `postgres_instances` | `null` | Per-key overrides (`sku`, `redundant`) |
-
-`postgres_multiple_instances` and `managed_sync_enabled` still filter which keys deploy (same as before). With `postgres_multiple_instances = true`, only `cerberus`, `eventlogs`, `hermes`, `triggerkit`, `zeus` (and `managed_sync` when enabled) deploy — `paragon` deploys only when `postgres_multiple_instances = false`.
-
-Built-in default map (used when `postgres_instances` is null):
-
-```hcl
-cerberus     = { sku = postgres_base_sku_name, redundant = false }
-eventlogs    = { sku = postgres_base_sku_name, redundant = false }
-hermes       = { sku = postgres_sku_name,      redundant = false }
-triggerkit   = { sku = postgres_base_sku_name, redundant = false }
-zeus         = { sku = postgres_base_sku_name, redundant = false }
-managed_sync = { sku = postgres_base_sku_name, redundant = false }
-paragon      = { sku = postgres_sku_name,      redundant = false }
-```
-
-All instances default to **no HA**. Enable zone-redundant HA on `hermes` explicitly (requires GP/MO SKU, not Burstable):
-
-```hcl
-postgres_instances = {
-  hermes = { redundant = true }
-}
-```
-
-Or use the legacy shorthand `postgres_redundant = true` (equivalent to the hermes override above).
-
-Per-instance override example (HA on a secondary instance):
-
-```hcl
-postgres_instances = {
-  cerberus = { redundant = true, sku = "GP_Standard_D2ads_v5" }
-}
-```
-
 ## AKS network profile
 
 The `k8s_*` network variables configure the AKS `network_profile`. Defaults are optimized for greenfield deployments:
@@ -211,7 +168,7 @@ Optional staged migrations for legacy clusters (each step is one-way where noted
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 3.0.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 
 ## Providers
@@ -260,7 +217,7 @@ No resources.
 | <a name="input_k8s_default_node_pool_vm_size"></a> [k8s\_default\_node\_pool\_vm\_size](#input\_k8s\_default\_node\_pool\_vm\_size) | VM size for the AKS default (system) node pool. Must be available in the target region (e.g. Standard\_B2s\_v2 in japaneast). | `string` | `"Standard_B2s"` | no |
 | <a name="input_k8s_dns_service_ip"></a> [k8s\_dns\_service\_ip](#input\_k8s\_dns\_service\_ip) | IP address within k8s\_service\_cidr for the cluster DNS service. Immutable after cluster creation. | `string` | `"172.16.0.10"` | no |
 | <a name="input_k8s_load_balancer_sku"></a> [k8s\_load\_balancer\_sku](#input\_k8s\_load\_balancer\_sku) | SKU for the AKS load balancer. | `string` | `"standard"` | no |
-| <a name="input_k8s_max_node_count"></a> [k8s\_max\_node\_count](#input\_k8s\_max\_node\_count) | Maximum number of node Kubernetes can scale up to. | `number` | `20` | no |
+| <a name="input_k8s_max_node_count"></a> [k8s\_max\_node\_count](#input\_k8s\_max\_node\_count) | Maximum number of node Kubernetes can scale up to. | `number` | `50` | no |
 | <a name="input_k8s_min_node_count"></a> [k8s\_min\_node\_count](#input\_k8s\_min\_node\_count) | Minimum number of node Kubernetes can scale down to. | `number` | `3` | no |
 | <a name="input_k8s_network_plugin"></a> [k8s\_network\_plugin](#input\_k8s\_network\_plugin) | AKS network plugin. Use `azure` (recommended) or legacy `kubenet`. | `string` | `"azure"` | no |
 | <a name="input_k8s_network_plugin_mode"></a> [k8s\_network\_plugin\_mode](#input\_k8s\_network\_plugin\_mode) | Azure CNI mode. `overlay` assigns pod IPs from k8s\_pod\_cidr (default, IP-efficient). Set to null for legacy node-subnet mode (pod IPs from the VNet). | `string` | `"overlay"` | no |
@@ -277,9 +234,8 @@ No resources.
 | <a name="input_managed_sync_enabled"></a> [managed\_sync\_enabled](#input\_managed\_sync\_enabled) | Whether to enable managed sync. | `bool` | `false` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of organization to include in resource names. | `string` | n/a | yes |
 | <a name="input_postgres_base_sku_name"></a> [postgres\_base\_sku\_name](#input\_postgres\_base\_sku\_name) | PostgreSQL SKU for secondary instances. Use GP\_Standard\_D2ads\_v5 for HA support. SKU availability may vary by Azure region. | `string` | `"B_Standard_B2s"` | no |
-| <a name="input_postgres_instances"></a> [postgres\_instances](#input\_postgres\_instances) | Overrides for PostgreSQL flexible server instances. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed\_sync, paragon).<br/>Merged per key with postgres\_instances\_default (sku, redundant). Null uses defaults only. | <pre>map(object({<br/>    sku       = optional(string)<br/>    redundant = optional(bool)<br/>  }))</pre> | `null` | no |
+| <a name="input_postgres_instances"></a> [postgres\_instances](#input\_postgres\_instances) | Per-instance PostgreSQL overrides. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed\_sync, paragon).<br/>Both sku and redundant must be set on each entry you include. Omitted keys use built-in defaults (no HA). Null uses defaults for all instances. | <pre>map(object({<br/>    sku       = string<br/>    redundant = bool<br/>  }))</pre> | `null` | no |
 | <a name="input_postgres_multiple_instances"></a> [postgres\_multiple\_instances](#input\_postgres\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
-| <a name="input_postgres_redundant"></a> [postgres\_redundant](#input\_postgres\_redundant) | When true, enables zone-redundant HA on hermes (or paragon when postgres\_multiple\_instances is false) via postgres\_instances override. All instances default to no HA. | `bool` | `false` | no |
 | <a name="input_postgres_sku_name"></a> [postgres\_sku\_name](#input\_postgres\_sku\_name) | PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`) | `string` | `"GP_Standard_D2ds_v5"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version (14, 15 or 16) | `string` | `"14"` | no |
 | <a name="input_redis_base_capacity"></a> [redis\_base\_capacity](#input\_redis\_base\_capacity) | Default capacity of the Redis cache for instances that don't use the main redis\_capacity. | `number` | `1` | no |

--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -129,6 +129,49 @@ Confirm SKU availability in the target region before apply.
 
 Requires `azurerm` provider `>= 4.60` in `main.tf` (see `main.tf.example`).
 
+## PostgreSQL per-instance tuning
+
+One map drives every PostgreSQL flexible server (`for_each` in `./postgres`). Globals set defaults; per-instance overrides merge on top (same pattern as `redis_managed_instances`).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `postgres_sku_name` | `GP_Standard_D2ds_v5` | SKU for primary instances (`hermes`, `paragon`) |
+| `postgres_base_sku_name` | `B_Standard_B2s` | SKU for secondary instances |
+| `postgres_redundant` | `false` | Shorthand: sets `hermes.redundant = true` (or `paragon` when single-instance) |
+| `postgres_instances` | `null` | Per-key overrides (`sku`, `redundant`) |
+
+`postgres_multiple_instances` and `managed_sync_enabled` still filter which keys deploy (same as before).
+
+Built-in default map (used when `postgres_instances` is null):
+
+```hcl
+cerberus     = { sku = postgres_base_sku_name, redundant = false }
+eventlogs    = { sku = postgres_base_sku_name, redundant = false }
+hermes       = { sku = postgres_sku_name,      redundant = false }
+triggerkit   = { sku = postgres_base_sku_name, redundant = false }
+zeus         = { sku = postgres_base_sku_name, redundant = false }
+managed_sync = { sku = postgres_base_sku_name, redundant = false }
+paragon      = { sku = postgres_sku_name,      redundant = false }
+```
+
+All instances default to **no HA**. Enable zone-redundant HA on `hermes` explicitly (requires GP/MO SKU, not Burstable):
+
+```hcl
+postgres_instances = {
+  hermes = { redundant = true }
+}
+```
+
+Or use the legacy shorthand `postgres_redundant = true` (equivalent to the hermes override above).
+
+Per-instance override example (HA on a secondary instance):
+
+```hcl
+postgres_instances = {
+  cerberus = { redundant = true, sku = "GP_Standard_D2ads_v5" }
+}
+```
+
 ## AKS network profile
 
 The `k8s_*` network variables configure the AKS `network_profile`. Defaults are optimized for greenfield deployments:
@@ -234,8 +277,9 @@ No resources.
 | <a name="input_managed_sync_enabled"></a> [managed\_sync\_enabled](#input\_managed\_sync\_enabled) | Whether to enable managed sync. | `bool` | `false` | no |
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of organization to include in resource names. | `string` | n/a | yes |
 | <a name="input_postgres_base_sku_name"></a> [postgres\_base\_sku\_name](#input\_postgres\_base\_sku\_name) | PostgreSQL SKU for secondary instances. Use GP\_Standard\_D2ads\_v5 for HA support. SKU availability may vary by Azure region. | `string` | `"B_Standard_B2s"` | no |
+| <a name="input_postgres_instances"></a> [postgres\_instances](#input\_postgres\_instances) | Overrides for PostgreSQL flexible server instances. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed\_sync, paragon).<br/>Merged per key with postgres\_instances\_default (sku, redundant). Null uses defaults only. | <pre>map(object({<br/>    sku       = optional(string)<br/>    redundant = optional(bool)<br/>  }))</pre> | `null` | no |
 | <a name="input_postgres_multiple_instances"></a> [postgres\_multiple\_instances](#input\_postgres\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
-| <a name="input_postgres_redundant"></a> [postgres\_redundant](#input\_postgres\_redundant) | Enable zone-redundant HA. Recommended: true for production (requires GP/MO SKU, not Burstable). | `bool` | `false` | no |
+| <a name="input_postgres_redundant"></a> [postgres\_redundant](#input\_postgres\_redundant) | When true, enables zone-redundant HA on hermes (or paragon when postgres\_multiple\_instances is false) via postgres\_instances override. All instances default to no HA. | `bool` | `false` | no |
 | <a name="input_postgres_sku_name"></a> [postgres\_sku\_name](#input\_postgres\_sku\_name) | PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`) | `string` | `"GP_Standard_D2ds_v5"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version (14, 15 or 16) | `string` | `"14"` | no |
 | <a name="input_redis_base_capacity"></a> [redis\_base\_capacity](#input\_redis\_base\_capacity) | Default capacity of the Redis cache for instances that don't use the main redis\_capacity. | `number` | `1` | no |

--- a/azure/workspaces/infra/cluster/cluster.tf
+++ b/azure/workspaces/infra/cluster/cluster.tf
@@ -95,7 +95,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
   lifecycle {
     ignore_changes = [
-      default_node_pool[0].upgrade_settings
+      default_node_pool[0].upgrade_settings, kubernetes_version
     ]
   }
 }
@@ -141,7 +141,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
-      upgrade_settings
+      upgrade_settings, orchestrator_version
     ]
   }
 }

--- a/azure/workspaces/infra/cluster/cluster.tf
+++ b/azure/workspaces/infra/cluster/cluster.tf
@@ -95,7 +95,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
   lifecycle {
     ignore_changes = [
-      default_node_pool[0].upgrade_settings, kubernetes_version
+      default_node_pool[0].upgrade_settings
     ]
   }
 }
@@ -141,7 +141,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "pool" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
-      upgrade_settings, orchestrator_version
+      upgrade_settings
     ]
   }
 }

--- a/azure/workspaces/infra/modules.tf
+++ b/azure/workspaces/infra/modules.tf
@@ -35,17 +35,13 @@ module "bastion" {
 module "postgres" {
   source = "./postgres"
 
-  managed_sync_enabled        = var.managed_sync_enabled
-  postgres_multiple_instances = var.postgres_multiple_instances
-  postgres_base_sku_name      = var.postgres_base_sku_name
-  postgres_redundant          = var.postgres_redundant
-  postgres_sku_name           = var.postgres_sku_name
-  postgres_version            = var.postgres_version
-  resource_group              = module.network.resource_group
-  tags                        = local.default_tags
-  virtual_network             = module.network.virtual_network
-  private_subnet              = module.network.postgres_subnet
-  workspace                   = local.workspace
+  instances        = local.postgres_instances
+  postgres_version = var.postgres_version
+  resource_group   = module.network.resource_group
+  tags             = local.default_tags
+  virtual_network  = module.network.virtual_network
+  private_subnet   = module.network.postgres_subnet
+  workspace        = local.workspace
 }
 
 module "redis" {

--- a/azure/workspaces/infra/postgres/variables.tf
+++ b/azure/workspaces/infra/postgres/variables.tf
@@ -20,20 +20,12 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "postgres_redundant" {
-  description = "Whether zone redundant HA should be enabled"
-  type        = bool
-}
-
-variable "postgres_sku_name" {
-  description = "PostgreSQL SKU name"
-  type        = string
-}
-
-variable "postgres_base_sku_name" {
-  description = "Default PostgreSQL SKU name for instances that don't use the main postgres_sku_name"
-  type        = string
-  default     = "B_Standard_B2s"
+variable "instances" {
+  description = "PostgreSQL instances to deploy. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed_sync, paragon)."
+  type = map(object({
+    sku       = string
+    redundant = bool
+  }))
 }
 
 variable "postgres_version" {
@@ -47,61 +39,33 @@ variable "postgres_port" {
   default     = "5432"
 }
 
-variable "postgres_multiple_instances" {
-  description = "Whether or not to create multiple Postgres instances."
-  type        = bool
-}
-
-variable "managed_sync_enabled" {
-  description = "Whether to enable managed sync."
-  type        = bool
-}
-
 locals {
-  postgres_instances = var.postgres_multiple_instances ? merge({
-    cerberus = {
-      name = "${var.workspace}-cerberus"
-      db   = "cerberus"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_base_sku_name
-    }
-    eventlogs = {
-      name = "${var.workspace}-eventlogs"
-      db   = "eventlogs"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_base_sku_name
-    }
-    hermes = {
-      name = "${var.workspace}-hermes"
-      db   = "hermes"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_sku_name
-    }
-    triggerkit = {
-      name = "${var.workspace}-triggerkit"
-      db   = "triggerkit"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_base_sku_name
-    }
-    zeus = {
-      name = "${var.workspace}-zeus"
-      db   = "zeus"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_base_sku_name
-    }
-    }, var.managed_sync_enabled ? {
-    managed_sync = {
-      name = "${var.workspace}-managed-sync"
-      db   = "managed_sync"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_base_sku_name
-    }
-    } : {}) : {
-    paragon = {
-      name = "${var.workspace}"
-      db   = "postgres"
-      ha   = var.postgres_redundant
-      sku  = var.postgres_sku_name
+  postgres_db_names = {
+    cerberus     = "cerberus"
+    eventlogs    = "eventlogs"
+    hermes       = "hermes"
+    triggerkit   = "triggerkit"
+    zeus         = "zeus"
+    managed_sync = "managed_sync"
+    paragon      = "postgres"
+  }
+
+  postgres_server_names = {
+    cerberus     = "${var.workspace}-cerberus"
+    eventlogs    = "${var.workspace}-eventlogs"
+    hermes       = "${var.workspace}-hermes"
+    triggerkit   = "${var.workspace}-triggerkit"
+    zeus         = "${var.workspace}-zeus"
+    managed_sync = "${var.workspace}-managed-sync"
+    paragon      = var.workspace
+  }
+
+  postgres_instances = {
+    for name, cfg in var.instances : name => {
+      name = local.postgres_server_names[name]
+      db   = local.postgres_db_names[name]
+      ha   = cfg.redundant
+      sku  = cfg.sku
     }
   }
 }

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -112,12 +112,6 @@ variable "cloudflare_tunnel_email_domain" {
 }
 
 # postgres
-variable "postgres_redundant" {
-  description = "When true, enables zone-redundant HA on hermes (or paragon when postgres_multiple_instances is false) via postgres_instances override. All instances default to no HA."
-  type        = bool
-  default     = false
-}
-
 variable "postgres_sku_name" {
   description = "PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`)"
   type        = string
@@ -144,12 +138,12 @@ variable "postgres_multiple_instances" {
 
 variable "postgres_instances" {
   description = <<-EOT
-    Overrides for PostgreSQL flexible server instances. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed_sync, paragon).
-    Merged per key with postgres_instances_default (sku, redundant). Null uses defaults only.
+    Per-instance PostgreSQL overrides. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed_sync, paragon).
+    Both sku and redundant must be set on each entry you include. Omitted keys use built-in defaults (no HA). Null uses defaults for all instances.
   EOT
   type = map(object({
-    sku       = optional(string)
-    redundant = optional(bool)
+    sku       = string
+    redundant = bool
   }))
   default  = null
   nullable = true
@@ -483,65 +477,25 @@ locals {
   # for `ip_whitelist`, if an ip doesn't contain a range at the end (e.g. `<IP_ADDRESS>/32`), then add `/32` to the end. `1.1.1.1` becomes `1.1.1.1/32`; `2.2.2.2/24` remains unchanged
   ssh_whitelist = distinct([for value in split(",", var.ssh_whitelist) : "${trimspace(value)}${replace(value, "/", "") != value ? "" : "/32"}" if trimspace(value) != ""])
 
-  postgres_instance_defaults = {
-    sku       = var.postgres_base_sku_name
-    redundant = false
+  postgres_instances_defaults = {
+    cerberus     = { sku = var.postgres_base_sku_name, redundant = false }
+    eventlogs    = { sku = var.postgres_base_sku_name, redundant = false }
+    hermes       = { sku = var.postgres_sku_name, redundant = false }
+    triggerkit   = { sku = var.postgres_base_sku_name, redundant = false }
+    zeus         = { sku = var.postgres_base_sku_name, redundant = false }
+    managed_sync = { sku = var.postgres_base_sku_name, redundant = false }
+    paragon      = { sku = var.postgres_sku_name, redundant = false }
   }
-
-  postgres_instances_default = {
-    cerberus = {
-      sku       = var.postgres_base_sku_name
-      redundant = false
-    }
-    eventlogs = {
-      sku       = var.postgres_base_sku_name
-      redundant = false
-    }
-    hermes = {
-      sku       = var.postgres_sku_name
-      redundant = false
-    }
-    triggerkit = {
-      sku       = var.postgres_base_sku_name
-      redundant = false
-    }
-    zeus = {
-      sku       = var.postgres_base_sku_name
-      redundant = false
-    }
-    managed_sync = {
-      sku       = var.postgres_base_sku_name
-      redundant = false
-    }
-    paragon = {
-      sku       = var.postgres_sku_name
-      redundant = false
-    }
-  }
-
-  postgres_redundant_overrides = var.postgres_redundant ? (
-    var.postgres_multiple_instances ? { hermes = { redundant = true } } : { paragon = { redundant = true } }
-  ) : {}
-
-  postgres_instances_overrides = merge(
-    local.postgres_redundant_overrides,
-    var.postgres_instances != null ? var.postgres_instances : {},
-  )
 
   postgres_instances_config = merge(
-    local.postgres_instances_default,
-    {
-      for name, override in local.postgres_instances_overrides : name => merge(
-        lookup(local.postgres_instances_default, name, local.postgres_instance_defaults),
-        { for key, value in override : key => value if value != null },
-      )
-    },
+    local.postgres_instances_defaults,
+    var.postgres_instances != null ? var.postgres_instances : {},
   )
 
   postgres_instances = var.postgres_multiple_instances ? {
     for name, cfg in local.postgres_instances_config : name => cfg
     if name != "paragon" && (var.managed_sync_enabled || name != "managed_sync")
-  } : {
+    } : {
     paragon = local.postgres_instances_config["paragon"]
   }
 

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -538,11 +538,10 @@ locals {
     },
   )
 
-  postgres_instances = var.postgres_multiple_instances ? (
-    var.managed_sync_enabled ? local.postgres_instances_config : {
-      for name, cfg in local.postgres_instances_config : name => cfg if name != "managed_sync"
-    }
-    ) : {
+  postgres_instances = var.postgres_multiple_instances ? {
+    for name, cfg in local.postgres_instances_config : name => cfg
+    if name != "paragon" && (var.managed_sync_enabled || name != "managed_sync")
+  } : {
     paragon = local.postgres_instances_config["paragon"]
   }
 

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -113,7 +113,7 @@ variable "cloudflare_tunnel_email_domain" {
 
 # postgres
 variable "postgres_redundant" {
-  description = "Enable zone-redundant HA. Recommended: true for production (requires GP/MO SKU, not Burstable)."
+  description = "When true, enables zone-redundant HA on hermes (or paragon when postgres_multiple_instances is false) via postgres_instances override. All instances default to no HA."
   type        = bool
   default     = false
 }
@@ -140,6 +140,19 @@ variable "postgres_multiple_instances" {
   description = "Whether or not to create multiple Postgres instances. Used for higher volume installations."
   type        = bool
   default     = true
+}
+
+variable "postgres_instances" {
+  description = <<-EOT
+    Overrides for PostgreSQL flexible server instances. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed_sync, paragon).
+    Merged per key with postgres_instances_default (sku, redundant). Null uses defaults only.
+  EOT
+  type = map(object({
+    sku       = optional(string)
+    redundant = optional(bool)
+  }))
+  default  = null
+  nullable = true
 }
 
 # redis
@@ -469,6 +482,69 @@ locals {
   # get distinct values from comma-separated list, filter empty values and trim them
   # for `ip_whitelist`, if an ip doesn't contain a range at the end (e.g. `<IP_ADDRESS>/32`), then add `/32` to the end. `1.1.1.1` becomes `1.1.1.1/32`; `2.2.2.2/24` remains unchanged
   ssh_whitelist = distinct([for value in split(",", var.ssh_whitelist) : "${trimspace(value)}${replace(value, "/", "") != value ? "" : "/32"}" if trimspace(value) != ""])
+
+  postgres_instance_defaults = {
+    sku       = var.postgres_base_sku_name
+    redundant = false
+  }
+
+  postgres_instances_default = {
+    cerberus = {
+      sku       = var.postgres_base_sku_name
+      redundant = false
+    }
+    eventlogs = {
+      sku       = var.postgres_base_sku_name
+      redundant = false
+    }
+    hermes = {
+      sku       = var.postgres_sku_name
+      redundant = false
+    }
+    triggerkit = {
+      sku       = var.postgres_base_sku_name
+      redundant = false
+    }
+    zeus = {
+      sku       = var.postgres_base_sku_name
+      redundant = false
+    }
+    managed_sync = {
+      sku       = var.postgres_base_sku_name
+      redundant = false
+    }
+    paragon = {
+      sku       = var.postgres_sku_name
+      redundant = false
+    }
+  }
+
+  postgres_redundant_overrides = var.postgres_redundant ? (
+    var.postgres_multiple_instances ? { hermes = { redundant = true } } : { paragon = { redundant = true } }
+  ) : {}
+
+  postgres_instances_overrides = merge(
+    local.postgres_redundant_overrides,
+    var.postgres_instances != null ? var.postgres_instances : {},
+  )
+
+  postgres_instances_config = merge(
+    local.postgres_instances_default,
+    {
+      for name, override in local.postgres_instances_overrides : name => merge(
+        lookup(local.postgres_instances_default, name, local.postgres_instance_defaults),
+        { for key, value in override : key => value if value != null },
+      )
+    },
+  )
+
+  postgres_instances = var.postgres_multiple_instances ? (
+    var.managed_sync_enabled ? local.postgres_instances_config : {
+      for name, cfg in local.postgres_instances_config : name => cfg if name != "managed_sync"
+    }
+    ) : {
+    paragon = local.postgres_instances_config["paragon"]
+  }
 
   redis_managed_instance_defaults = {
     sku                   = "Balanced_B3"

--- a/scripts/generate-tfvars.mjs
+++ b/scripts/generate-tfvars.mjs
@@ -11,11 +11,12 @@ const USAGE = `Usage: node ${SCRIPT_NAME} <variables.tf> <output.tfvars> [provid
 
 const AZURE_INFRA_RECOMMENDATIONS = [
   "",
-  "# PostgreSQL Zone-Redundant HA (recommended for production).",
-  "# Requires General Purpose or Memory Optimized SKUs (not Burstable).",
-  "# Remove or comment out these lines if not required.",
-  'postgres_redundant     = true',
-  'postgres_base_sku_name = "GP_Standard_D2ads_v5"',
+  "# PostgreSQL per-instance config (recommended for production).",
+  "# Requires General Purpose or Memory Optimized SKUs for zone-redundant HA (not Burstable).",
+  "# Remove or comment out if not required.",
+  "postgres_instances = {",
+  '  hermes = { sku = "GP_Standard_D2ds_v5", redundant = true }',
+  "}",
   "",
 ].join("\n");
 


### PR DESCRIPTION
### Issues Closed

- [PARA-22462](https://useparagon.atlassian.net/browse/PARA-22462)

### Brief Summary

per-instance postgres ha and sku config for azure infra

### Detailed Summary

`postgres_redundant = true` previously applied zone-redundant HA to every postgres flexible server in multi-instance mode, including Burstable secondaries (`cerberus`, `eventlogs`, `triggerkit`, `zeus`). only `hermes` should have HA in production.

this pr introduces a `postgres_instances` map (same merge pattern as `redis_managed_instances`) so `sku` and `redundant` can be set per logical instance. both fields are required on each entry you include; omitted keys keep built-in defaults (no HA).

`postgres_redundant` is removed from the terraform interface. this is an intentional breaking change when customers upgrade to an installer release that includes this pr. per-customer migration steps are documented on enterprise confluence pages where a tfvars change is required.

also fixes a follow-up bug where the multi-instance filter incorrectly included the `paragon` key, which would have created a spurious `postgres["paragon"]` resource in plans where `postgres_multiple_instances = true`.

### Changes

- add `postgres_instances` variable and `local.postgres_instances` merge logic in `azure/workspaces/infra/variables.tf`
- refactor `azure/workspaces/infra/postgres` module to accept a single `instances` map instead of global sku/redundant flags
- remove `postgres_redundant` variable (breaking change)
- exclude `paragon` from multi-instance postgres deploy filter
- update `scripts/generate-tfvars.mjs` to suggest `postgres_instances` for production HA on `hermes`
- regenerate `azure/workspaces/infra/README.md` via terraform-docs
- bump `azurerm` provider lock file to support managed redis (`>= 4.60`)

### Unrelated Changes

- `cluster/cluster.tf`: add `kubernetes_version` and `orchestrator_version` to `lifecycle.ignore_changes` to prevent drift on AKS version upgrades managed outside terraform

### Future Work

- align aws/gcp infra workspaces with the same `postgres_instances` pattern for consistency across clouds
- apply per-customer tfvars migrations when each customer upgrades their installer pin

### Customer Migration (documented in confluence)

| customer | action |
|----------|--------|
| [us](https://useparagon.atlassian.net/wiki/spaces/PARAGON/pages/2086174721) | remove `postgres_redundant = true`; add `postgres_instances = { hermes = { sku = "GP_Standard_D2ds_v5", redundant = true } }` |
| [](https://useparagon.atlassian.net/wiki/spaces/PARAGON/pages/1574731778) | add `postgres_instances = { cerberus = { sku = "B_Standard_B1ms", redundant = false } }` (only cerberus differs from defaults) |
| | already migrated in customer repo |
| eu, | no change — existing globals/defaults already match |

### Steps to Test

1. `cd azure/workspaces/infra && terraform init -backend=false && terraform validate`
2. run `terraform plan` on workspace with `postgres_instances = { hermes = { sku = "GP_Standard_D2ds_v5", redundant = true } }` and `postgres_multiple_instances = true`
3. confirm no postgres instance replacements or HA mode changes on `cerberus`, `eventlogs`, `triggerkit`, or `zeus`
4. confirm `hermes` retains zone-redundant HA
5. confirm no spurious `postgres["paragon"]` create when `postgres_multiple_instances = true`
6. test per-instance sku override (see deployment notes examples) and confirm only the targeted instance shows sku change in plan
7. confirm `terraform validate` fails if `postgres_redundant` is still present in tfvars (variable removed)

### QA Notes

- this is an infra/terraform change only; no application code changes
- safe apply criteria: zero postgres `replace` or `update` actions on existing servers
- Burstable SKUs (`B_Standard_B2s`) cannot enable zone-redundant HA — applying HA to secondaries would fail or force unwanted sku upgrades
- HA requires GP/MO SKU (`GP_Standard_D2ds_v5` or higher); do not set `redundant = true` on Burstable instances
- customers without a confluence callout do not need tfvars changes at upgrade time

### Deployment Notes

**default behavior (no overrides):**

    cerberus, eventlogs, triggerkit, zeus, managed_sync → B_Standard_B2s, no HA
    hermes → GP_Standard_D2ds_v5, no HA
    paragon (single-instance mode only) → GP_Standard_D2ds_v5, no HA

**ha on hermes only (recommended for / us):**

    postgres_instances = {
      hermes = { sku = "GP_Standard_D2ds_v5", redundant = true }
    }

**preserve custom sku (— only cerberus differs):**

    postgres_instances = {
      cerberus = { sku = "B_Standard_B1ms", redundant = false }
    }

**different sku per instance:**

    postgres_instances = {
      hermes     = { sku = "GP_Standard_D4ds_v5", redundant = true }
      cerberus   = { sku = "B_Standard_B2s", redundant = false }
      eventlogs  = { sku = "B_Standard_B1ms", redundant = false }
      triggerkit = { sku = "B_Standard_B2s", redundant = false }
      zeus       = { sku = "GP_Standard_D2ds_v5", redundant = false }
    }

**upgrade a secondary to GP without HA:**

    postgres_instances = {
      zeus = { sku = "GP_Standard_D2ds_v5", redundant = false }
    }

**ha on a secondary (requires GP/MO sku):**

    postgres_instances = {
      cerberus = { sku = "GP_Standard_D2ads_v5", redundant = true }
    }

- provider lock file update requires `terraform init` before apply
- no helm/k8s config changes required for this pr
- remove `postgres_redundant` from tfvars when upgrading; it is no longer a valid variable

### Screenshots

n/a — terraform plan output showing 0 postgres changes on

[PARA-22462]: https://useparagon.atlassian.net/browse/PARA-22462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ