### PR TITLE
chore(ci): integrate paragon-release-changelogs

### DIFF
--- a/.github/workflows/changelog-auto-trigger.yaml
+++ b/.github/workflows/changelog-auto-trigger.yaml
@@ -1,0 +1,91 @@
+## Changelog Auto-Trigger
+##
+## Fires when a new release tag is pushed, computes the from..to window from the
+## two most recent stable (non-canary) release tags, and dispatches
+## release-changelog.yaml against that window.
+##
+## Tag format in this repo is date-based: YYYY.MMDD.HHMM-<sha8>
+##   e.g. 2026.0612.1204-9346a7d4   (stable)
+##        2026.0614.1854-9a416ff7-canary  (canary — excluded)
+## NOT semver, so we sort by commit creation date (--sort=-creatordate), never
+## lexical or version sort, and filter out -canary tags in the job.
+##
+## ANTI-RECURSION NOTE: GitHub suppresses workflow triggers for events created
+## by the default GITHUB_TOKEN. If these release tags are ever pushed by an
+## in-repo workflow using GITHUB_TOKEN, this auto-trigger will NOT fire — the
+## tag-pushing step would need a PAT. Tags pushed by humans or external CI (or a
+## PAT) DO fire it. The workflow_dispatch entry on release-changelog.yaml is the
+## manual fallback in any case.
+
+name: changelog-auto-trigger
+
+on:
+  push:
+    tags:
+      # Year-prefixed date tags. Canary tags also match here and are filtered
+      # out inside the job (the glob can't express "not -canary").
+      - "20[0-9][0-9].*"
+  workflow_dispatch: {}
+
+jobs:
+  auto-changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine tag range from two most recent stable tags
+        id: tags
+        run: |
+          set -euo pipefail
+          # Two most recent stable (non-canary) tags, by commit creation date.
+          TAGS=$(git for-each-ref --sort=-creatordate \
+                   --format='%(refname:short)' 'refs/tags/20[0-9][0-9].*' \
+                 | grep -v -- '-canary' \
+                 | head -2)
+
+          TAG_COUNT=$(printf '%s\n' "$TAGS" | grep -c . || true)
+          if [ "$TAG_COUNT" -lt 2 ]; then
+            echo "Only $TAG_COUNT stable release tag(s) found; skipping (expected on the first release)."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TO_TAG=$(printf '%s\n' "$TAGS" | sed -n '1p')
+          FROM_TAG=$(printf '%s\n' "$TAGS" | sed -n '2p')
+          echo "to_tag=$TO_TAG" >> "$GITHUB_OUTPUT"
+          echo "from_tag=$FROM_TAG" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          echo "Resolved window from $FROM_TAG to $TO_TAG"
+
+      - name: Dispatch release-changelog workflow
+        if: ${{ steps.tags.outputs.skip != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_TAG: ${{ steps.tags.outputs.from_tag }}
+          TO_TAG: ${{ steps.tags.outputs.to_tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh workflow run release-changelog.yaml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.event.repository.default_branch }}" \
+            --field from_tag="$FROM_TAG" \
+            --field to_tag="$TO_TAG" \
+            --field jira_project_keys="PARA" \
+            --field draft=false \
+            --field verbose=true
+
+          {
+            echo "## Auto-Changelog Triggered"
+            echo "- **From:** \`$FROM_TAG\`"
+            echo "- **To:** \`$TO_TAG\`"
+            echo "- **Triggered by tag:** \`$REF_NAME\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -1,0 +1,69 @@
+## Release Changelog (manual dispatch caller)
+##
+## Calls the org-wide reusable changelog workflow in
+## useparagon-internal/paragon-release-changelogs. That workflow:
+##   1. release-scope   — resolves the from_tag..to_tag window, collects every
+##                        merged PR in the window, attaches them to a milestone.
+##   2. release-compose — builds the release package + an AI Release Summary
+##                        (cursor-agent, read-only ask mode over the PR/Jira
+##                        digest) with a deterministic categorized fallback.
+##   3. release-publish — creates/updates the GitHub Release (with the PR list +
+##                        AI summary) and the Confluence/Jira changelog page.
+##
+## This file is the MANUAL entry point. The companion changelog-auto-trigger.yaml
+## fires this automatically on each new release tag.
+##
+## Required on this repo before a live run:
+##   secrets: ATLASSIAN_API_TOKEN, ATLASSIAN_EMAIL  (and optionally CURSOR_API_KEY
+##            to enable the AI summary; without it a deterministic fallback runs)
+##   vars:    JIRA_BASE_URL  (e.g. https://useparagon.atlassian.net) — must be a
+##            repository/org VARIABLE, not a secret.
+
+name: release-changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_tag:
+        description: "Start tag — the previous release (e.g. 2026.0608.1108-f0557563)."
+        required: true
+        type: string
+      to_tag:
+        description: "End tag — the new release (e.g. 2026.0612.1204-9346a7d4)."
+        required: true
+        type: string
+      jira_project_keys:
+        description: "Jira project key filter (comma-separated). Leave default for PARA only."
+        required: false
+        type: string
+        default: "PARA"
+      draft:
+        description: "Publish as a draft release (banner + open milestone + unreleased Jira version)."
+        required: false
+        type: boolean
+        default: false
+      verbose:
+        description: "Enable verbose diagnostic logging."
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  changelog:
+    # TODO: pin to @vX.Y.Z once paragon-release-changelogs cuts a tagged release.
+    uses: useparagon-internal/paragon-release-changelogs/.github/workflows/release-changelog.yml@main
+    with:
+      repository: ${{ github.repository }}
+      scope_mode: tag
+      from_tag: ${{ inputs.from_tag }}
+      to_tag: ${{ inputs.to_tag }}
+      jira_base_url: ${{ vars.JIRA_BASE_URL }}
+      confluence_space_key: PARARELEASES
+      confluence_folder_path: Repositories/${{ github.event.repository.name }}
+      jira_project_keys: ${{ inputs.jira_project_keys }}
+      draft: ${{ inputs.draft }}
+      verbose: ${{ inputs.verbose }}
+    secrets:
+      ATLASSIAN_API_TOKEN: ${{ secrets.ATLASSIAN_API_TOKEN }}
+      ATLASSIAN_EMAIL: ${{ secrets.ATLASSIAN_EMAIL }}
+      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
## What

Adds a lightweight changelog integration to this repo. On each release it
produces:

- a **GitHub Release** containing every merged PR in the release window, plus
  an **AI-generated release summary**, and
- the **Confluence/Jira changelog** page,

by calling the org-wide reusable workflow
`useparagon-internal/paragon-release-changelogs/.github/workflows/release-changelog.yml@main`
— the same integration used by platform-monorepo, ocs, managed-sync, etc.

## Files

| File | Purpose |
|---|---|
| `.github/workflows/release-changelog.yaml` | Manual `workflow_dispatch` caller of the reusable workflow (inputs: `from_tag`, `to_tag`, `jira_project_keys`, `draft`, `verbose`). |
| `.github/workflows/changelog-auto-trigger.yaml` | Fires on a release tag push, selects the two most recent **stable** tags, dispatches the caller for that window. Also exposes `workflow_dispatch` as a manual fallback. |

## Tag handling

This repo uses date-based tags `YYYY.MMDD.HHMM-<sha8>` (e.g. `2026.0612.1204-9346a7d4`),
not semver, and has `-canary` variants. The auto-trigger therefore:

- globs `20[0-9][0-9].*`,
- sorts by `--sort=-creatordate` (never lexical/version sort), and
- filters out `-canary` tags.

Dry-run against current repo tags resolves `from=2026.0608.1108-f0557563`,
`to=2026.0612.1204-9346a7d4` (correctly skipping the newer-by-date canary tag).
Validated with `actionlint` (0 issues).

## ⚠️ Prerequisites before a live run

These must exist on this repo (or org) or the workflow will fail / silently no-op:

- **Secrets:** `ATLASSIAN_API_TOKEN`, `ATLASSIAN_EMAIL`. Optional `CURSOR_API_KEY`
  enables the AI summary; without it a deterministic categorized fallback runs
  (the workflow still succeeds).
- **Variable (NOT a secret):** `JIRA_BASE_URL` = `https://useparagon.atlassian.net`.
  The workflow reads `${{ vars.JIRA_BASE_URL }}` — setting it as a secret makes
  it resolve empty.
- **Cross-org reusable-workflow access:** this repo is in the `useparagon` org;
  the callee is in `useparagon-internal`. The callee's Actions access policy must
  allow this repo to call its reusable workflow, otherwise the run fails with
  `workflow was not found` even on `@main`.

## Notes / follow-ups

- **AI scope:** the current release-notes skill summarizes **PR titles/bodies +
  Jira tickets** (cursor-agent read-only ask mode). It does **not** diff the
  committed code. Making the AI read the actual diff is a separate change to
  `paragon-release-changelogs` itself — tracked as a possible fast-follow.
- **Reusable workflow ref** is pinned to `@main` with a TODO to switch to
  `@vX.Y.Z` once that repo cuts a tagged release (all caller repos update in
  lockstep then).
- The existing `release-charts.yaml` / `stage-charts.yaml` no-op stubs are left
  untouched; this is purely additive.

## Test plan

1. Provision the secrets/var above + confirm cross-org access.
2. Manually dispatch `release-changelog` with two real tags
   (`from_tag=2026.0608.1108-f0557563`, `to_tag=2026.0612.1204-9346a7d4`) and
   confirm the GitHub Release + Confluence page are produced.
3. Once validated, push a new stable tag and confirm `changelog-auto-trigger`
   fires and dispatches the correct window.
