### PR TITLE
fix(azure/paragon): guard api-sync host lookup when managed sync is d…

### DIFF
--- a/azure/workspaces/paragon/helm/helm-managed-sync.tf
+++ b/azure/workspaces/paragon/helm/helm-managed-sync.tf
@@ -1,4 +1,8 @@
 locals {
+  # api-sync is only in var.microservices when managed_sync_enabled is true, but locals
+  # are always evaluated — use try() so plan succeeds when managed sync is disabled.
+  api_sync_host = replace(replace(try(var.microservices["api-sync"].public_url, ""), "https://", ""), "http://", "")
+
   # openfga-migrate is a post-install hook while the openfga ServiceAccount is normally
   # a regular resource. On first install, AKS can create the Job before the SA is
   # visible, producing: serviceaccount "openfga" not found.
@@ -31,7 +35,7 @@ locals {
       ingress = {
         class     = "nginx"
         className = "nginx"
-        host      = replace(replace(var.microservices["api-sync"].public_url, "https://", ""), "http://", "")
+        host      = local.api_sync_host
         annotations = {
           "kubernetes.io/ingress.class"    = "nginx"
           "cert-manager.io/cluster-issuer" = "letsencrypt-prod"
@@ -89,7 +93,7 @@ resource "helm_release" "managed_sync" {
 
   set {
     name  = "ingress.host"
-    value = replace(replace(var.microservices["api-sync"].public_url, "https://", ""), "http://", "")
+    value = local.api_sync_host
   }
 
   set {


### PR DESCRIPTION
### Issues Closed

- PARA-22517

### Brief Summary

fix azure paragon plan when managed sync disabled

### Detailed Summary

Azure paragon `terraform plan` failed with `Invalid index` on `var.microservices["api-sync"]` when `managed_sync_enabled = false` (the default). The managed-sync Helm release is gated with `count = 0`, but `local.managed_sync_azure_values` still referenced `api-sync`, and `api-sync` is only added to `var.microservices` when managed sync is enabled. Terraform evaluates `locals` unconditionally, so the plan failed even though managed sync was never deployed.

This change extracts the host lookup into `local.api_sync_host` using `try()` so plan succeeds when managed sync is off. Behavior is unchanged when managed sync is enabled.

### Changes

- add `local.api_sync_host` with `try(var.microservices["api-sync"].public_url, "")` in `azure/workspaces/paragon/helm/helm-managed-sync.tf`
- replace two direct `var.microservices["api-sync"]` references with `local.api_sync_host`

### Unrelated Changes

- None

### Future Work

- None

### Steps to Test

1. `cd azure/workspaces/paragon`
2. Ensure `managed_sync_enabled = false` (default) in tfvars
3. Run `terraform init -backend=false && terraform plan`
4. Confirm plan completes without `Invalid index` on `helm-managed-sync.tf`
5. Optional: set `managed_sync_enabled = true`, ensure `api-sync` is in microservices, and confirm `local.api_sync_host` resolves to the expected ingress host

### QA Notes

- Azure paragon workspace only
- No runtime or Helm behavior change when `managed_sync_enabled = false` (release still not created)
- When managed sync is enabled, ingress host values should match previous behavior

### Deployment Notes

- no config changes required
- customers blocked on paragon `terraform plan` with managed sync disabled can pick up this fix without tfvars changes

### Screenshots

- n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Terraform-only change in Azure Paragon helm locals; no runtime or deployment behavior when managed sync stays disabled.
> 
> **Overview**
> Fixes **`terraform plan`** for Azure Paragon when **`managed_sync_enabled`** is off (the default). Locals in `helm-managed-sync.tf` were still indexing **`var.microservices["api-sync"]`**, but that key only exists when managed sync is enabled—while the managed-sync Helm release is already gated with **`count = 0`**.
> 
> Introduces **`local.api_sync_host`** using **`try(..., "")`** plus the same URL scheme stripping as before, and wires it into the **`api-sync`** ingress host in **`managed_sync_azure_values`** and the **`ingress.host`** Helm **`set`**. With managed sync disabled, plan no longer hits **`Invalid index`**; with it enabled, ingress host behavior should match the prior direct lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef6615f120af781afdb06e0655132d88e7c54ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->