### PR TITLE
feat: support KMS encryption for S3 buckets

### DIFF
--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -143,6 +143,7 @@ Notes:
 
 - Toggling this on an existing deployment changes the bucket default encryption in place. New objects are encrypted with KMS; previously written objects keep their existing encryption until rewritten.
 - The `logs` bucket always stays on SSE-S3. ALB access logs and S3 server access logs do not support SSE-KMS destination buckets, so it is intentionally excluded.
+- Setting `s3_kms_encryption_enabled` back to false sets module.s3_kms_key count to zero, so Terraform schedules the managed CMK for deletion. Bucket default encryption reverts to SSE-S3, but existing objects stay SSE-KMS with that key and can become unreadable after the key is removed.
 
 ## Updates
 

--- a/aws/workspaces/infra/README.md
+++ b/aws/workspaces/infra/README.md
@@ -9,9 +9,6 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.70 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.12.0 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.9 |
 
 ## Providers
 
@@ -90,6 +87,8 @@ See [setup-policy.json](../../setup-policy.json) for permissions that are requir
 | <a name="input_rds_multiple_instances"></a> [rds\_multiple\_instances](#input\_rds\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
 | <a name="input_rds_postgres_version"></a> [rds\_postgres\_version](#input\_rds\_postgres\_version) | Postgres version for the database. | `string` | `"14"` | no |
 | <a name="input_rds_restore_from_snapshot"></a> [rds\_restore\_from\_snapshot](#input\_rds\_restore\_from\_snapshot) | Specifies that RDS instances should be restored from a snapshot. | `bool` | `false` | no |
+| <a name="input_s3_kms_encryption_enabled"></a> [s3\_kms\_encryption\_enabled](#input\_s3\_kms\_encryption\_enabled) | Encrypt the app, CDN, audit logs, and managed sync S3 buckets with AWS KMS (SSE-KMS) instead of S3-managed keys (SSE-S3). Existing deployments default to SSE-S3; enable for new installs or to migrate existing buckets to KMS. The logs bucket always uses SSE-S3 because ALB and S3 server access logs do not support SSE-KMS. | `bool` | `false` | no |
+| <a name="input_s3_kms_key_arn"></a> [s3\_kms\_key\_arn](#input\_s3\_kms\_key\_arn) | ARN of an existing KMS key to use for S3 bucket encryption. When null and s3\_kms\_encryption\_enabled is true, a dedicated KMS key is created and managed by Terraform. Ignored when s3\_kms\_encryption\_enabled is false. | `string` | `null` | no |
 | <a name="input_ssh_whitelist"></a> [ssh\_whitelist](#input\_ssh\_whitelist) | An optional list of IP addresses to whitelist ssh access. | `string` | `""` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR for the VPC. | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_cidr_newbits"></a> [vpc\_cidr\_newbits](#input\_vpc\_cidr\_newbits) | Newbits used for calculating subnets. | `number` | `3` | no |
@@ -120,6 +119,30 @@ cdn_bucket_acl_reset = true
 ```
 
 After `BucketOwnerEnforced` is active, ACL updates are ignored via `lifecycle.ignore_changes` to avoid S3 API errors on subsequent applies.
+
+## S3 bucket encryption (SSE-S3 vs SSE-KMS)
+
+By default the S3 buckets use server-side encryption with S3-managed keys (SSE-S3 / `AES256`). This preserves the behavior of existing deployments.
+
+To meet compliance requirements that mandate AWS KMS, set `s3_kms_encryption_enabled = true`. This switches the app, CDN, audit logs, and managed sync buckets to SSE-KMS (with S3 Bucket Keys enabled to limit KMS request costs):
+
+```hcl
+s3_kms_encryption_enabled = true
+```
+
+When enabled, Terraform creates a dedicated customer-managed KMS key (alias `s3/<workspace>`) with rotation enabled, grants the application's S3 IAM user permission to use it, and adds the configured `eks_admin_arns` plus the Terraform caller as key administrators.
+
+To use a pre-existing KMS key instead of creating one, also set `s3_kms_key_arn`. The key policy must allow the application's S3 IAM user to `Decrypt`/`GenerateDataKey`, or enable IAM-based access so the attached IAM policy grant applies:
+
+```hcl
+s3_kms_encryption_enabled = true
+s3_kms_key_arn            = "arn:aws:kms:us-east-1:123456789012:key/abcd-..."
+```
+
+Notes:
+
+- Toggling this on an existing deployment changes the bucket default encryption in place. New objects are encrypted with KMS; previously written objects keep their existing encryption until rewritten.
+- The `logs` bucket always stays on SSE-S3. ALB access logs and S3 server access logs do not support SSE-KMS destination buckets, so it is intentionally excluded.
 
 ## Updates
 

--- a/aws/workspaces/infra/cluster/cluster.tf
+++ b/aws/workspaces/infra/cluster/cluster.tf
@@ -41,7 +41,7 @@ module "eks" {
         }
       }
     },
-    { for arn in local.eks_admin_arns : arn => {
+    { for arn in var.eks_admin_arns : arn => {
       kubernetes_groups = ["admin", "cluster-admin"]
       principal_arn     = arn
 

--- a/aws/workspaces/infra/cluster/kms.tf
+++ b/aws/workspaces/infra/cluster/kms.tf
@@ -1,7 +1,7 @@
 locals {
   key_administrators = distinct(compact(concat(
-    coalesce(var.eks_admin_arns, []),
-    [var.kms_admin_role != null ? var.kms_admin_role : local.caller_arn],
+    var.eks_admin_arns,
+    var.kms_admin_role != null ? [var.kms_admin_role] : [],
     [local.autoscaling_role_arn]
   )))
 }

--- a/aws/workspaces/infra/cluster/security.tf
+++ b/aws/workspaces/infra/cluster/security.tf
@@ -7,7 +7,7 @@ resource "aws_iam_role" "eks_cluster_admin" {
       {
         Effect = "Allow",
         Principal = {
-          AWS = local.eks_admin_arns
+          AWS = var.eks_admin_arns
         },
         Action = "sts:AssumeRole"
       }

--- a/aws/workspaces/infra/cluster/variables.tf
+++ b/aws/workspaces/infra/cluster/variables.tf
@@ -14,9 +14,8 @@ variable "private_subnet_ids" {
 }
 
 variable "eks_admin_arns" {
-  description = "Array of ARNs for IAM users, groups or roles that should have admin access to cluster. Used for viewing cluster resources in AWS dashboard."
+  description = "Array of ARNs for IAM users, groups or roles that should have admin access to cluster. Includes the Terraform caller."
   type        = list(string)
-  default     = []
 }
 
 variable "k8s_version" {
@@ -142,30 +141,4 @@ locals {
     http_tokens                 = "required"
     http_put_response_hop_limit = 2
   }
-
-  # when using an assumed role the role itself must be used instead of the current identity arn
-  # so convert identity arn (e.g. arn:aws:sts::123456789:assumed-role/ParagonAssumedRole/SessionName)
-  # to role arn (e.g. arn:aws:iam::123456789:role/ParagonAssumedRole)
-  is_assumed_role = can(regex("assumed-role", data.aws_caller_identity.current.arn))
-  assumed_role_parts = split(
-    "/",
-    replace(
-      replace(
-        data.aws_caller_identity.current.arn,
-        ":sts:",
-        ":iam:"
-      ),
-      ":assumed-role/",
-      # in the case of AWS SSO, the arn is in the format of arn:aws:sts::123456789:assumed-role/ParagonAssumedRole/SessionName
-      # but we need to convert it to arn:aws:iam::123456789:role/aws-reserved/sso.amazonaws.com/ParagonAssumedRole
-      local.is_assumed_role && strcontains(data.aws_caller_identity.current.arn, ":assumed-role/AWSReservedSSO") ? ":role__TEMPORARY_DIVIDER__aws-reserved__TEMPORARY_DIVIDER__sso.amazonaws.com/" : ":role/"
-    )
-  )
-  caller_arn = local.is_assumed_role ? replace(format("%s/%s", local.assumed_role_parts[0], local.assumed_role_parts[1]), "__TEMPORARY_DIVIDER__", "/") : data.aws_caller_identity.current.arn
-
-  # include current user as EKS admin
-  eks_admin_arns = distinct(compact(concat(
-    var.eks_admin_arns,
-    [local.caller_arn]
-  )))
 }

--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -62,12 +62,15 @@ module "redis" {
 module "storage" {
   source = "./storage"
 
-  workspace                = local.workspace
-  force_destroy            = var.disable_deletion_protection
-  app_bucket_expiration    = var.app_bucket_expiration
-  auditlogs_retention_days = var.auditlogs_retention_days
-  auditlogs_lock_enabled   = var.auditlogs_lock_enabled
-  managed_sync_enabled   = var.managed_sync_enabled
+  workspace                 = local.workspace
+  force_destroy             = var.disable_deletion_protection
+  app_bucket_expiration     = var.app_bucket_expiration
+  auditlogs_retention_days  = var.auditlogs_retention_days
+  auditlogs_lock_enabled    = var.auditlogs_lock_enabled
+  managed_sync_enabled      = var.managed_sync_enabled
+  s3_kms_encryption_enabled = var.s3_kms_encryption_enabled
+  s3_kms_key_arn            = var.s3_kms_key_arn
+  admin_arns                = local.admin_arns
 
   migrated             = var.migrated_workspace != null
   cdn_bucket_acl_reset = var.cdn_bucket_acl_reset
@@ -118,7 +121,7 @@ module "cluster" {
   bastion_security_group_id = module.bastion.security_group.host[0]
 
   create_autoscaling_linked_role  = var.create_autoscaling_linked_role
-  eks_admin_arns                  = var.eks_admin_arns
+  eks_admin_arns                  = local.admin_arns
   eks_max_node_count              = var.eks_max_node_count
   eks_min_node_count              = var.eks_min_node_count
   eks_ondemand_node_instance_type = local.eks_ondemand_node_instance_type

--- a/aws/workspaces/infra/outputs.tf
+++ b/aws/workspaces/infra/outputs.tf
@@ -47,6 +47,7 @@ output "storage" {
     managed_sync_bucket = module.storage.s3.managed_sync_bucket
     root_user           = module.storage.s3.access_key_id
     root_password       = module.storage.s3.access_key_secret
+    kms_key_arn         = module.storage.s3.kms_key_arn
   }
   sensitive = true
 }

--- a/aws/workspaces/infra/postgres/rds.tf
+++ b/aws/workspaces/infra/postgres/rds.tf
@@ -1,14 +1,14 @@
 locals {
   postgres_family = "postgres${split(".", var.rds_postgres_version)[0]}" // e.g. `postgres11`, `postgres12`, etc
 
-  # gp3 baseline depends on allocated size: PostgreSQL stripes at >= 400 GiB (12k IOPS / 500 MiB/s).
-  # Custom values must be set as a valid pair; if only one is set, fall back to the size-appropriate baseline.
-  rds_gp3_custom                       = var.rds_gp3_iops != null && var.rds_gp3_storage_throughput != null
+  # gp3 PostgreSQL stripes at >= 400 GiB (12k IOPS / 500 MiB/s baseline). Below 400 GiB gp3 uses a
+  # fixed 3000 IOPS / 125 MiB/s that AWS does NOT allow you to specify; passing iops/storage_throughput
+  # for those sizes fails with InvalidParameterCombination, so they must be omitted (null).
+  # Custom values must be set as a valid pair and are only honored at >= 400 GiB (enforced by variable validation).
   rds_gp3_striped                      = var.rds_allocated_storage >= 400
-  rds_gp3_baseline_iops                = local.rds_gp3_striped ? 12000 : 3000
-  rds_gp3_baseline_tp                  = local.rds_gp3_striped ? 500 : 125
-  rds_gp3_iops_effective               = local.rds_gp3_custom ? var.rds_gp3_iops : local.rds_gp3_baseline_iops
-  rds_gp3_storage_throughput_effective = local.rds_gp3_custom ? var.rds_gp3_storage_throughput : local.rds_gp3_baseline_tp
+  rds_gp3_custom                       = var.rds_gp3_iops != null && var.rds_gp3_storage_throughput != null
+  rds_gp3_iops_effective               = local.rds_gp3_striped ? (local.rds_gp3_custom ? var.rds_gp3_iops : 12000) : null
+  rds_gp3_storage_throughput_effective = local.rds_gp3_striped ? (local.rds_gp3_custom ? var.rds_gp3_storage_throughput : 500) : null
 }
 
 resource "random_string" "postgres_root_username" {

--- a/aws/workspaces/infra/storage/outputs.tf
+++ b/aws/workspaces/infra/storage/outputs.tf
@@ -7,6 +7,7 @@ output "s3" {
     auditlogs_bucket    = aws_s3_bucket.auditlogs.bucket
     logs_bucket         = aws_s3_bucket.logs.bucket
     managed_sync_bucket = var.managed_sync_enabled ? aws_s3_bucket.managed_sync[0].bucket : null
+    kms_key_arn         = local.s3_kms_key_arn
   }
   sensitive = true
 }

--- a/aws/workspaces/infra/storage/s3-app.tf
+++ b/aws/workspaces/infra/storage/s3-app.tf
@@ -23,8 +23,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "app" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = local.s3_kms_enabled ? "aws:kms" : "AES256"
+      kms_master_key_id = local.s3_kms_enabled ? local.s3_kms_key_arn : null
     }
+    bucket_key_enabled = local.s3_kms_enabled ? true : null
   }
 }
 
@@ -133,7 +135,7 @@ resource "aws_iam_group_policy" "app" {
   policy = jsonencode(
     {
       "Version" : "2012-10-17",
-      "Statement" : [
+      "Statement" : concat([
         {
           "Sid" : "AllowReadBucketOperations",
           "Action" : [
@@ -190,7 +192,20 @@ resource "aws_iam_group_policy" "app" {
             "${aws_s3_bucket.managed_sync[0].arn}/*"
           ] : [])
         }
-      ]
+        ], local.s3_kms_enabled ? [
+        {
+          "Sid" : "AllowS3KMSEncryption",
+          "Action" : [
+            "kms:Decrypt",
+            "kms:Encrypt",
+            "kms:GenerateDataKey",
+            "kms:ReEncrypt*",
+            "kms:DescribeKey"
+          ],
+          "Effect" : "Allow",
+          "Resource" : [local.s3_kms_key_arn]
+        }
+      ] : [])
     }
   )
 }

--- a/aws/workspaces/infra/storage/s3-app.tf
+++ b/aws/workspaces/infra/storage/s3-app.tf
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "app" {
     sid       = "AllowSSLRequestsOnly"
     actions   = ["s3:*"]
     effect    = "Deny"
-    resources = ["${aws_s3_bucket.app.arn}", "${aws_s3_bucket.app.arn}/*"]
+    resources = [aws_s3_bucket.app.arn, "${aws_s3_bucket.app.arn}/*"]
 
     condition {
       test     = "Bool"
@@ -150,11 +150,11 @@ resource "aws_iam_group_policy" "app" {
           ],
           "Effect" : "Allow",
           "Resource" : concat([
-            "${aws_s3_bucket.app.arn}",
-            "${aws_s3_bucket.cdn.arn}",
-            "${aws_s3_bucket.auditlogs.arn}"
+            aws_s3_bucket.app.arn,
+            aws_s3_bucket.cdn.arn,
+            aws_s3_bucket.auditlogs.arn
             ], var.managed_sync_enabled ? [
-            "${aws_s3_bucket.managed_sync[0].arn}"
+            aws_s3_bucket.managed_sync[0].arn
           ] : [])
         },
         {

--- a/aws/workspaces/infra/storage/s3-auditlogs.tf
+++ b/aws/workspaces/infra/storage/s3-auditlogs.tf
@@ -24,8 +24,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "auditlogs" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = local.s3_kms_enabled ? "aws:kms" : "AES256"
+      kms_master_key_id = local.s3_kms_enabled ? local.s3_kms_key_arn : null
     }
+    bucket_key_enabled = local.s3_kms_enabled ? true : null
   }
 }
 

--- a/aws/workspaces/infra/storage/s3-cdn.tf
+++ b/aws/workspaces/infra/storage/s3-cdn.tf
@@ -64,8 +64,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "cdn" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = local.s3_kms_enabled ? "aws:kms" : "AES256"
+      kms_master_key_id = local.s3_kms_enabled ? local.s3_kms_key_arn : null
     }
+    bucket_key_enabled = local.s3_kms_enabled ? true : null
   }
 }
 

--- a/aws/workspaces/infra/storage/s3-kms.tf
+++ b/aws/workspaces/infra/storage/s3-kms.tf
@@ -1,0 +1,32 @@
+locals {
+  s3_kms_enabled = var.s3_kms_encryption_enabled
+
+  # Use a caller-provided key when given; otherwise the key created below. Null when
+  # KMS encryption is disabled so the SSE configs fall back to SSE-S3 (AES256).
+  s3_kms_key_arn = local.s3_kms_enabled ? coalesce(var.s3_kms_key_arn, try(module.s3_kms_key[0].key_arn, null)) : null
+}
+
+# Dedicated customer-managed key for S3 object encryption. Only created when KMS
+# encryption is enabled and the caller did not bring their own key.
+module "s3_kms_key" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  count = local.s3_kms_enabled && var.s3_kms_key_arn == null ? 1 : 0
+
+  description             = "${var.workspace} s3 encryption key"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  aliases_use_name_prefix = false
+
+  key_administrators = var.admin_arns
+
+  # the application reads/writes objects via this IAM user, so it must be able to
+  # use the key to encrypt/decrypt objects
+  key_users = [aws_iam_user.app.arn]
+
+  computed_aliases = {
+    s3 = { name = "s3/${var.workspace}" }
+  }
+}

--- a/aws/workspaces/infra/storage/s3-logs.tf
+++ b/aws/workspaces/infra/storage/s3-logs.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "logs_bucket_policy" {
     actions = ["s3:PutObject"]
     effect  = "Allow"
     resources = [
-      "${aws_s3_bucket.logs.arn}",
+      aws_s3_bucket.logs.arn,
       "${aws_s3_bucket.logs.arn}/access_logs/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
     ]
     principals {
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "logs_bucket_policy" {
     ]
     effect = "Allow"
     resources = [
-      "${aws_s3_bucket.logs.arn}",
+      aws_s3_bucket.logs.arn,
       "${aws_s3_bucket.logs.arn}/*",
     ]
     principals {

--- a/aws/workspaces/infra/storage/s3-logs.tf
+++ b/aws/workspaces/infra/storage/s3-logs.tf
@@ -11,6 +11,9 @@ resource "aws_s3_bucket_ownership_controls" "logs" {
   }
 }
 
+# Always SSE-S3: this bucket receives ALB access logs and S3 server access logs,
+# neither of which support SSE-KMS destination buckets (delivery fails / objects
+# remain SSE-S3). Do not switch this bucket to aws:kms.
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
   bucket = aws_s3_bucket.logs.id
   rule {

--- a/aws/workspaces/infra/storage/s3-managed-sync.tf
+++ b/aws/workspaces/infra/storage/s3-managed-sync.tf
@@ -27,8 +27,10 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "managed_sync" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm     = local.s3_kms_enabled ? "aws:kms" : "AES256"
+      kms_master_key_id = local.s3_kms_enabled ? local.s3_kms_key_arn : null
     }
+    bucket_key_enabled = local.s3_kms_enabled ? true : null
   }
 }
 

--- a/aws/workspaces/infra/storage/s3-managed-sync.tf
+++ b/aws/workspaces/infra/storage/s3-managed-sync.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "managed_sync" {
     sid       = "AllowSSLRequestsOnly"
     actions   = ["s3:*"]
     effect    = "Deny"
-    resources = ["${aws_s3_bucket.managed_sync[0].arn}", "${aws_s3_bucket.managed_sync[0].arn}/*"]
+    resources = [aws_s3_bucket.managed_sync[0].arn, "${aws_s3_bucket.managed_sync[0].arn}/*"]
 
     condition {
       test     = "Bool"

--- a/aws/workspaces/infra/storage/variables.tf
+++ b/aws/workspaces/infra/storage/variables.tf
@@ -26,6 +26,23 @@ variable "managed_sync_enabled" {
   type        = bool
 }
 
+variable "s3_kms_encryption_enabled" {
+  description = "Encrypt the app, CDN, audit logs, and managed sync buckets with AWS KMS (SSE-KMS) instead of SSE-S3. The logs bucket always stays on SSE-S3 since ALB and S3 server access logs do not support SSE-KMS."
+  type        = bool
+  default     = false
+}
+
+variable "s3_kms_key_arn" {
+  description = "ARN of an existing KMS key for S3 encryption. When null and s3_kms_encryption_enabled is true, a dedicated KMS key is created."
+  type        = string
+  default     = null
+}
+
+variable "admin_arns" {
+  description = "IAM user/role ARNs with KMS administrative access, including the Terraform caller."
+  type        = list(string)
+}
+
 variable "migrated" {
   description = "Whether the workspace is being migrated from a legacy workspace."
   type        = bool

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -246,6 +246,18 @@ variable "auditlogs_lock_enabled" {
   default     = false
 }
 
+variable "s3_kms_encryption_enabled" {
+  description = "Encrypt the app, CDN, audit logs, and managed sync S3 buckets with AWS KMS (SSE-KMS) instead of S3-managed keys (SSE-S3). Existing deployments default to SSE-S3; enable for new installs or to migrate existing buckets to KMS. The logs bucket always uses SSE-S3 because ALB and S3 server access logs do not support SSE-KMS."
+  type        = bool
+  default     = false
+}
+
+variable "s3_kms_key_arn" {
+  description = "ARN of an existing KMS key to use for S3 bucket encryption. When null and s3_kms_encryption_enabled is true, a dedicated KMS key is created and managed by Terraform. Ignored when s3_kms_encryption_enabled is false."
+  type        = string
+  default     = null
+}
+
 # cloudflare
 variable "cloudflare_api_token" {
   description = "Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Account `Cloudflare Tunnel`, `Access: Organizations, Identity Providers, and Groups`, `Access: Apps and Policies` and Zone `DNS`"
@@ -360,4 +372,27 @@ locals {
   # split instance types by comma, trim, and remove duplicates
   eks_ondemand_node_instance_type = distinct([for value in split(",", var.eks_ondemand_node_instance_type) : trimspace(value)])
   eks_spot_node_instance_type     = distinct([for value in split(",", var.eks_spot_node_instance_type) : trimspace(value)])
+
+  # When using an assumed role the role itself must be referenced instead of the
+  # current session identity arn, otherwise KMS key policies are rejected with
+  # MalformedPolicyDocumentException.
+  is_assumed_role = can(regex("assumed-role", data.aws_caller_identity.current.arn))
+  assumed_role_parts = split(
+    "/",
+    replace(
+      replace(
+        data.aws_caller_identity.current.arn,
+        ":sts:",
+        ":iam:"
+      ),
+      ":assumed-role/",
+      local.is_assumed_role && strcontains(data.aws_caller_identity.current.arn, ":assumed-role/AWSReservedSSO") ? ":role__TEMPORARY_DIVIDER__aws-reserved__TEMPORARY_DIVIDER__sso.amazonaws.com/" : ":role/"
+    )
+  )
+  caller_arn = local.is_assumed_role ? replace(format("%s/%s", local.assumed_role_parts[0], local.assumed_role_parts[1]), "__TEMPORARY_DIVIDER__", "/") : data.aws_caller_identity.current.arn
+
+  admin_arns = distinct(compact(concat(
+    var.eks_admin_arns,
+    [local.caller_arn]
+  )))
 }


### PR DESCRIPTION
### Issues Closed

- PARA-21727

### Brief Summary

add optional kms encryption for s3 buckets

### Detailed Summary

The AWS infra workspace previously encrypted all S3 buckets with S3-managed keys (SSE-S3 / `AES256`). To meet compliance requirements that mandate AWS KMS, this adds an opt-in `s3_kms_encryption_enabled` flag that switches the app, CDN, audit logs, and managed sync buckets to SSE-KMS. Encryption defaults to SSE-S3 so existing deployments are unaffected, and the toggle can be flipped on existing installs to migrate buckets in place.

### Changes

- Add `s3_kms_encryption_enabled` (default `false`) and `s3_kms_key_arn` variables to the AWS infra workspace.
- Switch the app, CDN, audit logs, and managed sync buckets to SSE-KMS when enabled, with S3 Bucket Keys to limit KMS request costs; otherwise keep SSE-S3.
- Create a dedicated customer-managed KMS key (alias `s3/<workspace>`, rotation enabled) when enabled and no key ARN is supplied; otherwise use the provided key.
- Grant the application's S3 IAM user permission to use the key so object read/write keeps working.
- Keep the logs bucket on SSE-S3 because ALB and S3 server access logs do not support SSE-KMS destination buckets.
- Hoist the normalized Terraform caller ARN and the merged admin ARN list to the workspace root, shared by the storage and cluster modules.
- Surface the resolved `kms_key_arn` via the storage and infra outputs.

### Unrelated Changes

Refactored the cluster module to consume the shared root-level caller/admin ARN locals instead of recomputing them. This removes duplication introduced alongside the new S3 KMS key but is not strictly required by the ticket.

### Future Work

- Optionally extend KMS support to the other cloud providers (Azure / GCP) for parity.
- Consider a re-encryption path (e.g. batch copy) to encrypt pre-existing objects, since toggling only affects newly written objects.

### Steps to Test

1. With `s3_kms_encryption_enabled` unset/`false`, run `terraform plan` and confirm buckets remain SSE-S3 with no changes on existing deployments.
2. Set `s3_kms_encryption_enabled = true`, plan/apply, and confirm a KMS key (alias `s3/<workspace>`) is created and the app/cdn/auditlogs/managed-sync buckets use `aws:kms` with bucket keys enabled.
3. Set both `s3_kms_encryption_enabled = true` and `s3_kms_key_arn` to an existing key; confirm no new key is created and buckets use the supplied key.
4. Confirm the logs bucket stays on `AES256` in all cases.
5. Verify the application can still read/write objects (KMS grant on the S3 IAM user).

### QA Notes

The logs bucket intentionally stays on SSE-S3 — ALB access logs and S3 server access logging fail against SSE-KMS destination buckets, so this is by design rather than a miss.

### Deployment Notes

No action required for existing deployments (defaults preserve SSE-S3). To adopt KMS, set `s3_kms_encryption_enabled = true` (and optionally `s3_kms_key_arn`) in the infra workspace tfvars. Toggling on an existing deployment changes bucket default encryption in place; previously written objects keep their existing encryption until rewritten.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> S3/KMS and IAM changes can break object access or leave data unreadable if KMS is disabled after migration; defaults preserve SSE-S3, but enabling or rolling back KMS needs careful ops review.
> 
> **Overview**
> Adds **opt-in SSE-KMS** for the app, CDN, audit logs, and managed sync S3 buckets via `s3_kms_encryption_enabled` (default `false`) and optional `s3_kms_key_arn`. When enabled, Terraform can create a dedicated CMK (`s3/<workspace>`) with bucket keys, grant the app S3 IAM user KMS use, and expose `kms_key_arn` on storage outputs; the **logs bucket stays SSE-S3** (ALB/S3 access log limitation).
> 
> **Admin ARN handling** moves to the workspace root: assumed-role/SSO caller ARN normalization and `admin_arns` (`eks_admin_arns` + Terraform caller) are passed into **storage** (S3 KMS admins) and **cluster** (EKS admins / EBS & cluster KMS key admins) instead of being recomputed in the cluster module.
> 
> **RDS gp3** now omits `iops` / `storage_throughput` below 400 GiB to avoid AWS `InvalidParameterCombination` (only sets 12k/500 or custom pair at ≥400 GiB).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f6b0e24e2802e6366cf08a17fa69fa23933f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->