### PR TITLE
chore(ci): add release-changelog workflow stub

### DIFF
--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -1,0 +1,44 @@
+# Stub so workflow_dispatch registers on the default branch before the full
+# release-changelog pipeline lands. GitHub only exposes workflow_dispatch (and
+# only accepts dispatches against other refs) for workflows whose definition
+# exists on the default branch, so this stub is merged first.
+#
+# The inputs below intentionally mirror the full workflow's inputs so the real
+# implementation can be dispatched from a feature branch via:
+#   gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=...
+#
+# Replace this file with the full release-changelog workflow in a follow-up PR.
+name: release-changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      to_tag:
+        description: "End tag — the release to publish notes for (e.g. 2026.0625.1155-d32adb48). Defaults to the newest tag."
+        required: false
+        type: string
+      from_tag:
+        description: "Start tag — the previous release. Defaults to the tag before to_tag."
+        required: false
+        type: string
+      draft:
+        description: "Publish the GitHub Release as a draft."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release-changelog:
+    name: Stub (no-op)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "release-changelog: no-op stub on the default branch."
+          echo "to_tag input:   ${{ inputs.to_tag }}"
+          echo "from_tag input: ${{ inputs.from_tag }}"
+          echo "Run the full workflow from a branch that includes the implementation:"
+          echo "  gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **no-op stub** for a new `release-changelog` GitHub Actions workflow. This is intentionally minimal and meant to be merged **first**.

### Why a stub PR?

GitHub only exposes a `workflow_dispatch` entry (and only accepts dispatches targeting non-default refs) for workflows whose definition already exists on the **default branch**. Merging this stub registers the `release-changelog` workflow on `main` so that the full implementation (in a follow-up PR) can be:

- triggered manually from the Actions tab, and
- dispatched against a feature branch for testing previous tags via:

```bash
gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=...
```

### What it does

Nothing yet — it just echoes the inputs. The `workflow_dispatch` inputs (`to_tag`, `from_tag`, `draft`) deliberately mirror the upcoming full workflow so dispatches validate cleanly once the real implementation lands.

### Follow-up

The full pipeline (collect merged PRs in the tag window, generate an AI bullet-point summary via the Cursor Agent CLI, and create/update the GitHub Release tied to the tag) replaces this file in a separate PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10f2e7ec-bbd5-4fb7-8deb-d40c7e099fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10f2e7ec-bbd5-4fb7-8deb-d40c7e099fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

