### PR TITLE
feat(ci): release-changelog workflow with AI-generated release notes

### DIFF
--- a/.cursor/commands/changelog.md
+++ b/.cursor/commands/changelog.md
@@ -26,27 +26,37 @@ fences around the whole thing, and **no PDF**.
 
 Structure:
 
-1. A single short intro sentence (one line) summarizing the release at a high
-   level (what changed for users overall).
+1. **Overview** — a 2–4 sentence paragraph (not a bullet) that explains the
+   release at a high level: the main themes, who benefits, and any notable
+   upgrades or behavioural changes operators should know about.
 2. Grouped bullet-point sections. Use only the sections that have content,
    in this order:
    - `### Features` — new capabilities.
    - `### Improvements` — enhancements, performance, refactors that users feel.
    - `### Bug Fixes` — corrected behaviour.
    - `### Maintenance` — dependency bumps, chores, internal/CI changes.
-3. Each change is one bullet. End the relevant bullets with the PR reference in
+3. Each change is one bullet, written as **1–2 full sentences** that describe
+   both *what* changed and *why it matters / the user-facing impact* — do not
+   merely restate the PR title. End each bullet with the PR reference in
    parentheses, e.g. `(#169)`. Group multiple related PRs into one bullet when
    it reads better, listing each reference.
 
 ## Writing rules
 
 - **Public-facing tone.** Write for customers/operators of the product, not for
-  the internal team. Describe the user-visible impact, not the implementation.
-- **Be descriptive but concise.** One clear sentence per bullet. Prefer active
-  voice and present tense ("Adds…", "Fixes…", "Upgrades…").
-- **Translate internal jargon.** Expand or drop ticket prefixes (e.g. `PARA-123`),
-  internal branch names, and code-only details. Keep version numbers and the
-  names of user-facing components (e.g. OpenObserve, Karpenter, bastion).
+  the internal team. Describe the user-visible impact and the benefit, not the
+  implementation details.
+- **Be descriptive.** Each bullet should give enough context for a reader who did
+  not see the code to understand what changed and what it means for them. Prefer
+  active voice and present tense ("Adds…", "Fixes…", "Upgrades…"). Aim for
+  substance over brevity, but stay on-topic — no filler.
+- **Translate internal jargon.** Expand or drop ticket prefixes (e.g. `PARA-123`)
+  and internal branch names (e.g. `fix/PARA-20911/managed-sync-trial-disabled`
+  → "Fixes managed-sync being incorrectly disabled for trial accounts"). Keep
+  version numbers and the names of user-facing components (e.g. OpenObserve,
+  Karpenter, bastion, AKS, Managed Redis).
+- **Infer impact from context.** Use the PR title, labels, and the commit log to
+  reason about what the change does for the user, and state it plainly.
 - **Categorize from signals.** Use PR labels and conventional-commit prefixes
   (`feat`, `fix`, `chore`, `refactor`, `docs`, `perf`, `ci`) plus the title text
   to choose the section.
@@ -58,17 +68,25 @@ Structure:
 ## Example shape (illustrative only — do not copy the content)
 
 ```markdown
-This release focuses on logging stability and Kubernetes upgrades.
+This release strengthens Azure deployments and improves first-time install
+reliability. Operators on Azure gain managed Redis and more flexible cluster
+networking, while a fix to S3 permissions removes a common blocker on brand-new
+AWS deployments.
 
 ### Features
-- Adds optional bastion host support for private cluster access. (#142)
+- Adds support for Azure Managed Redis and managed-sync deployments, so Azure
+  operators no longer need to self-host Redis and can keep instances in sync
+  automatically. (#157)
 
 ### Improvements
-- Upgrades the managed Kubernetes version to 1.34 for newer node features. (#150)
+- Upgrades the managed Kubernetes version to 1.34, bringing newer node features
+  and longer upstream support. (#150)
 
 ### Bug Fixes
-- Fixes an S3 ACL error that blocked brand-new deployments. (#166)
+- Fixes an S3 ACL error that previously blocked brand-new deployments from
+  provisioning their storage buckets. (#166)
 
 ### Maintenance
-- Bumps the OpenObserve image to v0.91.0. (#169)
+- Bumps the OpenObserve logging image to v0.91.0 for the latest stability and
+  security fixes. (#169)
 ```

--- a/.cursor/commands/changelog.md
+++ b/.cursor/commands/changelog.md
@@ -1,0 +1,74 @@
+# Changelog Generator
+
+Generate a concise, **public-facing** release changelog as Markdown bullet points
+from a set of merged pull requests and their commits.
+
+> Adapted from the `changelog-pdf-generator` agent skill. The PDF-rendering
+> behaviour has been intentionally removed — this command produces **Markdown
+> bullet points only** for use as the body of a GitHub Release.
+
+## Inputs you will be given
+
+The caller appends a data block describing one release window:
+
+- `Repository` — `owner/repo`.
+- `Release` (`to_tag`) and `Previous release` (`from_tag`) — the git tags
+  bounding the window.
+- `Merged pull requests` — a list of PRs merged in the window, each with its
+  number, title, author, and labels.
+- `Commit log` — the raw `git log` between the two tags (titles + bodies),
+  useful for extra context when a PR title is terse.
+
+## What to produce
+
+Output **only** the changelog Markdown — no preamble, no explanation, no code
+fences around the whole thing, and **no PDF**.
+
+Structure:
+
+1. A single short intro sentence (one line) summarizing the release at a high
+   level (what changed for users overall).
+2. Grouped bullet-point sections. Use only the sections that have content,
+   in this order:
+   - `### Features` — new capabilities.
+   - `### Improvements` — enhancements, performance, refactors that users feel.
+   - `### Bug Fixes` — corrected behaviour.
+   - `### Maintenance` — dependency bumps, chores, internal/CI changes.
+3. Each change is one bullet. End the relevant bullets with the PR reference in
+   parentheses, e.g. `(#169)`. Group multiple related PRs into one bullet when
+   it reads better, listing each reference.
+
+## Writing rules
+
+- **Public-facing tone.** Write for customers/operators of the product, not for
+  the internal team. Describe the user-visible impact, not the implementation.
+- **Be descriptive but concise.** One clear sentence per bullet. Prefer active
+  voice and present tense ("Adds…", "Fixes…", "Upgrades…").
+- **Translate internal jargon.** Expand or drop ticket prefixes (e.g. `PARA-123`),
+  internal branch names, and code-only details. Keep version numbers and the
+  names of user-facing components (e.g. OpenObserve, Karpenter, bastion).
+- **Categorize from signals.** Use PR labels and conventional-commit prefixes
+  (`feat`, `fix`, `chore`, `refactor`, `docs`, `perf`, `ci`) plus the title text
+  to choose the section.
+- **Never invent changes.** Only describe what is present in the PRs/commits. If
+  a PR is purely internal noise (e.g. merge commits, formatting), omit it or fold
+  it into `Maintenance`.
+- If there are no meaningful changes, output a single line: `- No notable changes in this release.`
+
+## Example shape (illustrative only — do not copy the content)
+
+```markdown
+This release focuses on logging stability and Kubernetes upgrades.
+
+### Features
+- Adds optional bastion host support for private cluster access. (#142)
+
+### Improvements
+- Upgrades the managed Kubernetes version to 1.34 for newer node features. (#150)
+
+### Bug Fixes
+- Fixes an S3 ACL error that blocked brand-new deployments. (#166)
+
+### Maintenance
+- Bumps the OpenObserve image to v0.91.0. (#169)
+```

--- a/.github/scripts/release-changelog.sh
+++ b/.github/scripts/release-changelog.sh
@@ -203,15 +203,25 @@ $(cat "$ai_input")"
   local model_args=()
   [ -n "${CURSOR_MODEL:-}" ] && model_args=(--model "$CURSOR_MODEL")
 
-  if timeout 420 cursor-agent -p "${model_args[@]}" --output-format text "$prompt" > "$out" 2>"$OUTPUT_DIR/cursor-agent.log"; then
-    # Guard against an empty / whitespace-only response.
-    if [ -s "$out" ] && grep -q '[^[:space:]]' "$out"; then
-      return 0
-    fi
-    log "cursor-agent returned an empty response."
-  else
-    log "cursor-agent invocation failed (see cursor-agent.log)."
+  local agent_log="$OUTPUT_DIR/cursor-agent.log"
+  log "Invoking cursor-agent (model: ${CURSOR_MODEL:-default})..."
+  local rc=0
+  timeout 420 cursor-agent -p "${model_args[@]}" --output-format text "$prompt" \
+    > "$out" 2>"$agent_log" || rc=$?
+
+  if [ "$rc" -eq 0 ] && [ -s "$out" ] && grep -q '[^[:space:]]' "$out"; then
+    return 0
   fi
+
+  # Surface diagnostics directly in the job log (artifacts may be unavailable).
+  if [ "$rc" -ne 0 ]; then
+    log "cursor-agent exited with code ${rc}."
+  else
+    log "cursor-agent returned an empty response."
+  fi
+  log "----- cursor-agent stderr (begin) -----"
+  cat "$agent_log" >&2 || true
+  log "----- cursor-agent stderr (end) -----"
   return 1
 }
 
@@ -261,10 +271,12 @@ publish_release() {
     gh release edit "$to_tag" --repo "$REPO" \
       --notes-file "$body_md" --title "$to_tag" "${draft_flag[@]}"
   else
+    # The git tag already exists (pushed by the release automation), so we do
+    # NOT pass --target: gh attaches the release to the existing tag. Passing a
+    # tag name as --target is rejected (target_commitish must be a branch/SHA).
     log "Creating release ${to_tag}."
     gh release create "$to_tag" --repo "$REPO" \
-      --title "$to_tag" --notes-file "$body_md" \
-      --target "$to_tag" "${draft_flag[@]}"
+      --title "$to_tag" --notes-file "$body_md" "${draft_flag[@]}"
   fi
 }
 

--- a/.github/scripts/release-changelog.sh
+++ b/.github/scripts/release-changelog.sh
@@ -219,6 +219,9 @@ $(cat "$ai_input")"
   else
     log "cursor-agent returned an empty response."
   fi
+  log "----- cursor-agent stdout (begin) -----"
+  cat "$out" >&2 || true
+  log "----- cursor-agent stdout (end) -----"
   log "----- cursor-agent stderr (begin) -----"
   cat "$agent_log" >&2 || true
   log "----- cursor-agent stderr (end) -----"

--- a/.github/scripts/release-changelog.sh
+++ b/.github/scripts/release-changelog.sh
@@ -206,8 +206,12 @@ $(cat "$ai_input")"
   local agent_log="$OUTPUT_DIR/cursor-agent.log"
   log "Invoking cursor-agent (model: ${CURSOR_MODEL:-default})..."
   local rc=0
-  timeout 420 cursor-agent -p "${model_args[@]}" --output-format text "$prompt" \
-    > "$out" 2>"$agent_log" || rc=$?
+  # --trust: the CI checkout is an untrusted workspace; without this the agent
+  #          stops at the "Workspace Trust Required" gate and exits with no output.
+  # --mode ask: read-only Q&A — we only want it to summarize the supplied data,
+  #          never edit the repo or run commands.
+  timeout 420 cursor-agent -p --trust --mode ask "${model_args[@]}" \
+    --output-format text "$prompt" > "$out" 2>"$agent_log" || rc=$?
 
   if [ "$rc" -eq 0 ] && [ -s "$out" ] && grep -q '[^[:space:]]' "$out"; then
     return 0

--- a/.github/scripts/release-changelog.sh
+++ b/.github/scripts/release-changelog.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# release-changelog.sh
+#
+# Builds a GitHub Release body for a tag window:
+#   1. Resolves the from_tag..to_tag window (date-based tags, canary excluded).
+#   2. Collects every merged pull request in the window.
+#   3. Generates a public-facing bullet-point summary with the Cursor Agent CLI
+#      (falls back to a deterministic categorized summary when CURSOR_API_KEY is
+#      absent or the CLI fails).
+#   4. Writes the composed release body, and optionally creates/updates the
+#      GitHub Release tied to to_tag.
+#
+# It is intentionally split into small functions so the tag-resolution and PR
+# collection logic can be exercised locally (see SUBCOMMAND dispatch at bottom).
+#
+# Required environment:
+#   REPO              owner/repo (e.g. useparagon/enterprise-installer)
+#   GH_TOKEN          token with repo scope (for the gh CLI)
+# Optional environment:
+#   INPUT_TO_TAG      explicit end tag    (default: newest stable tag)
+#   INPUT_FROM_TAG    explicit start tag  (default: stable tag before to_tag)
+#   DRAFT             "true" to publish the release as a draft (default: false)
+#   CREATE_RELEASE    "true" to actually create/update the release (default: false)
+#   CURSOR_API_KEY    enables the AI summary; without it a fallback is used
+#   CURSOR_MODEL      optional model passed to cursor-agent
+#   COMMAND_FILE      path to the changelog command (default: .cursor/commands/changelog.md)
+#   OUTPUT_DIR        where artifacts are written (default: ./.release-changelog)
+#   GITHUB_OUTPUT     when set, resolved tags are exported as step outputs
+
+set -euo pipefail
+
+COMMAND_FILE="${COMMAND_FILE:-.cursor/commands/changelog.md}"
+OUTPUT_DIR="${OUTPUT_DIR:-./.release-changelog}"
+TAG_GLOB='20[0-9][0-9].*'
+
+log() { printf '%s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# Newest-first list of stable (non-canary) release tags, by commit creation date.
+stable_tags() {
+  git for-each-ref --sort=-creatordate \
+    --format='%(refname:short)' "refs/tags/${TAG_GLOB}" \
+    | grep -v -- '-canary' || true
+}
+
+# Resolve the to_tag/from_tag window from inputs + the tag list.
+resolve_window() {
+  local tags to_tag from_tag
+  tags="$(stable_tags)"
+  [ -n "$tags" ] || die "No release tags matching '${TAG_GLOB}' found."
+
+  if [ -n "${INPUT_TO_TAG:-}" ]; then
+    to_tag="$INPUT_TO_TAG"
+  else
+    to_tag="$(printf '%s\n' "$tags" | sed -n '1p')"
+  fi
+  git rev-parse -q --verify "refs/tags/${to_tag}" >/dev/null \
+    || die "to_tag '${to_tag}' does not exist."
+
+  if [ -n "${INPUT_FROM_TAG:-}" ]; then
+    from_tag="$INPUT_FROM_TAG"
+  else
+    # First stable tag strictly older than to_tag (by the sorted list order).
+    from_tag="$(printf '%s\n' "$tags" \
+      | awk -v t="$to_tag" 'found{print; exit} $0==t{found=1}')"
+  fi
+
+  if [ -z "$from_tag" ]; then
+    log "No previous tag before '${to_tag}'; using repository root as the start."
+    from_tag="$(git rev-list --max-parents=0 HEAD | tail -n1)"
+  else
+    git rev-parse -q --verify "${from_tag}" >/dev/null \
+      || die "from_tag '${from_tag}' does not exist."
+  fi
+
+  printf '%s\t%s\n' "$from_tag" "$to_tag"
+}
+
+# Emit "* <title> by @<author> in <url>" PR lines for the window using GitHub's
+# release-notes generator, which correctly handles squash- and merge-commits.
+generate_pr_notes() {
+  local from_tag="$1" to_tag="$2"
+  gh api -X POST "repos/${REPO}/releases/generate-notes" \
+    -f tag_name="$to_tag" \
+    -f previous_tag_name="$from_tag" \
+    --jq '.body' 2>/dev/null || true
+}
+
+# Extract unique PR numbers (newest-first preserved) from generated notes.
+pr_numbers_from_notes() {
+  grep -oE 'pull/[0-9]+' | sed 's#pull/##' | awk '!seen[$0]++'
+}
+
+build_changelog() {
+  mkdir -p "$OUTPUT_DIR"
+
+  local window from_tag to_tag
+  window="$(resolve_window)"
+  from_tag="$(printf '%s' "$window" | cut -f1)"
+  to_tag="$(printf '%s' "$window" | cut -f2)"
+  log "Resolved window: ${from_tag} -> ${to_tag}"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+      echo "from_tag=${from_tag}"
+      echo "to_tag=${to_tag}"
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  # --- Collect merged PRs --------------------------------------------------
+  local notes pr_numbers pr_list_md
+  notes="$(generate_pr_notes "$from_tag" "$to_tag")"
+  pr_numbers="$(printf '%s\n' "$notes" | pr_numbers_from_notes)"
+
+  pr_list_md="$OUTPUT_DIR/pr-list.md"
+  : > "$pr_list_md"
+  if [ -n "$pr_numbers" ]; then
+    while IFS= read -r num; do
+      [ -n "$num" ] || continue
+      gh pr view "$num" --repo "$REPO" \
+        --json number,title,author,url,labels \
+        --jq '"- [#\(.number)](\(.url)) \(.title) — @\(.author.login)"' \
+        2>/dev/null >> "$pr_list_md" || true
+    done <<< "$pr_numbers"
+  fi
+  if [ ! -s "$pr_list_md" ]; then
+    # Fallback: derive PR references straight from commit messages in the range.
+    git log --pretty='%s' "${from_tag}..${to_tag}" \
+      | grep -oE '#[0-9]+' | sort -u \
+      | sed 's/^/- /' >> "$pr_list_md" || true
+  fi
+  [ -s "$pr_list_md" ] || echo "- No merged pull requests found in this window." > "$pr_list_md"
+  log "Collected $(grep -c '^-' "$pr_list_md" || echo 0) PR entries."
+
+  # --- Build the data block the AI/fallback summarizes ---------------------
+  local ai_input="$OUTPUT_DIR/ai-input.md"
+  {
+    echo "Repository: ${REPO}"
+    echo "Release (to_tag): ${to_tag}"
+    echo "Previous release (from_tag): ${from_tag}"
+    echo
+    echo "Merged pull requests:"
+    if [ -n "$pr_numbers" ]; then
+      while IFS= read -r num; do
+        [ -n "$num" ] || continue
+        gh pr view "$num" --repo "$REPO" \
+          --json number,title,author,labels \
+          --jq '"- #\(.number) \(.title) [labels: \([.labels[].name] | join(", "))] (@\(.author.login))"' \
+          2>/dev/null || true
+      done <<< "$pr_numbers"
+    else
+      cat "$pr_list_md"
+    fi
+    echo
+    echo "Commit log (no-merge commits):"
+    git log --no-merges --pretty='- %s' "${from_tag}..${to_tag}" | head -300
+  } > "$ai_input"
+
+  # --- Generate the summary ------------------------------------------------
+  local summary_md="$OUTPUT_DIR/summary.md"
+  if generate_ai_summary "$ai_input" "$summary_md"; then
+    log "AI summary generated."
+  else
+    log "Falling back to deterministic summary."
+    fallback_summary "$ai_input" "$summary_md"
+  fi
+
+  # --- Compose the release body -------------------------------------------
+  local body_md="$OUTPUT_DIR/release-body.md"
+  {
+    cat "$summary_md"
+    echo
+    echo "## Merged Pull Requests"
+    echo
+    cat "$pr_list_md"
+    echo
+    echo "---"
+    echo "_**Full Changelog**: https://github.com/${REPO}/compare/${from_tag}...${to_tag}_"
+  } > "$body_md"
+
+  log "Release body written to ${body_md}"
+
+  if [ "${CREATE_RELEASE:-false}" = "true" ]; then
+    publish_release "$to_tag" "$body_md"
+  fi
+
+  printf '%s\n' "$body_md"
+}
+
+# Run cursor-agent over the data block; returns non-zero to trigger the fallback.
+generate_ai_summary() {
+  local ai_input="$1" out="$2"
+  [ -n "${CURSOR_API_KEY:-}" ] || { log "CURSOR_API_KEY not set."; return 1; }
+  command -v cursor-agent >/dev/null 2>&1 || { log "cursor-agent not on PATH."; return 1; }
+  [ -f "$COMMAND_FILE" ] || { log "Command file ${COMMAND_FILE} missing."; return 1; }
+
+  local prompt
+  prompt="$(cat "$COMMAND_FILE")
+$(printf '\n---\nGenerate the changelog for the following release window. Output Markdown bullet points only.\n\n')
+$(cat "$ai_input")"
+
+  local model_args=()
+  [ -n "${CURSOR_MODEL:-}" ] && model_args=(--model "$CURSOR_MODEL")
+
+  if timeout 420 cursor-agent -p "${model_args[@]}" --output-format text "$prompt" > "$out" 2>"$OUTPUT_DIR/cursor-agent.log"; then
+    # Guard against an empty / whitespace-only response.
+    if [ -s "$out" ] && grep -q '[^[:space:]]' "$out"; then
+      return 0
+    fi
+    log "cursor-agent returned an empty response."
+  else
+    log "cursor-agent invocation failed (see cursor-agent.log)."
+  fi
+  return 1
+}
+
+# Deterministic categorized summary from conventional-commit prefixes / labels.
+fallback_summary() {
+  local ai_input="$1" out="$2"
+  awk '
+    BEGIN {
+      feat=""; imp=""; fix=""; maint="";
+    }
+    /^- #/ {
+      line=$0
+      # Strip the leading "- #NNN " marker, keep "#NNN" reference for output.
+      num=$2
+      title=$0
+      sub(/^- #[0-9]+ /, "", title)
+      # Drop the trailing [labels: ...] (@author) annotation for readability.
+      sub(/ \[labels:.*$/, "", title)
+      ref=" (" num ")"
+      lower=tolower(title)
+      if (lower ~ /^feat/)                       feat = feat "- " title ref "\n"
+      else if (lower ~ /^fix/)                   fix  = fix  "- " title ref "\n"
+      else if (lower ~ /^(perf|refactor|improve)/) imp = imp "- " title ref "\n"
+      else if (lower ~ /^(chore|ci|build|docs|style|test)/) maint = maint "- " title ref "\n"
+      else                                       imp  = imp  "- " title ref "\n"
+    }
+    END {
+      print "This release includes the following changes."
+      print ""
+      if (feat  != "") { print "### Features";     printf "%s\n", feat }
+      if (imp   != "") { print "### Improvements"; printf "%s\n", imp }
+      if (fix   != "") { print "### Bug Fixes";    printf "%s\n", fix }
+      if (maint != "") { print "### Maintenance";  printf "%s\n", maint }
+      if (feat=="" && imp=="" && fix=="" && maint=="")
+        print "- No notable changes in this release."
+    }
+  ' "$ai_input" > "$out"
+}
+
+publish_release() {
+  local to_tag="$1" body_md="$2"
+  local draft_flag=()
+  [ "${DRAFT:-false}" = "true" ] && draft_flag=(--draft)
+
+  if gh release view "$to_tag" --repo "$REPO" >/dev/null 2>&1; then
+    log "Updating existing release ${to_tag}."
+    gh release edit "$to_tag" --repo "$REPO" \
+      --notes-file "$body_md" --title "$to_tag" "${draft_flag[@]}"
+  else
+    log "Creating release ${to_tag}."
+    gh release create "$to_tag" --repo "$REPO" \
+      --title "$to_tag" --notes-file "$body_md" \
+      --target "$to_tag" "${draft_flag[@]}"
+  fi
+}
+
+main() {
+  local cmd="${1:-build}"
+  case "$cmd" in
+    resolve-window) resolve_window ;;
+    stable-tags)    stable_tags ;;
+    build)          build_changelog ;;
+    *) die "Unknown subcommand: ${cmd} (expected: resolve-window | stable-tags | build)" ;;
+  esac
+}
+
+main "$@"

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -1,13 +1,28 @@
-# Stub so workflow_dispatch registers on the default branch before the full
-# release-changelog pipeline lands. GitHub only exposes workflow_dispatch (and
-# only accepts dispatches against other refs) for workflows whose definition
-# exists on the default branch, so this stub is merged first.
+# Release Changelog
 #
-# The inputs below intentionally mirror the full workflow's inputs so the real
-# implementation can be dispatched from a feature branch via:
-#   gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=...
+# Publishes a GitHub Release for the newest release tag, listing every merged
+# pull request in the tag window and an AI-generated, public-facing bullet-point
+# summary produced by the Cursor Agent CLI (cursor-agent).
 #
-# Replace this file with the full release-changelog workflow in a follow-up PR.
+# Tags in this repo are date-based (YYYY.MMDD.HHMM-<sha8>) and are pushed by the
+# external release automation on each main-branch push; canary tags
+# (…-canary) are ignored. The release is created against — and therefore tied
+# to — the resolved to_tag.
+#
+# Triggers:
+#   * push to main      — auto-publishes notes for the latest tag window. The
+#                         release tag is created by external automation shortly
+#                         after the push, so this job waits briefly for it.
+#   * workflow_dispatch  — manual run; pass to_tag/from_tag to (re)generate notes
+#                         for any historical window. This is the path used to
+#                         test the workflow from a feature branch:
+#                           gh workflow run release-changelog.yaml \
+#                             --ref <branch> -f to_tag=... -f from_tag=...
+#
+# Secrets / config:
+#   CURSOR_API_KEY (optional) — enables the AI summary. Without it the job still
+#                               succeeds using a deterministic categorized
+#                               fallback summary.
 name: release-changelog
 
 on:
@@ -26,19 +41,107 @@ on:
         required: false
         type: boolean
         default: false
+  push:
+    branches: [main]
 
 permissions:
-  contents: read
+  contents: write
+
+concurrency:
+  group: release-changelog
+  cancel-in-progress: false
 
 jobs:
   release-changelog:
-    name: Stub (no-op)
+    name: Publish release changelog
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Wait for the new release tag (push events only)
+        if: ${{ github.event_name == 'push' }}
+        env:
+          BASELINE_SHA: ${{ github.sha }}
         run: |
-          echo "release-changelog: no-op stub on the default branch."
-          echo "to_tag input:   ${{ inputs.to_tag }}"
-          echo "from_tag input: ${{ inputs.from_tag }}"
-          echo "Run the full workflow from a branch that includes the implementation:"
-          echo "  gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=..."
+          set -euo pipefail
+          # The external release automation creates the date tag on a follow-up
+          # commit a short time after this push. Poll for a stable tag newer than
+          # what we have, up to ~6 minutes, before giving up and using the newest
+          # tag already available.
+          newest_stable() {
+            git fetch --tags --quiet origin || true
+            git for-each-ref --sort=-creatordate \
+              --format='%(refname:short)' 'refs/tags/20[0-9][0-9].*' \
+              | grep -v -- '-canary' | head -1 || true
+          }
+          start_tag="$(newest_stable)"
+          echo "Newest stable tag at start: ${start_tag:-<none>}"
+          for i in $(seq 1 24); do
+            current="$(newest_stable)"
+            if [ -n "$current" ] && [ "$current" != "$start_tag" ]; then
+              echo "New release tag detected: $current"
+              exit 0
+            fi
+            echo "Attempt $i: no new tag yet (latest: ${current:-<none>}); sleeping 15s."
+            sleep 15
+          done
+          echo "::warning::No new release tag appeared; proceeding with the latest available tag."
+
+      - name: Install Cursor Agent CLI
+        run: |
+          set -euo pipefail
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Cursor Agent CLI
+        run: |
+          set -euo pipefail
+          if command -v cursor-agent >/dev/null 2>&1; then
+            cursor-agent --version || true
+          else
+            echo "::warning::cursor-agent not found on PATH; the deterministic fallback summary will be used."
+          fi
+
+      - name: Generate changelog and publish release
+        id: changelog
+        env:
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TO_TAG: ${{ inputs.to_tag }}
+          INPUT_FROM_TAG: ${{ inputs.from_tag }}
+          DRAFT: ${{ inputs.draft }}
+          CREATE_RELEASE: "true"
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          bash .github/scripts/release-changelog.sh build
+
+      - name: Job summary
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Release Changelog"
+            if [ -f .release-changelog/release-body.md ]; then
+              echo "- **Window:** \`${{ steps.changelog.outputs.from_tag }}\` → \`${{ steps.changelog.outputs.to_tag }}\`"
+              echo ""
+              echo "<details><summary>Generated release body</summary>"
+              echo ""
+              cat .release-changelog/release-body.md
+              echo ""
+              echo "</details>"
+            else
+              echo "No release body was produced."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload changelog artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-changelog
+          path: .release-changelog/
+          if-no-files-found: ignore

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -1,0 +1,44 @@
+# Stub so workflow_dispatch registers on the default branch before the full
+# release-changelog pipeline lands. GitHub only exposes workflow_dispatch (and
+# only accepts dispatches against other refs) for workflows whose definition
+# exists on the default branch, so this stub is merged first.
+#
+# The inputs below intentionally mirror the full workflow's inputs so the real
+# implementation can be dispatched from a feature branch via:
+#   gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=...
+#
+# Replace this file with the full release-changelog workflow in a follow-up PR.
+name: release-changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      to_tag:
+        description: "End tag — the release to publish notes for (e.g. 2026.0625.1155-d32adb48). Defaults to the newest tag."
+        required: false
+        type: string
+      from_tag:
+        description: "Start tag — the previous release. Defaults to the tag before to_tag."
+        required: false
+        type: string
+      draft:
+        description: "Publish the GitHub Release as a draft."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release-changelog:
+    name: Stub (no-op)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "release-changelog: no-op stub on the default branch."
+          echo "to_tag input:   ${{ inputs.to_tag }}"
+          echo "from_tag input: ${{ inputs.from_tag }}"
+          echo "Run the full workflow from a branch that includes the implementation:"
+          echo "  gh workflow run release-changelog.yaml --ref <branch> -f to_tag=... -f from_tag=..."

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -144,4 +144,5 @@ jobs:
         with:
           name: release-changelog
           path: .release-changelog/
+          include-hidden-files: true
           if-no-files-found: ignore

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -116,6 +116,8 @@ jobs:
           DRAFT: ${{ inputs.draft }}
           CREATE_RELEASE: "true"
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          # Claude 4.5 Sonnet (Thinking) — the reasoning-enabled Sonnet in the CLI.
+          CURSOR_MODEL: sonnet-4.5-thinking
         run: |
           set -euo pipefail
           bash .github/scripts/release-changelog.sh build

--- a/.github/workflows/release-changelog.yaml
+++ b/.github/workflows/release-changelog.yaml
@@ -116,8 +116,8 @@ jobs:
           DRAFT: ${{ inputs.draft }}
           CREATE_RELEASE: "true"
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
-          # Claude 4.5 Sonnet (Thinking) — the reasoning-enabled Sonnet in the CLI.
-          CURSOR_MODEL: sonnet-4.5-thinking
+          # Reasoning-enabled Sonnet model available to this account's CLI.
+          CURSOR_MODEL: claude-4-sonnet-thinking
         run: |
           set -euo pipefail
           bash .github/scripts/release-changelog.sh build

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ build/
 # ignore IDE files
 .cursor/*
 !.cursor/skills/
+!.cursor/commands/
 .idea/
 .vscode/
 
@@ -60,3 +61,6 @@ node_modules/
 
 # atlas generated service-inputs.json files
 charts/*/**/files/service-inputs.json
+
+# release-changelog workflow scratch output
+.release-changelog/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

## Issue Closed
[PARA-20580](https://useparagon.atlassian.net/browse/PARA-20580)
## Summary

Implements the full **`release-changelog`** GitHub Actions pipeline that publishes a GitHub Release on each `main` push, tied to the release tag, listing every merged pull request plus an AI-generated, public-facing bullet-point summary.

> Builds on the stub in #176 (merge that first so `workflow_dispatch` is registered on `main`).

## What it does

For a resolved `from_tag..to_tag` window the workflow:

1. **Resolves the tag window** — date-based release tags (`YYYY.MMDD.HHMM-<sha8>`), sorted by commit-creation date, with `-canary` tags excluded. `to_tag` defaults to the newest tag; `from_tag` to the one before it. Both can be overridden via dispatch inputs.
2. **Lists every merged PR** in the window using GitHub's release-notes generator (handles squash- and merge-commits), enriched with PR title/author/labels.
3. **Generates an AI summary** with the **Cursor Agent CLI** (`cursor-agent -p --output-format text`) driven by `.cursor/commands/changelog.md`. Produces grouped, public-facing bullet points (Features / Improvements / Bug Fixes / Maintenance).
4. **Creates/updates the GitHub Release** against the resolved `to_tag`, so the release is tied to the git tag. The body = AI summary + the full PR list + a compare link.

## Triggers

- **`push` to `main`** — auto-publishes notes for the latest tag window. Since the external release automation creates the date tag on a follow-up commit shortly after the push, the job waits (polls) up to ~6 minutes for the new tag before proceeding.
- **`workflow_dispatch`** — manual; pass `to_tag` / `from_tag` to (re)generate notes for any historical window. This is the path used to test from a feature branch:

```bash
gh workflow run release-changelog.yaml --ref cursor/release-changelog-workflow-9fc1 \
  -f to_tag=2026.0623.1208-de9100a6 -f from_tag=2026.0608.1108-f0557563
```

## Files

- `.github/workflows/release-changelog.yaml` — the workflow (replaces the stub).
- `.github/scripts/release-changelog.sh` — locally testable orchestration (`resolve-window`, `stable-tags`, `build` subcommands). Passes `shellcheck`.
- `.cursor/commands/changelog.md` — the `changelog-pdf-generator` skill adapted into a command: **PDF output removed**, bullet-point Markdown only, public-facing tone.
- `.gitignore` — un-ignores `.cursor/commands/`.

## Secrets

- **`CURSOR_API_KEY`** (optional but required for the AI summary) — must be added to repo secrets. Without it the job still succeeds using a deterministic categorized fallback summary.

## Local verification

Tag resolution, PR collection, the AI path (stubbed `cursor-agent`) and the deterministic fallback were all exercised locally against real tags; `shellcheck` is clean. The live AI run requires `CURSOR_API_KEY` in CI.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10f2e7ec-bbd5-4fb7-8deb-d40c7e099fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10f2e7ec-bbd5-4fb7-8deb-d40c7e099fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[PARA-20580]: https://useparagon.atlassian.net/browse/PARA-20580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ