### PR TITLE
Support private container registry and Artifactory image proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,35 @@ After running `prepare.sh`, you need to configure the following files before run
 
 3. **`{provider}/workspaces/paragon/.secure/values.yaml`** - Helm values containing Paragon application configuration and secrets (VERSION, LICENSE, and all environment variables). This file is created from `charts/values.placeholder.yaml` - see that file for the complete list of configurable values.
 
+### Private container registry (Artifactory / proxy)
+
+To pull images through a customer-provided registry (e.g. Artifactory) instead of public upstreams, configure `global` settings in `.secure/values.yaml`:
+
+```yaml
+global:
+  imageRegistry: artifactory.example.com/paragon
+  imageRepositoryPrefix: ""   # omit key entirely to keep useparagon/ in paths
+  imagePullSecrets:
+    - name: workday-af-secret
+```
+
+- **`imageRegistry`** — prepended to image repository paths (host and optional remote-repo path).
+- **`imageRepositoryPrefix`** — when set (including `""`), rewrites the default `useparagon/` prefix. Omit to preserve `useparagon/` in mirrored paths.
+- **`imagePullSecrets`** — merged with per-chart pull secrets on all workloads, jobs, and hooks.
+- **`testImage`** / **`kubectlImage`** — override busybox (helm tests) and alpine/kubectl (restart cron) defaults.
+
+Per-subchart `image.repository` overrides remain available for third-party images with non-standard mirror paths.
+
+**Terraform pull credentials** (in `vars.auto.tfvars`):
+
+```hcl
+docker_registry_server   = "artifactory.example.com"  # must match imageRegistry host
+docker_pull_secret_name  = "docker-cfg"               # or customer secret name
+create_docker_pull_secret = true                      # false if secret is pre-provisioned
+```
+
+Verify rendered images with `helm template` and grep for unexpected upstream hosts (`docker.io`, `ghcr.io`, `public.ecr.aws`, etc.).
+
 ## Usage
 
 ### Infrastructure Provisioning

--- a/aws/workspaces/paragon/README.md
+++ b/aws/workspaces/paragon/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.70 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_hoop"></a> [hoop](#requirement\_hoop) | >= 0.0.19 |
@@ -46,11 +46,13 @@
 | <a name="input_certificate"></a> [certificate](#input\_certificate) | Optional ACM certificate ARN of an existing certificate to use with the load balancer. | `string` | `null` | no |
 | <a name="input_cloudflare_dns_api_token"></a> [cloudflare\_dns\_api\_token](#input\_cloudflare\_dns\_api\_token) | Cloudflare DNS API token for SSL certificate creation and verification. | `string` | `null` | no |
 | <a name="input_cloudflare_zone_id"></a> [cloudflare\_zone\_id](#input\_cloudflare\_zone\_id) | Cloudflare zone id to set CNAMEs. | `string` | `null` | no |
+| <a name="input_create_docker_pull_secret"></a> [create\_docker\_pull\_secret](#input\_create\_docker\_pull\_secret) | Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm\_values. | `bool` | `true` | no |
 | <a name="input_customer_facing"></a> [customer\_facing](#input\_customer\_facing) | Whether the connections are customer-facing (true limits access to dev-team-oncall/dev-team-managers/admin, false adds dev-team-engineering). | `bool` | `true` | no |
 | <a name="input_dns_provider"></a> [dns\_provider](#input\_dns\_provider) | DNS provider to use. | `string` | `"none"` | no |
 | <a name="input_docker_email"></a> [docker\_email](#input\_docker\_email) | Docker email to pull images. | `string` | n/a | yes |
 | <a name="input_docker_password"></a> [docker\_password](#input\_docker\_password) | Docker password to pull images. | `string` | n/a | yes |
-| <a name="input_docker_registry_server"></a> [docker\_registry\_server](#input\_docker\_registry\_server) | Docker container registry server. | `string` | `"docker.io"` | no |
+| <a name="input_docker_pull_secret_name"></a> [docker\_pull\_secret\_name](#input\_docker\_pull\_secret\_name) | Kubernetes secret name for registry pull credentials. | `string` | `"docker-cfg"` | no |
+| <a name="input_docker_registry_server"></a> [docker\_registry\_server](#input\_docker\_registry\_server) | Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry. | `string` | `"docker.io"` | no |
 | <a name="input_docker_username"></a> [docker\_username](#input\_docker\_username) | Docker username to pull images. | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | The root domain used for the microservices. | `string` | n/a | yes |
 | <a name="input_excluded_microservices"></a> [excluded\_microservices](#input\_excluded\_microservices) | The microservices that should be excluded from the deployment. | `list(string)` | `[]` | no |

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -103,6 +103,13 @@ locals {
     }
   })
 
+  docker_pull_secret_global_values = var.create_docker_pull_secret ? {
+    imagePullSecrets = concat(
+      try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
+      [{ name = var.docker_pull_secret_name }]
+    )
+  } : {}
+
   global_values = yamlencode({
     global = merge(
       nonsensitive(var.helm_values.global),
@@ -116,21 +123,20 @@ locals {
         ),
         paragon_version = local.version
       },
-      var.create_docker_pull_secret ? {
-        imagePullSecrets = concat(
-          try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
-          [{ name = var.docker_pull_secret_name }]
-        )
-      } : {}
+      local.docker_pull_secret_global_values
     )
   })
 
   global_values_minus_env = yamlencode(merge(
     nonsensitive(var.helm_values),
     {
-      global = merge(nonsensitive(var.helm_values).global, { env = {
-        HOST_ENV = "AWS_K8"
-      } })
+      global = merge(
+        nonsensitive(var.helm_values).global,
+        { env = {
+          HOST_ENV = "AWS_K8"
+        } },
+        local.docker_pull_secret_global_values
+      )
     }
   ))
 

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -162,10 +162,12 @@ resource "kubernetes_config_map" "feature_flag_content" {
   }
 }
 
-# kubernetes secret to pull docker image from docker hub
+# kubernetes secret to pull container images from a registry (Docker Hub, Artifactory, etc.)
 resource "kubernetes_secret" "docker_login" {
+  count = var.create_docker_pull_secret ? 1 : 0
+
   metadata {
-    name      = "docker-cfg"
+    name      = var.docker_pull_secret_name
     namespace = kubernetes_namespace.paragon.id
   }
 

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -115,7 +115,13 @@ locals {
           }
         ),
         paragon_version = local.version
-      }
+      },
+      var.create_docker_pull_secret ? {
+        imagePullSecrets = concat(
+          try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
+          [{ name = var.docker_pull_secret_name }]
+        )
+      } : {}
     )
   })
 

--- a/aws/workspaces/paragon/helm/variables.tf
+++ b/aws/workspaces/paragon/helm/variables.tf
@@ -14,8 +14,20 @@ variable "cluster_name" {
 }
 
 variable "docker_registry_server" {
-  description = "Docker container registry server."
+  description = "Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry."
   type        = string
+}
+
+variable "docker_pull_secret_name" {
+  description = "Kubernetes secret name for registry pull credentials."
+  type        = string
+  default     = "docker-cfg"
+}
+
+variable "create_docker_pull_secret" {
+  description = "Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm_values."
+  type        = bool
+  default     = true
 }
 
 variable "docker_username" {

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -32,31 +32,33 @@ module "alb" {
 module "helm" {
   source = "./helm"
 
-  certificate            = module.alb.certificate
-  aws_region             = var.aws_region
-  cluster_name           = local.cluster_name
-  docker_email           = var.docker_email
-  docker_password        = var.docker_password
-  docker_registry_server = var.docker_registry_server
-  docker_username        = var.docker_username
-  feature_flags_content  = local.feature_flags_content
-  flipt_options          = local.flipt_options
-  helm_values            = local.helm_values
-  ingress_scheme         = var.ingress_scheme
-  k8s_version            = var.k8s_version
-  logs_bucket            = local.logs_bucket
-  managed_sync_enabled   = var.managed_sync_enabled
-  managed_sync_version   = var.managed_sync_version
-  microservices          = local.microservices
-  monitor_version        = local.monitor_version
-  monitors               = local.monitors
-  monitors_enabled       = var.monitors_enabled
-  openobserve_email      = var.openobserve_email
-  openobserve_password   = var.openobserve_password
-  public_microservices   = local.public_microservices
-  public_monitors        = local.public_monitors
-  waf_web_acl_arn        = local.waf_active ? module.waf[0].web_acl_arn : ""
-  workspace              = local.workspace
+  certificate               = module.alb.certificate
+  aws_region                = var.aws_region
+  cluster_name              = local.cluster_name
+  docker_email              = var.docker_email
+  docker_password           = var.docker_password
+  docker_registry_server    = var.docker_registry_server
+  docker_pull_secret_name   = var.docker_pull_secret_name
+  create_docker_pull_secret = var.create_docker_pull_secret
+  docker_username           = var.docker_username
+  feature_flags_content     = local.feature_flags_content
+  flipt_options             = local.flipt_options
+  helm_values               = local.helm_values
+  ingress_scheme            = var.ingress_scheme
+  k8s_version               = var.k8s_version
+  logs_bucket               = local.logs_bucket
+  managed_sync_enabled      = var.managed_sync_enabled
+  managed_sync_version      = var.managed_sync_version
+  microservices             = local.microservices
+  monitor_version           = local.monitor_version
+  monitors                  = local.monitors
+  monitors_enabled          = var.monitors_enabled
+  openobserve_email         = var.openobserve_email
+  openobserve_password      = var.openobserve_password
+  public_microservices      = local.public_microservices
+  public_monitors           = local.public_monitors
+  waf_web_acl_arn           = local.waf_active ? module.waf[0].web_acl_arn : ""
+  workspace                 = local.workspace
 }
 
 module "managed_sync_config" {

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -36,9 +36,21 @@ variable "certificate" {
 }
 
 variable "docker_registry_server" {
-  description = "Docker container registry server."
+  description = "Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry."
   type        = string
   default     = "docker.io"
+}
+
+variable "docker_pull_secret_name" {
+  description = "Kubernetes secret name for registry pull credentials."
+  type        = string
+  default     = "docker-cfg"
+}
+
+variable "create_docker_pull_secret" {
+  description = "Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm_values."
+  type        = bool
+  default     = true
 }
 
 variable "docker_username" {

--- a/azure/workspaces/paragon/README.md
+++ b/azure/workspaces/paragon/README.md
@@ -20,12 +20,11 @@ Do not commit real secrets to git. Prefer environment variables or a secret mana
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
 | <a name="requirement_hoop"></a> [hoop](#requirement\_hoop) | >= 0.0.19 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
@@ -60,10 +59,12 @@ Do not commit real secrets to git. Prefer environment variables or a secret mana
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | Azure tenant ID | `string` | n/a | yes |
 | <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Zone `DNS` | `string` | `null` | no |
 | <a name="input_cloudflare_zone_id"></a> [cloudflare\_zone\_id](#input\_cloudflare\_zone\_id) | Cloudflare zone id to set CNAMEs. | `string` | `null` | no |
+| <a name="input_create_docker_pull_secret"></a> [create\_docker\_pull\_secret](#input\_create\_docker\_pull\_secret) | Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm\_values. | `bool` | `true` | no |
 | <a name="input_customer_facing"></a> [customer\_facing](#input\_customer\_facing) | Whether the connections are customer-facing (true limits access to dev-team-oncall/dev-team-managers/admin, false adds dev-team-engineering). | `bool` | `true` | no |
 | <a name="input_docker_email"></a> [docker\_email](#input\_docker\_email) | Docker email to pull images. | `string` | n/a | yes |
 | <a name="input_docker_password"></a> [docker\_password](#input\_docker\_password) | Docker password to pull images. | `string` | n/a | yes |
-| <a name="input_docker_registry_server"></a> [docker\_registry\_server](#input\_docker\_registry\_server) | Docker container registry server. | `string` | `"docker.io"` | no |
+| <a name="input_docker_pull_secret_name"></a> [docker\_pull\_secret\_name](#input\_docker\_pull\_secret\_name) | Kubernetes secret name for registry pull credentials. | `string` | `"docker-cfg"` | no |
+| <a name="input_docker_registry_server"></a> [docker\_registry\_server](#input\_docker\_registry\_server) | Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry. | `string` | `"docker.io"` | no |
 | <a name="input_docker_username"></a> [docker\_username](#input\_docker\_username) | Docker username to pull images. | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | The root domain used for the microservices. | `string` | n/a | yes |
 | <a name="input_excluded_microservices"></a> [excluded\_microservices](#input\_excluded\_microservices) | The microservices that should be excluded from the deployment. | `list(string)` | `[]` | no |

--- a/azure/workspaces/paragon/helm/helm.tf
+++ b/azure/workspaces/paragon/helm/helm.tf
@@ -161,10 +161,12 @@ resource "kubernetes_config_map" "feature_flag_content" {
   }
 }
 
-# kubernetes secret to pull docker image from docker hub
+# kubernetes secret to pull container images from a registry (Docker Hub, Artifactory, etc.)
 resource "kubernetes_secret" "docker_login" {
+  count = var.create_docker_pull_secret ? 1 : 0
+
   metadata {
-    name      = "docker-cfg"
+    name      = var.docker_pull_secret_name
     namespace = kubernetes_namespace.paragon.id
   }
 

--- a/azure/workspaces/paragon/helm/helm.tf
+++ b/azure/workspaces/paragon/helm/helm.tf
@@ -118,7 +118,13 @@ locals {
           }
         ),
         paragon_version = local.version
-      }
+      },
+      var.create_docker_pull_secret ? {
+        imagePullSecrets = concat(
+          try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
+          [{ name = var.docker_pull_secret_name }]
+        )
+      } : {}
     )
   })
 

--- a/azure/workspaces/paragon/helm/helm.tf
+++ b/azure/workspaces/paragon/helm/helm.tf
@@ -106,6 +106,13 @@ locals {
     }
   })
 
+  docker_pull_secret_global_values = var.create_docker_pull_secret ? {
+    imagePullSecrets = concat(
+      try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
+      [{ name = var.docker_pull_secret_name }]
+    )
+  } : {}
+
   global_values = yamlencode({
     global = merge(
       nonsensitive(var.helm_values.global),
@@ -119,21 +126,20 @@ locals {
         ),
         paragon_version = local.version
       },
-      var.create_docker_pull_secret ? {
-        imagePullSecrets = concat(
-          try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
-          [{ name = var.docker_pull_secret_name }]
-        )
-      } : {}
+      local.docker_pull_secret_global_values
     )
   })
 
   global_values_minus_env = yamlencode(merge(
     nonsensitive(var.helm_values),
     {
-      global = merge(nonsensitive(var.helm_values).global, { env = {
-        HOST_ENV = "AZURE_K8"
-      } })
+      global = merge(
+        nonsensitive(var.helm_values).global,
+        { env = {
+          HOST_ENV = "AZURE_K8"
+        } },
+        local.docker_pull_secret_global_values
+      )
     }
   ))
 

--- a/azure/workspaces/paragon/helm/variables.tf
+++ b/azure/workspaces/paragon/helm/variables.tf
@@ -13,8 +13,20 @@ variable "cluster_name" {
 }
 
 variable "docker_registry_server" {
-  description = "Docker container registry server."
+  description = "Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry."
   type        = string
+}
+
+variable "docker_pull_secret_name" {
+  description = "Kubernetes secret name for registry pull credentials."
+  type        = string
+  default     = "docker-cfg"
+}
+
+variable "create_docker_pull_secret" {
+  description = "Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm_values."
+  type        = bool
+  default     = true
 }
 
 variable "docker_username" {

--- a/azure/workspaces/paragon/modules.tf
+++ b/azure/workspaces/paragon/modules.tf
@@ -1,29 +1,31 @@
 module "helm" {
   source = "./helm"
 
-  cluster_name           = local.cluster_name
-  docker_email           = var.docker_email
-  docker_password        = var.docker_password
-  docker_registry_server = var.docker_registry_server
-  docker_username        = var.docker_username
-  feature_flags_content  = local.feature_flags_content
-  flipt_options          = local.flipt_options
-  helm_values            = local.helm_values
-  ingress_scheme         = var.ingress_scheme
-  k8s_version            = var.k8s_version
-  logs_bucket            = local.logs_bucket
-  managed_sync_enabled   = var.managed_sync_enabled
-  managed_sync_version   = var.managed_sync_version
-  microservices          = local.microservices
-  monitor_version        = local.monitor_version
-  monitors               = local.monitors
-  monitors_enabled       = var.monitors_enabled
-  openobserve_email      = var.openobserve_email
-  openobserve_password   = var.openobserve_password
-  public_microservices   = local.public_microservices
-  public_monitors        = local.public_monitors
-  resource_group         = local.infra_vars.resource_group.value
-  workspace              = local.workspace
+  cluster_name              = local.cluster_name
+  docker_email              = var.docker_email
+  docker_password           = var.docker_password
+  docker_registry_server    = var.docker_registry_server
+  docker_pull_secret_name   = var.docker_pull_secret_name
+  create_docker_pull_secret = var.create_docker_pull_secret
+  docker_username           = var.docker_username
+  feature_flags_content     = local.feature_flags_content
+  flipt_options             = local.flipt_options
+  helm_values               = local.helm_values
+  ingress_scheme            = var.ingress_scheme
+  k8s_version               = var.k8s_version
+  logs_bucket               = local.logs_bucket
+  managed_sync_enabled      = var.managed_sync_enabled
+  managed_sync_version      = var.managed_sync_version
+  microservices             = local.microservices
+  monitor_version           = local.monitor_version
+  monitors                  = local.monitors
+  monitors_enabled          = var.monitors_enabled
+  openobserve_email         = var.openobserve_email
+  openobserve_password      = var.openobserve_password
+  public_microservices      = local.public_microservices
+  public_monitors           = local.public_monitors
+  resource_group            = local.infra_vars.resource_group.value
+  workspace                 = local.workspace
 }
 
 module "managed_sync_config" {

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -35,9 +35,21 @@ variable "domain" {
 }
 
 variable "docker_registry_server" {
-  description = "Docker container registry server."
+  description = "Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry."
   type        = string
   default     = "docker.io"
+}
+
+variable "docker_pull_secret_name" {
+  description = "Kubernetes secret name for registry pull credentials."
+  type        = string
+  default     = "docker-cfg"
+}
+
+variable "create_docker_pull_secret" {
+  description = "Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm_values."
+  type        = bool
+  default     = true
 }
 
 variable "docker_username" {

--- a/charts/paragon-logging/Chart.yaml
+++ b/charts/paragon-logging/Chart.yaml
@@ -6,6 +6,9 @@ version: __PARAGON_VERSION__
 appVersion: 'v1'
 
 dependencies:
+  - name: paragon-templates
+    version: 1
+    repository: file://../paragon-templates
   - name: fluent-bit
     version: __PARAGON_VERSION__
     repository: file://charts/fluent-bit

--- a/charts/paragon-logging/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/paragon-logging/charts/fluent-bit/templates/_helpers.tpl
@@ -63,12 +63,29 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Fluent-bit image with tag/digest
+Fluent-bit image with tag/digest. Pass root in the dict for global registry support.
 */}}
 {{- define "fluent-bit.image" -}}
-{{- $tag := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
-{{- $digest := ternary "" (printf "@%s" .digest) (empty .digest) -}}
-{{- printf "%s%s%s" .repository $tag $digest -}}
+{{- $root := .root -}}
+{{- $repository := .repository -}}
+{{- $tag := .tag -}}
+{{- $digest := .digest | default "" -}}
+{{- if $root -}}
+{{- $resolvedTag := $tag -}}
+{{- if or (empty $tag) (eq "-" (toString $tag)) -}}
+{{- $resolvedTag = $root.Chart.AppVersion -}}
+{{- end -}}
+{{- if $digest -}}
+{{- $base := include "paragon.image" (dict "root" $root "repository" $repository "tag" $resolvedTag) -}}
+{{- printf "%s@%s" $base $digest -}}
+{{- else -}}
+{{- include "paragon.image" (dict "root" $root "repository" $repository "tag" $resolvedTag) -}}
+{{- end -}}
+{{- else -}}
+{{- $tagSuffix := ternary "" (printf ":%s" (toString .tag)) (or (empty .tag) (eq "-" (toString .tag))) -}}
+{{- $digestSuffix := ternary "" (printf "@%s" .digest) (empty .digest) -}}
+{{- printf "%s%s%s" .repository $tagSuffix $digestSuffix -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
@@ -3,6 +3,12 @@ serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
+{{- else }}
+{{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+{{- if $pullSecrets }}
+imagePullSecrets:
+  {{- $pullSecrets | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- if .Values.priorityClass.name }}
 priorityClassName: {{ .Values.priorityClass.name }}
@@ -38,7 +44,7 @@ containers:
     securityContext:
       {{- toYaml . | nindent 6 }}
   {{- end }}
-    image: {{ include "fluent-bit.image" (merge .Values.image (dict "tag" (default .Chart.AppVersion .Values.image.tag))) | quote }}
+    image: {{ include "fluent-bit.image" (merge .Values.image (dict "tag" (default .Chart.AppVersion .Values.image.tag) "root" .)) | quote }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if or .Values.env .Values.envWithTpl }}
     env:
@@ -103,7 +109,7 @@ containers:
     {{- end }}
 {{- if .Values.hotReload.enabled }}
   - name: reloader
-    image: {{ include "fluent-bit.image" .Values.hotReload.image }}
+    image: {{ include "fluent-bit.image" (merge .Values.hotReload.image (dict "root" .)) | quote }}
     args:
       - {{ printf "-webhook-url=http://localhost:%s/api/v2/reload" (toString .Values.metricsPort) }}
       - -volume-dir=/watch/config

--- a/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
@@ -1,14 +1,9 @@
 {{- define "fluent-bit.pod" -}}
 serviceAccountName: {{ include "fluent-bit.serviceAccountName" . }}
-{{- with .Values.imagePullSecrets }}
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- else }}
 {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
 {{- if $pullSecrets }}
 imagePullSecrets:
   {{- $pullSecrets | nindent 2 }}
-{{- end }}
 {{- end }}
 {{- if .Values.priorityClass.name }}
 priorityClassName: {{ .Values.priorityClass.name }}

--- a/charts/paragon-logging/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -14,13 +14,14 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: {{ include "fluent-bit.image" .Values.testFramework.image | quote }}
+      image: {{ include "fluent-bit.image" (merge .Values.testFramework.image (dict "root" .)) | quote }}
       imagePullPolicy: {{ .Values.testFramework.image.pullPolicy }}
       command: ["sh"]
       args: ["-c", "wget -O- {{ include "fluent-bit.fullname" . }}:{{ .Values.service.port }}"]
-  {{- with .Values.imagePullSecrets }}
+  {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+  {{- if $pullSecrets }}
   imagePullSecrets:
-    {{- toYaml . | nindent 4 }}
+    {{- $pullSecrets | nindent 4 }}
   {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/charts/paragon-logging/charts/fluent-bit/values.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/values.yaml
@@ -21,8 +21,7 @@ testFramework:
     tag: latest
     digest:
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 
 nameOverride: "fluent-bit"
 fullnameOverride: "fluent-bit"

--- a/charts/paragon-logging/charts/fluent-bit/values.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/values.yaml
@@ -516,7 +516,7 @@ initContainers: []
 # Array mode
 # initContainers:
 #   - name: do-something
-#     image: alpine/kubectl:1.33.4
+#     image: alpine/kubectl:1.36.2
 #     command: ['kubectl', 'version']
 
 # String mode

--- a/charts/paragon-logging/charts/openobserve/templates/statefulset.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/statefulset.yaml
@@ -21,6 +21,11 @@ spec:
       labels:
         {{- include "openobserve.selectorLabels" . | nindent 8 }}
     spec:
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+      {{- if $pullSecrets }}
+      imagePullSecrets:
+        {{- $pullSecrets | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "openobserve.serviceAccountName" . }}
       securityContext:
         fsGroup: 2000
@@ -29,7 +34,8 @@ spec:
         runAsNonRoot: true
       containers:
         - name: {{ include "openobserve.fullname" . }}
-          image: {{ .Values.image.repository | default "public.ecr.aws/zinclabs/openobserve" }}:{{ .Values.image.tag | default "latest" }}
+          image: {{ include "paragon.image" (dict "root" . "repository" (.Values.image.repository | default "public.ecr.aws/zinclabs/openobserve") "tag" (.Values.image.tag | default "latest")) | quote }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" .) }}
           env:
             {{- /* Handle environment variables */}}
             {{- if and .Values.envKeys (kindIs "slice" .Values.envKeys) }}
@@ -58,7 +64,6 @@ spec:
                   optional: true
             {{- end }}
             {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           resources:
             limits:
               cpu: {{ .Values.resources.limits.cpu | default "4096m" }}

--- a/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
+++ b/charts/paragon-logging/charts/openobserve/templates/uds-apply-job.yaml
@@ -19,10 +19,15 @@ spec:
         app.kubernetes.io/component: uds-apply
     spec:
       restartPolicy: Never
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+      {{- if $pullSecrets }}
+      imagePullSecrets:
+        {{- $pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: uds-apply
-          image: "{{ .Values.uds.image.repository }}:{{ .Values.uds.image.tag }}"
-          imagePullPolicy: {{ .Values.uds.image.pullPolicy }}
+          image: {{ include "paragon.image" (dict "root" . "repository" .Values.uds.image.repository "tag" .Values.uds.image.tag) | quote }}
+          imagePullPolicy: {{ .Values.uds.image.pullPolicy | default .Values.global.pullPolicy | default "IfNotPresent" }}
           command:
             - /bin/sh
             - -c

--- a/charts/paragon-logging/charts/openobserve/values.yaml
+++ b/charts/paragon-logging/charts/openobserve/values.yaml
@@ -10,8 +10,7 @@ image:
   tag: v0.91.0
   # tag: v0.91.0-debug
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 
 service:
   type: ClusterIP

--- a/charts/paragon-logging/charts/openobserve/values.yaml
+++ b/charts/paragon-logging/charts/openobserve/values.yaml
@@ -10,6 +10,9 @@ image:
   tag: v0.91.0
   # tag: v0.91.0-debug
 
+imagePullSecrets:
+  - name: docker-cfg
+
 service:
   type: ClusterIP
   port: 5080

--- a/charts/paragon-logging/values.yaml
+++ b/charts/paragon-logging/values.yaml
@@ -6,6 +6,18 @@ subchart:
     enabled: true
 
 global:
+  # Optional private registry / Artifactory proxy (prepended to image repository paths).
+  imageRegistry: ""
+  # When set (including ""), rewrites useparagon/ prefix in repository paths. Omit to preserve useparagon/.
+  # imageRepositoryPrefix: null
+  migrationImageRegistry: ""
+  imagePullSecrets: []
   pullPolicy: IfNotPresent
+  testImage:
+    repository: busybox
+    tag: latest
+  kubectlImage:
+    repository: alpine/kubectl
+    tag: "1.36.2"
   namespace: paragon
   env: {}

--- a/charts/paragon-monitoring/charts/bull-exporter/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/bull-exporter/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "bull-exporter.fullname" . }}-test-connection"
-  labels:
-    {{- include "bull-exporter.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "bull-exporter.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/bull-exporter/values.yaml
+++ b/charts/paragon-monitoring/charts/bull-exporter/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'bull-exporter'
 

--- a/charts/paragon-monitoring/charts/grafana/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/grafana/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "grafana.fullname" . }}-test-connection"
-  labels:
-    {{- include "grafana.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "grafana.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/grafana/values.yaml
+++ b/charts/paragon-monitoring/charts/grafana/values.yaml
@@ -29,8 +29,7 @@ autoscaling:
   # targetCPUUtilizationPercentage: 75
   # targetMemoryUtilizationPercentage: 75
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'grafana'
 

--- a/charts/paragon-monitoring/charts/kafka-exporter/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/kafka-exporter/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "kafka-exporter.fullname" . }}-test-connection"
-  labels:
-    {{- include "kafka-exporter.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "kafka-exporter.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/kafka-exporter/values.yaml
+++ b/charts/paragon-monitoring/charts/kafka-exporter/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'kafka-exporter'
 

--- a/charts/paragon-monitoring/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/paragon-monitoring/charts/kube-state-metrics/templates/deployment.yaml
@@ -124,8 +124,8 @@ spec:
 {{ toYaml .Values.volumeMounts | indent 8 }}
         {{- end }}
         {{- end }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" .) }}
+        image: {{ include "paragon.containerImage" (dict "root" . "tag" (.Values.image.tag | default .Chart.AppVersion)) | quote }}
         {{- if eq .Values.kubeRBACProxy.enabled false }}
         ports:
         - containerPort: {{ .Values.service.port | default 8080}}
@@ -172,7 +172,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        image: {{ include "kubeRBACProxy.image" . }}
+        image: {{ include "paragon.image" (dict "root" . "repository" .Values.kubeRBACProxy.image.repository "tag" (.Values.kubeRBACProxy.image.tag | default .Chart.AppVersion) "registry" .Values.kubeRBACProxy.image.registry) | quote }}
         ports:
           - containerPort: {{ .Values.service.port | default 8080}}
             name: "http"
@@ -210,7 +210,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        image: {{ include "kubeRBACProxy.image" . }}
+        image: {{ include "paragon.image" (dict "root" . "repository" .Values.kubeRBACProxy.image.repository "tag" (.Values.kubeRBACProxy.image.tag | default .Chart.AppVersion) "registry" .Values.kubeRBACProxy.image.registry) | quote }}
         ports:
           - containerPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
             name: "metrics"
@@ -235,8 +235,8 @@ spec:
       {{- end }}
 {{- if or .Values.imagePullSecrets .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.imagePullSecrets) | indent 8 }}
-      {{- end }}
+        {{- include "paragon.imagePullSecrets" (dict "root" .) | indent 8 }}
+{{- end }}
       {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/charts/paragon-monitoring/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/paragon-monitoring/charts/kube-state-metrics/templates/deployment.yaml
@@ -172,7 +172,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        image: {{ include "paragon.image" (dict "root" . "repository" .Values.kubeRBACProxy.image.repository "tag" (.Values.kubeRBACProxy.image.tag | default .Chart.AppVersion) "registry" .Values.kubeRBACProxy.image.registry) | quote }}
+        image: {{ include "paragon.image" (dict "root" . "repository" .Values.kubeRBACProxy.image.repository "tag" (.Values.kubeRBACProxy.image.tag | default .Chart.AppVersion) "registry" .Values.kubeRBACProxy.image.registry "sha" (.Values.kubeRBACProxy.image.sha | default "")) | quote }}
         ports:
           - containerPort: {{ .Values.service.port | default 8080}}
             name: "http"
@@ -210,7 +210,7 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
         imagePullPolicy: {{ .Values.kubeRBACProxy.image.pullPolicy }}
-        image: {{ include "paragon.image" (dict "root" . "repository" .Values.kubeRBACProxy.image.repository "tag" (.Values.kubeRBACProxy.image.tag | default .Chart.AppVersion) "registry" .Values.kubeRBACProxy.image.registry) | quote }}
+        image: {{ include "paragon.image" (dict "root" . "repository" .Values.kubeRBACProxy.image.repository "tag" (.Values.kubeRBACProxy.image.tag | default .Chart.AppVersion) "registry" .Values.kubeRBACProxy.image.registry "sha" (.Values.kubeRBACProxy.image.sha | default "")) | quote }}
         ports:
           - containerPort: {{ .Values.selfMonitor.telemetryPort | default 8081 }}
             name: "metrics"

--- a/charts/paragon-monitoring/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/paragon-monitoring/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -11,5 +11,5 @@ metadata:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
 imagePullSecrets:
-  {{- include "kube-state-metrics.imagePullSecrets" (dict "Values" .Values "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
+  {{- include "paragon.imagePullSecrets" (dict "root" . "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
 {{- end -}}

--- a/charts/paragon-monitoring/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/paragon-monitoring/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -10,6 +10,9 @@ metadata:
   annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
+{{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" . "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) -}}
+{{- if $pullSecrets }}
 imagePullSecrets:
-  {{- include "paragon.imagePullSecrets" (dict "root" . "imagePullSecrets" .Values.serviceAccount.imagePullSecrets) | indent 2 }}
+  {{- $pullSecrets | indent 2 }}
+{{- end }}
 {{- end -}}

--- a/charts/paragon-monitoring/charts/kube-state-metrics/values.yaml
+++ b/charts/paragon-monitoring/charts/kube-state-metrics/values.yaml
@@ -6,8 +6,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 # - name: "image-pull-secret"
 fullnameOverride: 'kube-state-metrics'
 

--- a/charts/paragon-monitoring/charts/node-exporter/templates/daemonset.yaml
+++ b/charts/paragon-monitoring/charts/node-exporter/templates/daemonset.yaml
@@ -13,6 +13,11 @@ spec:
       labels:
         {{- include "node-exporter.selectorLabels" . | nindent 8 }}
     spec:
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+      {{- if $pullSecrets }}
+      imagePullSecrets:
+        {{- $pullSecrets | nindent 8 }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.hostPID }}
       {{- if .Values.priorityClass.name }}
@@ -20,8 +25,8 @@ spec:
       {{- end }}
       containers:
         - name: node-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "paragon.image" (dict "root" . "repository" .Values.image.repository "tag" .Values.image.tag) | quote }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" .) }}
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys

--- a/charts/paragon-monitoring/charts/node-exporter/values.yaml
+++ b/charts/paragon-monitoring/charts/node-exporter/values.yaml
@@ -3,8 +3,7 @@ image:
   pullPolicy: IfNotPresent
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 
 fullnameOverride: 'node-exporter'
 

--- a/charts/paragon-monitoring/charts/node-exporter/values.yaml
+++ b/charts/paragon-monitoring/charts/node-exporter/values.yaml
@@ -3,6 +3,9 @@ image:
   pullPolicy: IfNotPresent
   tag: 'latest'
 
+imagePullSecrets:
+  - name: docker-cfg
+
 fullnameOverride: 'node-exporter'
 
 service:

--- a/charts/paragon-monitoring/charts/pgadmin/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/pgadmin/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "pgadmin.fullname" . }}-test-connection"
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "pgadmin.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/pgadmin/values.yaml
+++ b/charts/paragon-monitoring/charts/pgadmin/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'pgadmin'
 

--- a/charts/paragon-monitoring/charts/postgres-exporter/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/postgres-exporter/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "postgres-exporter.fullname" . }}-test-connection"
-  labels:
-    {{- include "postgres-exporter.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "postgres-exporter.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/postgres-exporter/values.yaml
+++ b/charts/paragon-monitoring/charts/postgres-exporter/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'postgres-exporter'
 

--- a/charts/paragon-monitoring/charts/prometheus/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/prometheus/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "prometheus.fullname" . }}-test-connection"
-  labels:
-    {{- include "prometheus.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "prometheus.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/prometheus/values.yaml
+++ b/charts/paragon-monitoring/charts/prometheus/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'prometheus'
 

--- a/charts/paragon-monitoring/charts/redis-exporter/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/redis-exporter/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "redis-exporter.fullname" . }}-test-connection"
-  labels:
-    {{- include "redis-exporter.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "redis-exporter.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/redis-exporter/values.yaml
+++ b/charts/paragon-monitoring/charts/redis-exporter/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'redis-exporter'
 

--- a/charts/paragon-monitoring/charts/redis-insight/templates/tests/test-connection.yaml
+++ b/charts/paragon-monitoring/charts/redis-insight/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "redis-insight.fullname" . }}-test-connection"
-  labels:
-    {{- include "redis-insight.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "redis-insight.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-monitoring/charts/redis-insight/values.yaml
+++ b/charts/paragon-monitoring/charts/redis-insight/values.yaml
@@ -10,8 +10,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: 'latest'
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'redis-insight'
 

--- a/charts/paragon-monitoring/values.yaml
+++ b/charts/paragon-monitoring/values.yaml
@@ -21,6 +21,18 @@ subchart:
     enabled: true
 
 global:
+  # Optional private registry / Artifactory proxy (prepended to image repository paths).
+  imageRegistry: ""
+  # When set (including ""), rewrites useparagon/ prefix in repository paths. Omit to preserve useparagon/.
+  # imageRepositoryPrefix: null
+  migrationImageRegistry: ""
+  imagePullSecrets: []
   pullPolicy: IfNotPresent
+  testImage:
+    repository: busybox
+    tag: latest
+  kubectlImage:
+    repository: alpine/kubectl
+    tag: "1.36.2"
   namespace: paragon
   env: {}

--- a/charts/paragon-onprem/charts/account/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/account/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "account.fullname" . }}-test-connection"
-  labels:
-    {{- include "account.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "account.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/account/values.yaml
+++ b/charts/paragon-onprem/charts/account/values.yaml
@@ -40,8 +40,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'account'
 

--- a/charts/paragon-onprem/charts/api-triggerkit/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "api-triggerkit.fullname" . }}-test-connection"
-  labels:
-    {{- include "api-triggerkit.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "api-triggerkit.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/api-triggerkit/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/api-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'api-triggerkit'
 

--- a/charts/paragon-onprem/charts/cache-replay/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/cache-replay/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "cache-replay.fullname" . }}-test-connection"
-  labels:
-    {{- include "cache-replay.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "cache-replay.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/cache-replay/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/cache-replay/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/cache-replay/values.yaml
+++ b/charts/paragon-onprem/charts/cache-replay/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'cache-replay'
 

--- a/charts/paragon-onprem/charts/cerberus/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/cerberus/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "cerberus.fullname" . }}-test-connection"
-  labels:
-    {{- include "cerberus.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "cerberus.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/cerberus/values.yaml
+++ b/charts/paragon-onprem/charts/cerberus/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'cerberus'
 

--- a/charts/paragon-onprem/charts/connect/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/connect/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "connect.fullname" . }}-test-connection"
-  labels:
-    {{- include "connect.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "connect.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/connect/values.yaml
+++ b/charts/paragon-onprem/charts/connect/values.yaml
@@ -40,8 +40,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'connect'
 

--- a/charts/paragon-onprem/charts/dashboard/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/dashboard/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "dashboard.fullname" . }}-test-connection"
-  labels:
-    {{- include "dashboard.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "dashboard.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/dashboard/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/dashboard/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/dashboard/values.yaml
+++ b/charts/paragon-onprem/charts/dashboard/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'dashboard'
 

--- a/charts/paragon-onprem/charts/flipt/templates/deployment.yaml
+++ b/charts/paragon-onprem/charts/flipt/templates/deployment.yaml
@@ -31,9 +31,10 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- $pullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "flipt.serviceAccountName" . }}
       securityContext:
@@ -42,8 +43,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "paragon.image" (dict "root" . "repository" .Values.image.repository "tag" (.Values.image.tag | default .Chart.AppVersion)) | quote }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" .) }}
           command: ["/flipt"]
           {{- if .Values.flipt.args }}
           args:

--- a/charts/paragon-onprem/charts/flipt/templates/migration_job.yaml
+++ b/charts/paragon-onprem/charts/flipt/templates/migration_job.yaml
@@ -20,9 +20,10 @@ spec:
         {{- include "flipt.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- $pullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "flipt.serviceAccountName" . }}
       securityContext:
@@ -31,8 +32,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "paragon.image" (dict "root" . "repository" .Values.image.repository "tag" (.Values.image.tag | default .Chart.AppVersion)) | quote }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" .) }}
           command:
           - "./flipt"
           - "migrate"

--- a/charts/paragon-onprem/charts/flipt/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/flipt/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "flipt.fullname" . }}-test-connection"
-  labels:
-    {{- include "flipt.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox:{{ (.Values.test).tag | default "latest" }}
-      command: ['wget']
-      args: ['{{ include "flipt.fullname" . }}:{{ .Values.service.httpPort }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" . "tag" ((.Values.test).tag | default "") "port" .Values.service.httpPort) }}

--- a/charts/paragon-onprem/charts/flipt/values.yaml
+++ b/charts/paragon-onprem/charts/flipt/values.yaml
@@ -7,8 +7,7 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 
 nameOverride: ""
 fullnameOverride: "flipt"

--- a/charts/paragon-onprem/charts/hades/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/hades/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "hades.fullname" . }}-test-connection"
-  labels:
-    {{- include "hades.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "hades.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/hades/values.yaml
+++ b/charts/paragon-onprem/charts/hades/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'hades'
 

--- a/charts/paragon-onprem/charts/health-checker/templates/stateful-set.yaml
+++ b/charts/paragon-onprem/charts/health-checker/templates/stateful-set.yaml
@@ -23,9 +23,10 @@ spec:
         {{- include "health-checker.selectorLabels" . | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- $pullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "health-checker.serviceAccountName" . }}
       securityContext:
@@ -34,8 +35,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "paragon.image" (dict "root" . "repository" .Values.image.repository "tag" (.Values.image.tag | default .Chart.AppVersion)) | quote }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" .) }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/paragon-onprem/charts/health-checker/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/health-checker/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "health-checker.fullname" . }}-test-connection"
-  labels:
-    {{- include "health-checker.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "health-checker.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/health-checker/values.yaml
+++ b/charts/paragon-onprem/charts/health-checker/values.yaml
@@ -91,8 +91,7 @@ envKeys:
   - WORKER_WORKFLOWS_PRIVATE_URL
   - ZEUS_PRIVATE_URL
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'health-checker'
 

--- a/charts/paragon-onprem/charts/hermes/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/hermes/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "hermes.fullname" . }}-test-connection"
-  labels:
-    {{- include "hermes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "hermes.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/hermes/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/hermes/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -46,8 +46,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'hermes'
 

--- a/charts/paragon-onprem/charts/passport/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/passport/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "passport.fullname" . }}-test-connection"
-  labels:
-    {{- include "passport.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "passport.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/passport/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/passport/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/passport/values.yaml
+++ b/charts/paragon-onprem/charts/passport/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'passport'
 

--- a/charts/paragon-onprem/charts/pheme/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/pheme/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "pheme.fullname" . }}-test-connection"
-  labels:
-    {{- include "pheme.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "pheme.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/pheme/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/pheme/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/pheme/values.yaml
+++ b/charts/paragon-onprem/charts/pheme/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'pheme'
 

--- a/charts/paragon-onprem/charts/release/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/release/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "release.fullname" . }}-test-connection"
-  labels:
-    {{- include "release.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "release.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/release/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/release/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'release'
 

--- a/charts/paragon-onprem/charts/worker-actionkit/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-actionkit.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-actionkit.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-actionkit.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-actionkit/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-actionkit'
 

--- a/charts/paragon-onprem/charts/worker-actions/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-actions.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-actions.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-actions.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-actions/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-actions'
 

--- a/charts/paragon-onprem/charts/worker-auditlogs/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-auditlogs.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-auditlogs.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-auditlogs.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-auditlogs/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: "worker-auditlogs"
 

--- a/charts/paragon-onprem/charts/worker-credentials/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-credentials.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-credentials.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-credentials.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-credentials/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-credentials'
 

--- a/charts/paragon-onprem/charts/worker-crons/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-crons.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-crons.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-crons.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-crons/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-crons'
 

--- a/charts/paragon-onprem/charts/worker-deployments/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-deployments.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-deployments.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-deployments.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-deployments/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-deployments'
 

--- a/charts/paragon-onprem/charts/worker-eventlogs/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-eventlogs.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-eventlogs.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-eventlogs.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-eventlogs/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-eventlogs'
 

--- a/charts/paragon-onprem/charts/worker-proxy/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-proxy.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-proxy.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-proxy.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-proxy/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-proxy'
 

--- a/charts/paragon-onprem/charts/worker-triggerkit/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-triggerkit.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-triggerkit.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-triggerkit.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-triggerkit/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-triggerkit'
 

--- a/charts/paragon-onprem/charts/worker-triggers/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-triggers.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-triggers.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-triggers.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-triggers/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-triggers'
 

--- a/charts/paragon-onprem/charts/worker-workflows/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "worker-workflows.fullname" . }}-test-connection"
-  labels:
-    {{- include "worker-workflows.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "worker-workflows.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-workflows/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'worker-workflows'
 

--- a/charts/paragon-onprem/charts/zeus/templates/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/zeus/templates/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "zeus.fullname" . }}-test-connection"
-  labels:
-    {{- include "zeus.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "zeus.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/zeus/tests/test-connection.yaml
+++ b/charts/paragon-onprem/charts/zeus/tests/test-connection.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ include "test.fullname" . }}-test-connection"
-  labels:
-    {{- include "test.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": test
-spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['{{ include "test.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+{{ include "test-connection.standard" (dict "root" .) }}

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -30,8 +30,7 @@ autoscaling:
 
 secretName: "paragon-secrets"
 
-imagePullSecrets:
-  - name: docker-cfg
+imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: 'zeus'
 

--- a/charts/paragon-onprem/templates/restart-cron.yaml
+++ b/charts/paragon-onprem/templates/restart-cron.yaml
@@ -10,9 +10,14 @@ spec:
       template:
         spec:
           serviceAccountName: paragon-restart-manager
+          {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" .) -}}
+          {{- if $pullSecrets }}
+          imagePullSecrets:
+            {{- $pullSecrets | nindent 12 }}
+          {{- end }}
           containers:
           - name: restart-pods
-            image: alpine/kubectl:1.33.4
+            image: {{ include "paragon.kubectlImage" (dict "root" .) | quote }}
             command:
             - /bin/sh
             - -c

--- a/charts/paragon-onprem/values.yaml
+++ b/charts/paragon-onprem/values.yaml
@@ -55,6 +55,18 @@ restart:
   schedule: 0 14 * * * # everyday at 9am EST
 
 global:
+  # Optional private registry / Artifactory proxy (prepended to image repository paths).
+  imageRegistry: ""
+  # When set (including ""), rewrites useparagon/ prefix in repository paths. Omit to preserve useparagon/.
+  # imageRepositoryPrefix: null
+  migrationImageRegistry: ""
+  imagePullSecrets: []
   pullPolicy: IfNotPresent
+  testImage:
+    repository: busybox
+    tag: latest
+  kubectlImage:
+    repository: alpine/kubectl
+    tag: "1.36.2"
   namespace: paragon
   env: {}

--- a/charts/paragon-templates/templates/_deployment.yaml
+++ b/charts/paragon-templates/templates/_deployment.yaml
@@ -39,9 +39,10 @@ spec:
         {{- include (printf "%s.selectorLabels" $name) $root | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 65
-      {{- with $root.Values.imagePullSecrets }}
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" $root) -}}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- $pullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include (printf "%s.serviceAccountName" $name) $root }}
       securityContext:
@@ -50,11 +51,11 @@ spec:
         - name: {{ $name }}
           securityContext:
             {{- toYaml $root.Values.securityContext | nindent 12 }}
-          image: "{{ $root.Values.image.repository }}:{{ $root.Values.global.paragon_version | default $root.Values.global.env.VERSION }}"
+          image: {{ include "paragon.containerImage" (dict "root" $root) | quote }}
           {{- if $command }}
           command: [{{ $command | quote }}]
           {{- end }}
-          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" $root) }}
           ports:
             - name: http
               containerPort: {{ $root.Values.service.port }}

--- a/charts/paragon-templates/templates/_helpers.tpl
+++ b/charts/paragon-templates/templates/_helpers.tpl
@@ -1,0 +1,126 @@
+{{/*
+Resolve repository path with optional useparagon/ prefix rewrite.
+Input: (dict "root" $ "repository" "useparagon/account")
+Skips rewrite when repository already includes a registry host (first path segment contains ".").
+*/}}
+{{- define "paragon.resolveRepository" -}}
+{{- $root := .root -}}
+{{- $repository := required "repository" .repository -}}
+{{- $parts := splitList "/" $repository -}}
+{{- $first := index $parts 0 | default $repository -}}
+{{- if contains "." $first -}}
+{{- $repository -}}
+{{- else if and $root.Values.global (hasKey $root.Values.global "imageRepositoryPrefix") -}}
+{{- if hasPrefix "useparagon/" $repository -}}
+{{- $repository = trimPrefix "useparagon/" $repository -}}
+{{- end -}}
+{{- with $root.Values.global.imageRepositoryPrefix -}}
+{{- $repository = printf "%s/%s" . $repository -}}
+{{- end -}}
+{{- $repository -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Build a full container image reference (repository:tag).
+Input: (dict "root" $ "repository" "useparagon/account" "tag" "1.0.0" "registry" "" "useMigrationRegistry" false)
+Optional registry supports split registry/repository fields (e.g. quay.io + brancz/kube-rbac-proxy).
+useMigrationRegistry selects global.migrationImageRegistry before global.imageRegistry.
+*/}}
+{{- define "paragon.image" -}}
+{{- $root := .root -}}
+{{- $repository := include "paragon.resolveRepository" . -}}
+{{- $tag := required "tag" .tag -}}
+{{- $registry := .registry | default "" -}}
+{{- $useMigrationRegistry := .useMigrationRegistry | default false -}}
+{{- $globalRegistry := "" -}}
+{{- if and $root.Values.global $useMigrationRegistry -}}
+{{- $globalRegistry = $root.Values.global.migrationImageRegistry | default $root.Values.global.imageRegistry | default "" -}}
+{{- else if $root.Values.global -}}
+{{- $globalRegistry = $root.Values.global.imageRegistry | default "" -}}
+{{- end -}}
+{{- $parts := splitList "/" $repository -}}
+{{- $first := index $parts 0 | default $repository -}}
+{{- if contains "." $first -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- else if $globalRegistry -}}
+{{- printf "%s/%s:%s" $globalRegistry $repository $tag -}}
+{{- else if $registry -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Image reference for a chart's main workload container.
+Input: (dict "root" $) — tag from global.paragon_version / global.env.VERSION.
+For statefulsets pass tagFallback from image.tag via the tag param.
+*/}}
+{{- define "paragon.containerImage" -}}
+{{- $root := .root -}}
+{{- $tag := .tag | default ($root.Values.global.paragon_version | default $root.Values.global.env.VERSION) -}}
+{{- include "paragon.image" (dict "root" $root "repository" $root.Values.image.repository "tag" $tag "registry" ($root.Values.image.registry | default "") "useMigrationRegistry" (.useMigrationRegistry | default false)) -}}
+{{- end -}}
+
+{{/*
+Merge global and chart-level imagePullSecrets.
+Input: (dict "root" $) or (dict "root" $ "imagePullSecrets" .Values.imagePullSecrets)
+*/}}
+{{- define "paragon.imagePullSecrets" -}}
+{{- $root := .root -}}
+{{- $local := .imagePullSecrets | default $root.Values.imagePullSecrets | default list -}}
+{{- $global := list -}}
+{{- if and $root.Values.global $root.Values.global.imagePullSecrets -}}
+{{- $global = $root.Values.global.imagePullSecrets -}}
+{{- end -}}
+{{- range (concat $global $local) }}
+{{- if eq (typeOf .) "map[string]interface {}" }}
+- {{ toYaml . | trim }}
+{{- else }}
+- name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+imagePullPolicy: chart value, then global.pullPolicy, then IfNotPresent.
+Input: (dict "root" $)
+*/}}
+{{- define "paragon.imagePullPolicy" -}}
+{{- $root := .root -}}
+{{- $root.Values.image.pullPolicy | default $root.Values.global.pullPolicy | default "IfNotPresent" -}}
+{{- end -}}
+
+{{/*
+Helm test hook image (busybox by default).
+Input: (dict "root" $) or (dict "root" $ "tag" "1.36")
+*/}}
+{{- define "paragon.testImage" -}}
+{{- $root := .root -}}
+{{- $repo := "busybox" -}}
+{{- $defaultTag := "latest" -}}
+{{- if and $root.Values.global $root.Values.global.testImage -}}
+{{- $repo = $root.Values.global.testImage.repository | default $repo -}}
+{{- $defaultTag = $root.Values.global.testImage.tag | default $defaultTag -}}
+{{- end -}}
+{{- $tag := .tag | default $defaultTag -}}
+{{- include "paragon.image" (dict "root" $root "repository" $repo "tag" $tag) -}}
+{{- end -}}
+
+{{/*
+Restart cron kubectl image.
+Input: (dict "root" $)
+*/}}
+{{- define "paragon.kubectlImage" -}}
+{{- $root := .root -}}
+{{- $repo := "alpine/kubectl" -}}
+{{- $tag := "1.36.2" -}}
+{{- if and $root.Values.global $root.Values.global.kubectlImage -}}
+{{- $repo = $root.Values.global.kubectlImage.repository | default $repo -}}
+{{- $tag = $root.Values.global.kubectlImage.tag | default $tag -}}
+{{- end -}}
+{{- include "paragon.image" (dict "root" $root "repository" $repo "tag" $tag) -}}
+{{- end -}}

--- a/charts/paragon-templates/templates/_helpers.tpl
+++ b/charts/paragon-templates/templates/_helpers.tpl
@@ -24,16 +24,18 @@ Skips rewrite when repository already includes a registry host (first path segme
 {{- end -}}
 
 {{/*
-Build a full container image reference (repository:tag).
-Input: (dict "root" $ "repository" "useparagon/account" "tag" "1.0.0" "registry" "" "useMigrationRegistry" false)
+Build a full container image reference (repository:tag or repository:tag@sha).
+Input: (dict "root" $ "repository" "useparagon/account" "tag" "1.0.0" "registry" "" "useMigrationRegistry" false "sha" "")
 Optional registry supports split registry/repository fields (e.g. quay.io + brancz/kube-rbac-proxy).
 useMigrationRegistry selects global.migrationImageRegistry before global.imageRegistry.
+Optional sha appends @digest when set.
 */}}
 {{- define "paragon.image" -}}
 {{- $root := .root -}}
 {{- $repository := include "paragon.resolveRepository" . -}}
 {{- $tag := required "tag" .tag -}}
 {{- $registry := .registry | default "" -}}
+{{- $sha := .sha | default "" -}}
 {{- $useMigrationRegistry := .useMigrationRegistry | default false -}}
 {{- $globalRegistry := "" -}}
 {{- if and $root.Values.global $useMigrationRegistry -}}
@@ -43,14 +45,20 @@ useMigrationRegistry selects global.migrationImageRegistry before global.imageRe
 {{- end -}}
 {{- $parts := splitList "/" $repository -}}
 {{- $first := index $parts 0 | default $repository -}}
+{{- $ref := "" -}}
 {{- if contains "." $first -}}
-{{- printf "%s:%s" $repository $tag -}}
+{{- $ref = printf "%s:%s" $repository $tag -}}
 {{- else if $globalRegistry -}}
-{{- printf "%s/%s:%s" $globalRegistry $repository $tag -}}
+{{- $ref = printf "%s/%s:%s" $globalRegistry $repository $tag -}}
 {{- else if $registry -}}
-{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- $ref = printf "%s/%s:%s" $registry $repository $tag -}}
 {{- else -}}
-{{- printf "%s:%s" $repository $tag -}}
+{{- $ref = printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- if $sha -}}
+{{- printf "%s@%s" $ref $sha -}}
+{{- else -}}
+{{- $ref -}}
 {{- end -}}
 {{- end -}}
 
@@ -62,7 +70,7 @@ For statefulsets pass tagFallback from image.tag via the tag param.
 {{- define "paragon.containerImage" -}}
 {{- $root := .root -}}
 {{- $tag := .tag | default ($root.Values.global.paragon_version | default $root.Values.global.env.VERSION) -}}
-{{- include "paragon.image" (dict "root" $root "repository" $root.Values.image.repository "tag" $tag "registry" ($root.Values.image.registry | default "") "useMigrationRegistry" (.useMigrationRegistry | default false)) -}}
+{{- include "paragon.image" (dict "root" $root "repository" $root.Values.image.repository "tag" $tag "registry" ($root.Values.image.registry | default "") "useMigrationRegistry" (.useMigrationRegistry | default false) "sha" ($root.Values.image.sha | default "")) -}}
 {{- end -}}
 
 {{/*

--- a/charts/paragon-templates/templates/_helpers.tpl
+++ b/charts/paragon-templates/templates/_helpers.tpl
@@ -1,14 +1,26 @@
 {{/*
+Returns non-empty when a path segment looks like a registry host
+(e.g. artifactory.example.com, localhost:5000, registry:5000).
+Input: path segment string.
+*/}}
+{{- define "paragon.isRegistryHost" -}}
+{{- $segment := . -}}
+{{- if or (contains "." $segment) (contains ":" $segment) (eq $segment "localhost") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Resolve repository path with optional useparagon/ prefix rewrite.
 Input: (dict "root" $ "repository" "useparagon/account")
-Skips rewrite when repository already includes a registry host (first path segment contains ".").
+Skips rewrite when repository already includes a registry host.
 */}}
 {{- define "paragon.resolveRepository" -}}
 {{- $root := .root -}}
 {{- $repository := required "repository" .repository -}}
 {{- $parts := splitList "/" $repository -}}
 {{- $first := index $parts 0 | default $repository -}}
-{{- if contains "." $first -}}
+{{- if include "paragon.isRegistryHost" $first -}}
 {{- $repository -}}
 {{- else if and $root.Values.global (hasKey $root.Values.global "imageRepositoryPrefix") -}}
 {{- if hasPrefix "useparagon/" $repository -}}
@@ -46,7 +58,7 @@ Optional sha appends @digest when set.
 {{- $parts := splitList "/" $repository -}}
 {{- $first := index $parts 0 | default $repository -}}
 {{- $ref := "" -}}
-{{- if contains "." $first -}}
+{{- if include "paragon.isRegistryHost" $first -}}
 {{- $ref = printf "%s:%s" $repository $tag -}}
 {{- else if $globalRegistry -}}
 {{- $ref = printf "%s/%s:%s" $globalRegistry $repository $tag -}}

--- a/charts/paragon-templates/templates/_migration.yaml
+++ b/charts/paragon-templates/templates/_migration.yaml
@@ -25,9 +25,10 @@ spec:
       labels:
         {{- include (printf "%s.selectorLabels" $name) $root | nindent 8 }}
     spec:
-      {{- with $root.Values.imagePullSecrets }}
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" $root) -}}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- $pullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: default
       securityContext:
@@ -36,8 +37,8 @@ spec:
         - name: {{ $imageName | quote }}
           securityContext:
             {{- toYaml $root.Values.securityContext | nindent 12 }}
-          image: "useparagon/{{ $imageName }}:{{ $root.Values.global.paragon_version | default $root.Values.global.env.VERSION }}"
-          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          image: {{ include "paragon.image" (dict "root" $root "repository" (printf "useparagon/%s" $imageName) "tag" ($root.Values.global.paragon_version | default $root.Values.global.env.VERSION) "useMigrationRegistry" true) | quote }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" $root) }}
           resources:
             {{- toYaml $root.Values.resources | nindent 12 }}
           env:

--- a/charts/paragon-templates/templates/_stateful-set.yaml
+++ b/charts/paragon-templates/templates/_stateful-set.yaml
@@ -34,9 +34,10 @@ spec:
         {{- include (printf "%s.selectorLabels" $name) $root | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 65
-      {{- with $root.Values.imagePullSecrets }}
+      {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" $root) -}}
+      {{- if $pullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- $pullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include (printf "%s.serviceAccountName" $name) $root }}
       securityContext:
@@ -45,11 +46,11 @@ spec:
         - name: {{ $name }}
           securityContext:
             {{- toYaml $root.Values.securityContext | nindent 12 }}
-          image: "{{ $root.Values.image.repository }}:{{ $root.Values.global.paragon_version | default $root.Values.image.tag | default $root.Values.global.env.VERSION }}"
+          image: {{ include "paragon.containerImage" (dict "root" $root "tag" ($root.Values.global.paragon_version | default $root.Values.image.tag | default $root.Values.global.env.VERSION)) | quote }}
           {{- if $command }}
           command: [{{ $command | quote }}]
           {{- end }}
-          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          imagePullPolicy: {{ include "paragon.imagePullPolicy" (dict "root" $root) }}
           ports:
             - name: http
               containerPort: {{ $root.Values.service.port }}

--- a/charts/paragon-templates/templates/_test-connection.yaml
+++ b/charts/paragon-templates/templates/_test-connection.yaml
@@ -1,0 +1,30 @@
+{{/*
+Standard helm test connection pod.
+Call with: include "test-connection.standard" (dict "root" $)
+Optional: "tag" for test image tag override (e.g. flipt test.tag).
+*/}}
+{{- define "test-connection.standard" -}}
+{{- $root := .root -}}
+{{- $tag := .tag | default "" -}}
+{{- $port := .port | default $root.Values.service.port -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include (printf "%s.fullname" $root.Chart.Name) $root }}-test-connection"
+  labels:
+    {{- include (printf "%s.labels" $root.Chart.Name) $root | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  {{- $pullSecrets := include "paragon.imagePullSecrets" (dict "root" $root) -}}
+  {{- if $pullSecrets }}
+  imagePullSecrets:
+    {{- $pullSecrets | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: wget
+      image: {{ include "paragon.testImage" (dict "root" $root "tag" $tag) | quote }}
+      command: ['wget']
+      args: ['{{ include (printf "%s.fullname" $root.Chart.Name) $root }}:{{ $port }}']
+  restartPolicy: Never
+{{- end -}}

--- a/gcp/workspaces/paragon/README.md
+++ b/gcp/workspaces/paragon/README.md
@@ -15,7 +15,7 @@ NOTE: The credentials above may refer to a Workload Identity Pool account instea
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.0 |
@@ -52,10 +52,12 @@ NOTE: The credentials above may refer to a Workload Identity Pool account instea
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_cloudflare_api_token"></a> [cloudflare\_api\_token](#input\_cloudflare\_api\_token) | Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Zone `DNS` | `string` | `null` | no |
 | <a name="input_cloudflare_zone_id"></a> [cloudflare\_zone\_id](#input\_cloudflare\_zone\_id) | Cloudflare zone id to set CNAMEs. | `string` | `null` | no |
+| <a name="input_create_docker_pull_secret"></a> [create\_docker\_pull\_secret](#input\_create\_docker\_pull\_secret) | Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm\_values. | `bool` | `true` | no |
 | <a name="input_customer_facing"></a> [customer\_facing](#input\_customer\_facing) | Whether the connections are customer-facing (true limits access to dev-team-oncall/dev-team-managers/admin, false adds dev-team-engineering). | `bool` | `true` | no |
 | <a name="input_docker_email"></a> [docker\_email](#input\_docker\_email) | Docker email to pull images. | `string` | n/a | yes |
 | <a name="input_docker_password"></a> [docker\_password](#input\_docker\_password) | Docker password to pull images. | `string` | n/a | yes |
-| <a name="input_docker_registry_server"></a> [docker\_registry\_server](#input\_docker\_registry\_server) | Docker container registry server. | `string` | `"docker.io"` | no |
+| <a name="input_docker_pull_secret_name"></a> [docker\_pull\_secret\_name](#input\_docker\_pull\_secret\_name) | Kubernetes secret name for registry pull credentials. | `string` | `"docker-cfg"` | no |
+| <a name="input_docker_registry_server"></a> [docker\_registry\_server](#input\_docker\_registry\_server) | Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry. | `string` | `"docker.io"` | no |
 | <a name="input_docker_username"></a> [docker\_username](#input\_docker\_username) | Docker username to pull images. | `string` | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | The root domain used for the microservices. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Type of environment being deployed to. | `string` | `"enterprise"` | no |

--- a/gcp/workspaces/paragon/helm/helm.tf
+++ b/gcp/workspaces/paragon/helm/helm.tf
@@ -170,7 +170,13 @@ locals {
             }
           ),
           paragon_version = local.version
-        }
+        },
+        var.create_docker_pull_secret ? {
+          imagePullSecrets = concat(
+            try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
+            [{ name = var.docker_pull_secret_name }]
+          )
+        } : {}
       )
     }
   ))

--- a/gcp/workspaces/paragon/helm/helm.tf
+++ b/gcp/workspaces/paragon/helm/helm.tf
@@ -222,10 +222,12 @@ resource "kubernetes_config_map_v1" "feature_flag_content" {
   }
 }
 
-# kubernetes secret to pull docker image from docker hub
+# kubernetes secret to pull container images from a registry (Docker Hub, Artifactory, etc.)
 resource "kubernetes_secret_v1" "docker_login" {
+  count = var.create_docker_pull_secret ? 1 : 0
+
   metadata {
-    name      = "docker-cfg"
+    name      = var.docker_pull_secret_name
     namespace = kubernetes_namespace_v1.paragon.id
   }
 

--- a/gcp/workspaces/paragon/helm/helm.tf
+++ b/gcp/workspaces/paragon/helm/helm.tf
@@ -156,6 +156,13 @@ locals {
     if var.storage_service_account != null
   }
 
+  docker_pull_secret_global_values = var.create_docker_pull_secret ? {
+    imagePullSecrets = concat(
+      try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
+      [{ name = var.docker_pull_secret_name }]
+    )
+  } : {}
+
   global_values = yamlencode(merge(
     local.service_account_values,
     {
@@ -171,12 +178,7 @@ locals {
           ),
           paragon_version = local.version
         },
-        var.create_docker_pull_secret ? {
-          imagePullSecrets = concat(
-            try(nonsensitive(var.helm_values.global.imagePullSecrets), []),
-            [{ name = var.docker_pull_secret_name }]
-          )
-        } : {}
+        local.docker_pull_secret_global_values
       )
     }
   ))
@@ -185,7 +187,11 @@ locals {
   global_values_minus_env = yamlencode(merge(
     nonsensitive(var.helm_values),
     {
-      global = merge(nonsensitive(var.helm_values).global, { env = { HOST_ENV = "GCP_K8" } })
+      global = merge(
+        nonsensitive(var.helm_values).global,
+        { env = { HOST_ENV = "GCP_K8" } },
+        local.docker_pull_secret_global_values
+      )
     }
   ))
 

--- a/gcp/workspaces/paragon/helm/variables.tf
+++ b/gcp/workspaces/paragon/helm/variables.tf
@@ -26,8 +26,20 @@ variable "cluster_name" {
 }
 
 variable "docker_registry_server" {
-  description = "Docker container registry server."
+  description = "Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry."
   type        = string
+}
+
+variable "docker_pull_secret_name" {
+  description = "Kubernetes secret name for registry pull credentials."
+  type        = string
+  default     = "docker-cfg"
+}
+
+variable "create_docker_pull_secret" {
+  description = "Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm_values."
+  type        = bool
+  default     = true
 }
 
 variable "docker_username" {

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -23,34 +23,36 @@ module "managed_sync_config" {
 module "helm" {
   source = "./helm"
 
-  cluster_name            = local.cluster_name
-  docker_email            = var.docker_email
-  docker_password         = var.docker_password
-  docker_registry_server  = var.docker_registry_server
-  docker_username         = var.docker_username
-  domain                  = var.domain
-  feature_flags_content   = local.feature_flags_content
-  flipt_options           = local.flipt_options
-  gcp_creds               = local.gcp_creds
-  helm_values             = local.helm_values
-  ingress_scheme          = var.ingress_scheme
-  k8s_version             = var.k8s_version
-  logs_bucket             = local.logs_bucket
-  managed_sync_enabled    = var.managed_sync_enabled
-  managed_sync_version    = var.managed_sync_version
-  microservices           = local.microservices
-  monitor_version         = local.monitor_version
-  monitors                = local.monitors
-  monitors_enabled        = var.monitors_enabled
-  openobserve_email       = var.openobserve_email
-  openobserve_password    = var.openobserve_password
-  public_microservices    = local.public_microservices
-  public_monitors         = local.public_monitors
-  public_services         = local.public_services
-  region                  = var.region
-  storage_service_account = try(local.storage_output.service_account, null)
-  infra_vars              = local.infra_vars
-  workspace               = local.workspace
+  cluster_name              = local.cluster_name
+  docker_email              = var.docker_email
+  docker_password           = var.docker_password
+  docker_registry_server    = var.docker_registry_server
+  docker_pull_secret_name   = var.docker_pull_secret_name
+  create_docker_pull_secret = var.create_docker_pull_secret
+  docker_username           = var.docker_username
+  domain                    = var.domain
+  feature_flags_content     = local.feature_flags_content
+  flipt_options             = local.flipt_options
+  gcp_creds                 = local.gcp_creds
+  helm_values               = local.helm_values
+  ingress_scheme            = var.ingress_scheme
+  k8s_version               = var.k8s_version
+  logs_bucket               = local.logs_bucket
+  managed_sync_enabled      = var.managed_sync_enabled
+  managed_sync_version      = var.managed_sync_version
+  microservices             = local.microservices
+  monitor_version           = local.monitor_version
+  monitors                  = local.monitors
+  monitors_enabled          = var.monitors_enabled
+  openobserve_email         = var.openobserve_email
+  openobserve_password      = var.openobserve_password
+  public_microservices      = local.public_microservices
+  public_monitors           = local.public_monitors
+  public_services           = local.public_services
+  region                    = var.region
+  storage_service_account   = try(local.storage_output.service_account, null)
+  infra_vars                = local.infra_vars
+  workspace                 = local.workspace
 }
 
 module "hoop" {

--- a/gcp/workspaces/paragon/variables.tf
+++ b/gcp/workspaces/paragon/variables.tf
@@ -81,9 +81,21 @@ variable "domain" {
 }
 
 variable "docker_registry_server" {
-  description = "Docker container registry server."
+  description = "Container registry server for image pull credentials (e.g. docker.io or artifactory.example.com). Must match the host portion of global.imageRegistry when using a private registry."
   type        = string
   default     = "docker.io"
+}
+
+variable "docker_pull_secret_name" {
+  description = "Kubernetes secret name for registry pull credentials."
+  type        = string
+  default     = "docker-cfg"
+}
+
+variable "create_docker_pull_secret" {
+  description = "Create the registry pull secret in the paragon namespace. Set false when the customer pre-provisions the secret and sets global.imagePullSecrets in helm_values."
+  type        = bool
+  default     = true
 }
 
 variable "docker_username" {

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.06.25"
+version="2026.06.30"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-21725

### Brief Summary

private registry overrides for all helm workloads

### Detailed Summary

Enterprise customers often pull Paragon images through a private registry proxy (e.g. Artifactory) instead of public upstreams. This change adds centralized Helm helpers to rewrite image references, merge pull secrets globally, and optionally skip the default `useparagon/` prefix when mirroring. Terraform gains configurable pull-secret creation so customers can pre-provision credentials and reference them from Helm values.

### Changes

- Add `paragon-templates` helpers for image resolution, pull secrets, test/kubectl images, and a shared test-connection template
- Wire deployments, statefulsets, migrations, restart cron, and helm tests through the new helpers
- Add `global.imageRegistry`, `imageRepositoryPrefix`, `imagePullSecrets`, `testImage`, and `kubectlImage` values
- Make registry pull-secret creation optional and configurable via `docker_pull_secret_name` and `create_docker_pull_secret` across AWS, Azure, and GCP
- Document private registry configuration in README

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. Run `./prepare.sh -p aws -t <tag>` and `helm template` with sample `global.imageRegistry` / `imageRepositoryPrefix` values; verify rendered manifests point at the expected registry host
2. Grep rendered output for unexpected upstream hosts (`docker.io`, `ghcr.io`, `public.ecr.aws`)
3. Run `terraform validate` in `{aws,azure,gcp}/workspaces/paragon` with `create_docker_pull_secret = false` and confirm the docker login secret resource is omitted

### QA Notes

When `imageRepositoryPrefix` is omitted, `useparagon/` paths are preserved for mirrored layouts that keep that prefix. Setting it to `""` strips `useparagon/` without adding a replacement prefix.

### Deployment Notes

Customers using a private registry should set matching values in `.secure/values.yaml` (`global.imageRegistry`, `global.imagePullSecrets`) and `vars.auto.tfvars` (`docker_registry_server`, optionally `create_docker_pull_secret = false` and `docker_pull_secret_name`).

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide Helm and Terraform changes affect every workload image reference and pull credentials; misaligned registry host or pull-secret settings could block cluster rollouts, though defaults preserve current Docker Hub behavior.
> 
> **Overview**
> Adds **private registry / Artifactory proxy** support so enterprise deployments can pull all Paragon images through a customer mirror instead of public upstreams.
> 
> **Helm** introduces shared `paragon-templates` helpers (`paragon.image`, `paragon.imagePullSecrets`, `paragon.containerImage`, `test-connection.standard`, etc.) and wires deployments, statefulsets, migrations, jobs, logging/monitoring subcharts, and the restart cron through them. New `global` knobs include `imageRegistry`, optional `imageRepositoryPrefix` (rewrite or strip `useparagon/`), `migrationImageRegistry`, merged `imagePullSecrets`, and overrides for helm-test **busybox** and cron **kubectl** images. Per-chart hardcoded `docker-cfg` pull secrets are removed in favor of global merge.
> 
> **Terraform** (AWS, Azure, GCP paragon workspaces) adds `docker_pull_secret_name` and `create_docker_pull_secret`; the registry login secret is optional and, when created, its name is concatenated into Helm `global.imagePullSecrets`. `docker_registry_server` is documented to align with `global.imageRegistry` host. Root **README** documents the values + tfvars pairing; chart prep version bumps to `2026.06.30`; generated READMEs bump Terraform to `>= 1.9.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a50c3c509d000e8a8fd4533c231697d6f994c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->