### PR TITLE
fix(PARA-23478, PARA-23479): OpenObserve password policy and ALB ingress annotation

### DIFF
--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -268,15 +268,13 @@ resource "helm_release" "ingress" {
     value = "1"
   }
 
-  set {
-    name  = "podAnnotations.cluster-autoscaler\\.kubernetes\\.io/safe-to-evict"
-    value = "false"
-  }
-
   # Custom affinity replaces chart default (configureDefaultAffinity); include both
   # preferred on-demand placement and preferred per-host spread.
   values = [yamlencode({
     configureDefaultAffinity = false
+    podAnnotations = {
+      "cluster-autoscaler.kubernetes.io/safe-to-evict" = "false"
+    }
     affinity = {
       nodeAffinity = {
         preferredDuringSchedulingIgnoredDuringExecution = [{

--- a/aws/workspaces/paragon/helm/openobserve.tf
+++ b/aws/workspaces/paragon/helm/openobserve.tf
@@ -16,6 +16,9 @@ resource "random_password" "openobserve_password" {
   numeric          = true
   special          = true
   upper            = true
+  min_lower        = 2
+  min_upper        = 2
+  min_numeric      = 2
   min_special      = 2
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/azure/workspaces/paragon/helm/openobserve.tf
+++ b/azure/workspaces/paragon/helm/openobserve.tf
@@ -16,9 +16,9 @@ resource "random_password" "openobserve_password" {
   numeric          = true
   special          = true
   upper            = true
-  min_lower        = 1
-  min_upper        = 1
-  min_numeric      = 1
+  min_lower        = 2
+  min_upper        = 2
+  min_numeric      = 2
   min_special      = 2
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/azure/workspaces/paragon/helm/openobserve.tf
+++ b/azure/workspaces/paragon/helm/openobserve.tf
@@ -16,6 +16,9 @@ resource "random_password" "openobserve_password" {
   numeric          = true
   special          = true
   upper            = true
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
   min_special      = 2
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/gcp/workspaces/paragon/helm/openobserve.tf
+++ b/gcp/workspaces/paragon/helm/openobserve.tf
@@ -16,9 +16,9 @@ resource "random_password" "openobserve_password" {
   numeric          = true
   special          = true
   upper            = true
-  min_lower        = 1
-  min_upper        = 1
-  min_numeric      = 1
+  min_lower        = 2
+  min_upper        = 2
+  min_numeric      = 2
   min_special      = 2
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/gcp/workspaces/paragon/helm/openobserve.tf
+++ b/gcp/workspaces/paragon/helm/openobserve.tf
@@ -16,6 +16,9 @@ resource "random_password" "openobserve_password" {
   numeric          = true
   special          = true
   upper            = true
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
   min_special      = 2
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }


### PR DESCRIPTION
### Issues Closed

- PARA-23478
- PARA-23479

### Brief Summary

fix openobserve password generation and alb ingress annotation type

### Detailed Summary

During a staging `terraform apply`, two independent issues blocked the paragon workspace: OpenObserve password migration rejected Terraform-generated passwords that lacked digits, and the ALB ingress Helm release failed because `safe-to-evict` was coerced to a boolean instead of a string annotation. This PR fixes both at the source in `enterprise-installer`.

### Changes

- add `min_lower`, `min_upper`, and `min_numeric` constraints to `random_password.openobserve_password` on AWS, Azure, and GCP so generated passwords always satisfy OpenObserve v0.91.0 policy
- move `cluster-autoscaler.kubernetes.io/safe-to-evict` from a Helm `set` block into the `values` yamlencode block as string `"false"` in `aws/workspaces/paragon/helm/helm.tf`

### Unrelated Changes

None

### Future Work

None

### Steps to Test

1. Run `terraform apply` in `aws/workspaces/paragon/helm` on a cluster with an existing ingress release and confirm `helm_release.ingress` succeeds.
2. Inspect the ingress controller Deployment and verify `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` is a string annotation.
3. Apply with default generated OpenObserve credentials (no `openobserve_password` override) and confirm the secret password contains lower, upper, digit, and special characters.
4. On an existing cluster, run `scripts/migrate-openobserve-password.sh` and confirm the OpenObserve password update returns HTTP 200.

### QA Notes

- Existing clusters with an already-generated invalid OpenObserve password still need a one-time password rotation or manual override before migration succeeds; this PR prevents new invalid passwords from being generated.
- Ingress fix only affects AWS ALB controller deployments.

### Deployment Notes

- No customer config changes required.
- Existing OpenObserve installs may still need `migrate-openobserve-password.sh` after apply if the secret password was rotated.

### Screenshots

N/A — Terraform/IaC changes only.