### PR TITLE
fix: on-prem chart autoscaling and Zeus resources

### DIFF
--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -22,11 +22,11 @@ resources:
     memory: 800Mi
 
 autoscaling:
-  enabled: true
-  minReplicas: 2
-  maxReplicas: 20
-  targetCPUUtilizationPercentage: 75
-  targetMemoryUtilizationPercentage: 75
+  enabled: false
+  # minReplicas: 2
+  # maxReplicas: 20
+  # targetCPUUtilizationPercentage: 75
+  # targetMemoryUtilizationPercentage: 75
 
 secretName: "paragon-secrets"
 
@@ -42,6 +42,11 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ''
+
+env:
+  WORKER_SHARED_AUTOSCALING_DISABLED: false
+  WORKER_SHARED_SERVICE_MAX_INSTANCES: 20
+  WORKER_SHARED_SERVICE_MIN_INSTANCES: 2
 
 podAnnotations:
   prometheus.io/scrape: "true"

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -22,11 +22,11 @@ resources:
     memory: 1024Mi
 
 autoscaling:
-  enabled: true
-  minReplicas: 2
-  maxReplicas: 20
-  targetCPUUtilizationPercentage: 75
-  targetMemoryUtilizationPercentage: 75
+  enabled: false
+  # minReplicas: 2
+  # maxReplicas: 20
+  # targetCPUUtilizationPercentage: 75
+  # targetMemoryUtilizationPercentage: 75
 
 secretName: "paragon-secrets"
 
@@ -42,6 +42,11 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ''
+
+env:
+  WORKER_SHARED_AUTOSCALING_DISABLED: false
+  WORKER_SHARED_SERVICE_MAX_INSTANCES: 20
+  WORKER_SHARED_SERVICE_MIN_INSTANCES: 2
 
 podAnnotations:
   prometheus.io/scrape: "true"

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -22,11 +22,11 @@ resources:
     memory: 1200Mi
 
 autoscaling:
-  enabled: true
-  minReplicas: 2
-  maxReplicas: 20
-  targetCPUUtilizationPercentage: 75
-  targetMemoryUtilizationPercentage: 75
+  enabled: false
+  # minReplicas: 2
+  # maxReplicas: 20
+  # targetCPUUtilizationPercentage: 75
+  # targetMemoryUtilizationPercentage: 75
 
 secretName: "paragon-secrets"
 
@@ -42,6 +42,11 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ''
+
+env:
+  WORKER_SHARED_AUTOSCALING_DISABLED: false
+  WORKER_SHARED_SERVICE_MAX_INSTANCES: 20
+  WORKER_SHARED_SERVICE_MIN_INSTANCES: 2
 
 podAnnotations:
   prometheus.io/scrape: "true"

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -18,7 +18,7 @@ resources:
   limits:
     memory: 800Mi
   requests:
-    cpu: 200m
+    cpu: 400m
     memory: 800Mi
 
 autoscaling:

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.06.30"
+version="2026.07.08"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- [PARA-21305](https://useparagon.atlassian.net/browse/PARA-21305)
- [PARA-23037](https://useparagon.atlassian.net/browse/PARA-23037)
- [PARA-23041](https://useparagon.atlassian.net/browse/PARA-23041)

### Brief Summary

disable hpa for queue-scaled workers; raise zeus cpu defaults

### Detailed Summary

On-prem worker charts had both Kubernetes HPA and application-level queue-based autoscaling enabled, causing conflicting scale decisions (e.g. HPA scaling worker-triggerkit to max replicas with no queue activity). This aligns worker-triggerkit, worker-triggers, and worker-crons with the existing worker-workflows pattern: HPA disabled, min/max replica bounds set via `WORKER_SHARED_*` env vars.

Separately, raises Zeus default CPU request from 200m to 400m (memory already at 800Mi) per SEV-1014 follow-up to reduce under-provisioning and pod restarts on on-prem fleets.

### Changes

- Disable K8s HPA for `worker-triggerkit`, `worker-triggers`, and `worker-crons`
- Add `WORKER_SHARED_AUTOSCALING_DISABLED`, `WORKER_SHARED_SERVICE_MIN_INSTANCES` (2), and `WORKER_SHARED_SERVICE_MAX_INSTANCES` (20) env vars to mirror prior HPA bounds
- Raise Zeus CPU request from `200m` to `400m` in chart defaults
- Bump `prepare.sh` chart version to `2026.07.08`

### Unrelated Changes

None.

### Future Work

- Fleet remediation: apply updated Zeus resources and HPA removal to existing on-prem clusters via upgrade
- Consider whether other workers still on HPA should follow the same pattern

### Steps to Test

- [ ] Run `./prepare.sh -p aws -t <tag>` and verify prepared charts reflect the new values
- [ ] `helm lint aws/workspaces/paragon/charts/paragon-onprem/charts/worker-triggerkit` (and triggers/crons/zeus) on prepared charts
- [ ] Confirm HPA templates are not rendered when `autoscaling.enabled: false`
- [ ] Confirm env vars appear in deployment manifests for the three worker charts

### QA Notes

Customers upgrading will get HPA removed and app autoscaling env vars applied on next Helm deploy. Zeus pods will request 400m CPU on upgrade (may trigger rolling restart).

### Deployment Notes

Requires running `prepare.sh` and deploying updated charts. No Terraform changes.

### Screenshots

N/A — values.yaml changes only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default replica scaling for production workers on upgrade (HPA removed, app autoscaling only) and increases Zeus CPU scheduling footprint, which can cause rolling restarts and different scale behavior under load.
> 
> **Overview**
> **On-prem queue workers** (`worker-crons`, `worker-triggerkit`, `worker-triggers`) stop using Kubernetes HPA by default (`autoscaling.enabled: false`, prior min/max CPU/memory targets commented out). Scaling bounds move to app-level env: `WORKER_SHARED_SERVICE_MIN_INSTANCES` (2), `WORKER_SHARED_SERVICE_MAX_INSTANCES` (20), and `WORKER_SHARED_AUTOSCALING_DISABLED: false`—matching the existing `worker-workflows` / `pheme` chart pattern so queue-based scaling isn’t fighting CPU/memory HPA.
> 
> **Zeus** default CPU **request** rises from `200m` to `400m` (memory unchanged at `800Mi`); HPA for Zeus stays enabled.
> 
> **Release packaging:** `prepare.sh` chart version bumps from `2026.06.30` to `2026.07.08`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa8f76f6cd0399656106b416001ae6526bc767b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PARA-21305]: https://useparagon.atlassian.net/browse/PARA-21305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PARA-23037]: https://useparagon.atlassian.net/browse/PARA-23037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PARA-23041]: https://useparagon.atlassian.net/browse/PARA-23041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ