### PR TITLE
fix(PARA-23614): deepCopy before sprig merge in fluent-bit templates

### DIFF
--- a/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
@@ -39,7 +39,7 @@ containers:
     securityContext:
       {{- toYaml . | nindent 6 }}
   {{- end }}
-    image: {{ include "fluent-bit.image" (merge .Values.image (dict "tag" (default .Chart.AppVersion .Values.image.tag) "root" .)) | quote }}
+    image: {{ include "fluent-bit.image" (merge (deepCopy .Values.image) (dict "tag" (default .Chart.AppVersion .Values.image.tag) "root" .)) | quote }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
   {{- if or .Values.env .Values.envWithTpl }}
     env:
@@ -104,7 +104,7 @@ containers:
     {{- end }}
 {{- if .Values.hotReload.enabled }}
   - name: reloader
-    image: {{ include "fluent-bit.image" (merge .Values.hotReload.image (dict "root" .)) | quote }}
+    image: {{ include "fluent-bit.image" (merge (deepCopy .Values.hotReload.image) (dict "root" .)) | quote }}
     args:
       - {{ printf "-webhook-url=http://localhost:%s/api/v2/reload" (toString .Values.metricsPort) }}
       - -volume-dir=/watch/config

--- a/charts/paragon-logging/charts/fluent-bit/templates/tests/test-connection.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/templates/tests/test-connection.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: {{ include "fluent-bit.image" (merge .Values.testFramework.image (dict "root" .)) | quote }}
+      image: {{ include "fluent-bit.image" (merge (deepCopy .Values.testFramework.image) (dict "root" .)) | quote }}
       imagePullPolicy: {{ .Values.testFramework.image.pullPolicy }}
       command: ["sh"]
       args: ["-c", "wget -O- {{ include "fluent-bit.fullname" . }}:{{ .Values.service.port }}"]


### PR DESCRIPTION
### Issues Closed

- [PARA-23614](https://useparagon.atlassian.net/browse/PARA-23614)

### Brief Summary

fix fluent-bit helm release encode cycle

### Detailed Summary

Sprig `merge` mutates its first argument. In fluent-bit templates we merged `dict "root" .` into `.Values.image` (and hotReload/testFramework image maps), which wrote the Helm root context into Values and created a cycle when Helm JSON-encoded the release secret. That broke `terraform apply` / `helm upgrade` for `paragon-logging` with `json: unsupported value: encountered a cycle via map[string]interface {}`. Fixed by `deepCopy` before `merge` so Values is not mutated while image helpers still get the root context for registry overrides.

### Changes

- `deepCopy` `.Values.image` before `merge` in fluent-bit `_pod.tpl`
- `deepCopy` `.Values.hotReload.image` before `merge` in fluent-bit `_pod.tpl`
- `deepCopy` `.Values.testFramework.image` before `merge` in fluent-bit `test-connection.yaml`

### Unrelated Changes

None.

### Future Work

None.

### Steps to Test

1. From a prepared `paragon-logging` chart that includes this change, run `helm upgrade --install paragon-logging ./charts/paragon-logging` (or Terraform `helm_release.paragon_logging`).
2. Confirm the release reaches `deployed` with no encode-cycle error.
3. Confirm fluent-bit DaemonSet pods are Running and image refs still resolve correctly when registry overrides are set.

### QA Notes

`helm template` alone may still succeed on the broken chart; the failure is on release encode/storage. Prefer a real install/upgrade (or Terraform apply) to verify.

### Deployment Notes

Customer/prepared charts under `<provider>/workspaces/paragon/charts/` are gitignored and must be refreshed via `prepare.sh` (or equivalent copy) after merge so the fix is what Terraform deploys.

### Screenshots

N/A

[PARA-23614]: https://useparagon.atlassian.net/browse/PARA-23614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Helm template-only change that preserves rendered image strings while fixing release persistence; verify with a real upgrade/apply rather than template-only.
> 
> **Overview**
> Fixes **`paragon-logging` / fluent-bit** installs failing on release encode with `json: unsupported value: encountered a cycle via map[string]interface {}` during `helm upgrade` or Terraform apply.
> 
> Sprig **`merge` mutates its first argument**. Templates were merging a `dict` that includes **`root` .** directly into **`.Values.image`**, **`.Values.hotReload.image`**, and **`.Values.testFramework.image`**, which injected the Helm root context into Values and created a reference cycle when Helm persisted the release. Each of those three **`fluent-bit.image`** call sites now **`deepCopy`s** the Values image map **before** `merge`, so registry/tag helpers still receive **`root`** without mutating chart values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b4cec2c8f86e4e27c6451276c696a00d67c987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->