### PR TITLE
Feat/para 21728/eks pod identity s3 grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ This will produce an `infra-output.json` file that will generally follow the sch
     "value": {
       "private_bucket": "<private-bucket-name>",
       "public_bucket": "<public-bucket-name>",
-      "root_password": "<iam-password>",
-      "root_user": "<iam-username>"
+      "role_arn": "<iam-role-arn-for-eks-pod-identity>"
     }
   },
   "postgres": {

--- a/aws/workspaces/infra/cluster/eks_addons.tf
+++ b/aws/workspaces/infra/cluster/eks_addons.tf
@@ -68,8 +68,6 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
 }
 
 resource "aws_eks_addon" "eks_pod_identity_agent" {
-  count = var.enable_karpenter ? 1 : 0
-
   cluster_name                = module.eks.cluster_name
   addon_name                  = "eks-pod-identity-agent"
   addon_version               = local.eks_addon_versions["eks-pod-identity-agent"]

--- a/aws/workspaces/infra/outputs.tf
+++ b/aws/workspaces/infra/outputs.tf
@@ -40,13 +40,12 @@ output "auditlogs_bucket" {
 }
 
 output "storage" {
-  description = "Object storage connection info."
+  description = "Object storage connection info. S3 access uses EKS Pod Identity (role_arn); static access keys are no longer provisioned."
   value = {
     public_bucket       = module.storage.s3.public_bucket
     private_bucket      = module.storage.s3.private_bucket
     managed_sync_bucket = module.storage.s3.managed_sync_bucket
-    root_user           = module.storage.s3.access_key_id
-    root_password       = module.storage.s3.access_key_secret
+    role_arn            = module.storage.s3.role_arn
     kms_key_arn         = module.storage.s3.kms_key_arn
   }
   sensitive = true

--- a/aws/workspaces/infra/storage/outputs.tf
+++ b/aws/workspaces/infra/storage/outputs.tf
@@ -1,7 +1,6 @@
 output "s3" {
   value = {
-    access_key_id       = aws_iam_access_key.app.id
-    access_key_secret   = aws_iam_access_key.app.secret
+    role_arn            = aws_iam_role.app.arn
     private_bucket      = aws_s3_bucket.app.bucket
     public_bucket       = aws_s3_bucket.cdn.bucket
     auditlogs_bucket    = aws_s3_bucket.auditlogs.bucket

--- a/aws/workspaces/infra/storage/s3-app.tf
+++ b/aws/workspaces/infra/storage/s3-app.tf
@@ -106,31 +106,34 @@ resource "aws_s3_bucket_policy" "app" {
   policy = data.aws_iam_policy_document.app.json
 }
 
-resource "aws_iam_user" "app" {
-  name = "${var.workspace}-s3-user"
-
-  tags = {
-    Name = "${var.workspace}-s3-user"
+# EKS Pod Identity role for Paragon microservices that access app/cdn/auditlogs S3 buckets.
+# Associations (SA → role) are created in the paragon workspace.
+data "aws_iam_policy_document" "app_assume" {
+  statement {
+    sid = "PodIdentity"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
   }
 }
 
-resource "aws_iam_access_key" "app" {
-  user = aws_iam_user.app.name
+resource "aws_iam_role" "app" {
+  name               = "${var.workspace}-s3"
+  assume_role_policy = data.aws_iam_policy_document.app_assume.json
+
+  tags = {
+    Name = "${var.workspace}-s3"
+  }
 }
 
-resource "aws_iam_group" "app_group" {
-  name = "${var.workspace}-s3-user-group"
-}
-
-resource "aws_iam_group_membership" "app_group_membership" {
-  name  = "${var.workspace}-s3-user-group-membership"
-  group = aws_iam_group.app_group.name
-  users = [aws_iam_user.app.name]
-}
-
-resource "aws_iam_group_policy" "app" {
-  name  = "${var.workspace}-s3-user-group-policy"
-  group = aws_iam_group.app_group.name
+resource "aws_iam_role_policy" "app" {
+  name = "${var.workspace}-s3-policy"
+  role = aws_iam_role.app.id
 
   policy = jsonencode(
     {

--- a/aws/workspaces/infra/storage/s3-kms.tf
+++ b/aws/workspaces/infra/storage/s3-kms.tf
@@ -22,9 +22,8 @@ module "s3_kms_key" {
 
   key_administrators = var.admin_arns
 
-  # the application reads/writes objects via this IAM user, so it must be able to
-  # use the key to encrypt/decrypt objects
-  key_users = [aws_iam_user.app.arn]
+  # Pod Identity role used by Paragon workloads to read/write encrypted objects
+  key_users = [aws_iam_role.app.arn]
 
   computed_aliases = {
     s3 = { name = "s3/${var.workspace}" }

--- a/aws/workspaces/paragon/helm-config/outputs.tf
+++ b/aws/workspaces/paragon/helm-config/outputs.tf
@@ -1,3 +1,7 @@
 output "config" {
-  value = local.managed_sync_secrets
+  value = {
+    for key, value in local.managed_sync_secrets :
+    key => value
+    if value != null
+  }
 }

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,8 +66,10 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_USER"], local.storage_output.root_user)
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_PASS"], local.storage_output.root_password)
+    # TODO(PARA-21728 follow-up): Managed Sync Pod Identity — do not inject static S3 keys on AWS.
+    # Optional override only if explicitly provided in customer helm values.
+    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
+    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -88,11 +90,12 @@ locals {
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
-    CLOUD_STORAGE_USER                = local.storage_config.user
-    CLOUD_STORAGE_PASS                = local.storage_config.pass
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
+    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
+    CLOUD_STORAGE_USER = local.storage_config.user
+    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -80,17 +80,47 @@ module "managed_sync_config" {
   microservices    = local.microservices
 }
 
+# EKS Pod Identity: associate Paragon ServiceAccounts with the infra S3 IAM role.
+module "pod_identity" {
+  source = "./pod-identity"
+  count  = try(local.storage_output.role_arn, null) != null ? 1 : 0
+
+  cluster_name = local.cluster_name
+  namespace    = module.helm.namespace_paragon.id
+  s3_role_arn  = local.storage_output.role_arn
+  service_accounts = toset([
+    "api-triggerkit",
+    "cache-replay",
+    "hades",
+    "health-checker",
+    "hermes",
+    "release",
+    "zeus",
+    "worker-actionkit",
+    "worker-actions",
+    "worker-auditlogs",
+    "worker-credentials",
+    "worker-crons",
+    "worker-deployments",
+    "worker-eventlogs",
+    "worker-proxy",
+    "worker-triggerkit",
+    "worker-triggers",
+    "worker-workflows",
+  ])
+}
+
 module "monitors" {
   source = "./monitors"
   count  = var.monitors_enabled ? 1 : 0
 
-  grafana_admin_email           = try(local.helm_vars.global.env["MONITOR_GRAFANA_SECURITY_ADMIN_USER"], null)
-  grafana_admin_password        = try(local.helm_vars.global.env["MONITOR_GRAFANA_SECURITY_ADMIN_PASSWORD"], null)
-  grafana_aws_access_key_id     = try(local.helm_vars.global.env["MONITOR_GRAFANA_AWS_ACCESS_ID"], null)
-  grafana_aws_secret_access_key = try(local.helm_vars.global.env["MONITOR_GRAFANA_AWS_SECRET_KEY"], null)
-  pgadmin_admin_email           = try(local.helm_vars.global.env["MONITOR_PGADMIN_EMAIL"], null)
-  pgadmin_admin_password        = try(local.helm_vars.global.env["MONITOR_PGADMIN_PASSWORD"], null)
-  workspace                     = local.workspace
+  grafana_admin_email    = try(local.helm_vars.global.env["MONITOR_GRAFANA_SECURITY_ADMIN_USER"], null)
+  grafana_admin_password = try(local.helm_vars.global.env["MONITOR_GRAFANA_SECURITY_ADMIN_PASSWORD"], null)
+  pgadmin_admin_email    = try(local.helm_vars.global.env["MONITOR_PGADMIN_EMAIL"], null)
+  pgadmin_admin_password = try(local.helm_vars.global.env["MONITOR_PGADMIN_PASSWORD"], null)
+  workspace              = local.workspace
+  cluster_name           = local.cluster_name
+  namespace              = module.helm.namespace_paragon.id
 }
 
 module "uptime" {

--- a/aws/workspaces/paragon/monitors/grafana.tf
+++ b/aws/workspaces/paragon/monitors/grafana.tf
@@ -1,39 +1,31 @@
-resource "aws_iam_user" "grafana" {
-  count = var.grafana_aws_access_key_id == null && var.grafana_aws_secret_access_key == null ? 1 : 0
+# Grafana CloudWatch access via EKS Pod Identity (no long-lived IAM access keys).
+data "aws_iam_policy_document" "grafana_assume" {
+  statement {
+    sid = "PodIdentity"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
 
-  name = "${var.workspace}-iam-grafana"
-  path = "/env/"
+resource "aws_iam_role" "grafana" {
+  name               = "${var.workspace}-iam-grafana"
+  path               = "/env/"
+  assume_role_policy = data.aws_iam_policy_document.grafana_assume.json
 
   tags = {
     Name = "${var.workspace}-iam-grafana"
   }
 }
 
-resource "aws_iam_access_key" "grafana" {
-  count = var.grafana_aws_access_key_id == null && var.grafana_aws_secret_access_key == null ? 1 : 0
-
-  user = aws_iam_user.grafana[0].name
-}
-
-resource "aws_iam_group" "grafana" {
-  count = var.grafana_aws_access_key_id == null && var.grafana_aws_secret_access_key == null ? 1 : 0
-
-  name = "${var.workspace}-iam-grafana-group"
-}
-
-resource "aws_iam_group_membership" "grafana" {
-  count = var.grafana_aws_access_key_id == null && var.grafana_aws_secret_access_key == null ? 1 : 0
-
-  name  = "${var.workspace}-iam-grafana-group-membership"
-  group = aws_iam_group.grafana[0].name
-  users = [aws_iam_user.grafana[0].name]
-}
-
-resource "aws_iam_group_policy" "grafana_ro" {
-  count = var.grafana_aws_access_key_id == null && var.grafana_aws_secret_access_key == null ? 1 : 0
-
-  name  = "${var.workspace}-iam-grafana-group-policy"
-  group = aws_iam_group.grafana[0].name
+resource "aws_iam_role_policy" "grafana_ro" {
+  name = "${var.workspace}-iam-grafana-policy"
+  role = aws_iam_role.grafana.id
 
   policy = jsonencode({
     "Version" : "2012-10-17",
@@ -62,6 +54,13 @@ resource "aws_iam_group_policy" "grafana_ro" {
       }
     ]
   })
+}
+
+resource "aws_eks_pod_identity_association" "grafana" {
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = "grafana"
+  role_arn        = aws_iam_role.grafana.arn
 }
 
 resource "random_string" "grafana_admin_email_prefix" {

--- a/aws/workspaces/paragon/monitors/outputs.tf
+++ b/aws/workspaces/paragon/monitors/outputs.tf
@@ -1,13 +1,6 @@
-output "grafana_aws_access_key_id" {
-  description = "AWS access key id for Grafana. Optional and can be provisioned outside of Terraform."
-  sensitive   = true
-  value       = var.grafana_aws_access_key_id != null ? var.grafana_aws_access_key_id : aws_iam_access_key.grafana[0].id
-}
-
-output "grafana_aws_secret_access_key" {
-  description = "AWS secret access key for Grafana. Optional and can be provisioned outside of Terraform."
-  sensitive   = true
-  value       = var.grafana_aws_secret_access_key != null ? var.grafana_aws_secret_access_key : aws_iam_access_key.grafana[0].secret
+output "grafana_role_arn" {
+  description = "IAM role ARN for Grafana CloudWatch access via EKS Pod Identity."
+  value       = aws_iam_role.grafana.arn
 }
 
 output "grafana_admin_email" {

--- a/aws/workspaces/paragon/monitors/variables.tf
+++ b/aws/workspaces/paragon/monitors/variables.tf
@@ -3,16 +3,14 @@ variable "workspace" {
   type        = string
 }
 
-variable "grafana_aws_access_key_id" {
-  description = "AWS access key id for Grafana. Optional and can be provisioned outside of Terraform."
+variable "cluster_name" {
+  description = "EKS cluster name for Grafana Pod Identity association."
   type        = string
-  default     = null
 }
 
-variable "grafana_aws_secret_access_key" {
-  description = "AWS secret access key for Grafana. Optional and can be provisioned outside of Terraform."
+variable "namespace" {
+  description = "Kubernetes namespace where the grafana ServiceAccount lives."
   type        = string
-  default     = null
 }
 
 variable "grafana_admin_email" {

--- a/aws/workspaces/paragon/pod-identity/associations.tf
+++ b/aws/workspaces/paragon/pod-identity/associations.tf
@@ -1,0 +1,8 @@
+resource "aws_eks_pod_identity_association" "s3" {
+  for_each = var.service_accounts
+
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = each.value
+  role_arn        = var.s3_role_arn
+}

--- a/aws/workspaces/paragon/pod-identity/outputs.tf
+++ b/aws/workspaces/paragon/pod-identity/outputs.tf
@@ -1,0 +1,7 @@
+output "s3_associations" {
+  description = "Pod Identity associations for S3 access."
+  value = {
+    for name, assoc in aws_eks_pod_identity_association.s3 :
+    name => assoc.association_arn
+  }
+}

--- a/aws/workspaces/paragon/pod-identity/variables.tf
+++ b/aws/workspaces/paragon/pod-identity/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_name" {
+  description = "EKS cluster name for Pod Identity associations."
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for Paragon workloads."
+  type        = string
+}
+
+variable "s3_role_arn" {
+  description = "IAM role ARN for S3 access via EKS Pod Identity."
+  type        = string
+}
+
+variable "service_accounts" {
+  description = "Kubernetes ServiceAccount names that should assume the S3 Pod Identity role."
+  type        = set(string)
+}

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -814,6 +814,11 @@ locals {
     "POSTGRES_DATABASE",
     "REDIS_HOST",
     "REDIS_PORT",
+    # AWS uses EKS Pod Identity — strip static access keys even if present in customer values.
+    "CLOUD_STORAGE_MICROSERVICE_USER",
+    "CLOUD_STORAGE_MICROSERVICE_PASS",
+    "MONITOR_GRAFANA_AWS_ACCESS_ID",
+    "MONITOR_GRAFANA_AWS_SECRET_KEY",
   ]
 
   default_redis_cluster = try(
@@ -989,13 +994,11 @@ locals {
           WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
           WORKFLOW_REDIS_URL             = try("${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}", local.default_redis_url)
 
-          # Cloud Storage configurations
-          CLOUD_STORAGE_MICROSERVICE_PASS = local.storage_output.root_password
-          CLOUD_STORAGE_MICROSERVICE_USER = local.storage_output.root_user
-          CLOUD_STORAGE_PUBLIC_BUCKET     = try(local.storage_output.public_bucket, "${local.workspace}-cdn")
-          CLOUD_STORAGE_SYSTEM_BUCKET     = try(local.storage_output.private_bucket, "${local.workspace}-app")
-          CLOUD_STORAGE_TYPE              = local.cloud_storage_type
-          CLOUD_STORAGE_REGION            = var.aws_region
+          # Cloud Storage configurations (S3 auth via EKS Pod Identity; no static access keys)
+          CLOUD_STORAGE_PUBLIC_BUCKET = try(local.storage_output.public_bucket, "${local.workspace}-cdn")
+          CLOUD_STORAGE_SYSTEM_BUCKET = try(local.storage_output.private_bucket, "${local.workspace}-app")
+          CLOUD_STORAGE_TYPE          = local.cloud_storage_type
+          CLOUD_STORAGE_REGION        = var.aws_region
 
           CLOUD_STORAGE_PUBLIC_URL = coalesce(
             try(local.helm_vars.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
@@ -1006,11 +1009,9 @@ locals {
             local.cloud_storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
           )
 
-          # Monitor configurations
+          # Monitor configurations (Grafana CloudWatch via EKS Pod Identity; no static AWS keys)
           MONITOR_BULL_EXPORTER_HOST               = "http://bull-exporter"
           MONITOR_BULL_EXPORTER_PORT               = try(local.monitors["bull-exporter"].port, null)
-          MONITOR_GRAFANA_AWS_ACCESS_ID            = var.monitors_enabled ? module.monitors[0].grafana_aws_access_key_id : null
-          MONITOR_GRAFANA_AWS_SECRET_KEY           = var.monitors_enabled ? module.monitors[0].grafana_aws_secret_access_key : null
           MONITOR_GRAFANA_HOST                     = "http://grafana"
           MONITOR_GRAFANA_PORT                     = try(local.monitors["grafana"].port, null)
           MONITOR_GRAFANA_SECURITY_ADMIN_PASSWORD  = var.monitors_enabled ? module.monitors[0].grafana_admin_password : null

--- a/charts/example.yaml
+++ b/charts/example.yaml
@@ -293,12 +293,14 @@ secrets:
   ZEUS_POSTGRES_USERNAME: "your-zeus-db-username"
   
   # Cloud Storage
-  CLOUD_STORAGE_MICROSERVICE_PASS: "your-s3-secret-key"
-  CLOUD_STORAGE_MICROSERVICE_USER: "your-s3-access-key"
+  # On AWS, S3 auth uses EKS Pod Identity — do not set CLOUD_STORAGE_MICROSERVICE_USER/PASS.
+  # CLOUD_STORAGE_MICROSERVICE_PASS: "your-s3-secret-key"   # legacy / MinIO only
+  # CLOUD_STORAGE_MICROSERVICE_USER: "your-s3-access-key"   # legacy / MinIO only
   
   # Monitoring
-  MONITOR_GRAFANA_AWS_ACCESS_ID: "your-grafana-aws-access-key"
-  MONITOR_GRAFANA_AWS_SECRET_KEY: "your-grafana-aws-secret-key"
+  # On AWS, Grafana CloudWatch uses EKS Pod Identity — do not set MONITOR_GRAFANA_AWS_*.
+  # MONITOR_GRAFANA_AWS_ACCESS_ID: "your-grafana-aws-access-key"   # legacy only
+  # MONITOR_GRAFANA_AWS_SECRET_KEY: "your-grafana-aws-secret-key"  # legacy only
   MONITOR_GRAFANA_SECURITY_ADMIN_PASSWORD: "your-grafana-admin-password"
   MONITOR_GRAFANA_SECURITY_ADMIN_USER: "your-grafana-admin-email@example.com"
   MONITOR_PGADMIN_EMAIL: "your-pgadmin-email@example.com"

--- a/charts/paragon-onprem/charts/api-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'api-triggerkit'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/cache-replay/values.yaml
+++ b/charts/paragon-onprem/charts/cache-replay/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'cache-replay'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/hades/values.yaml
+++ b/charts/paragon-onprem/charts/hades/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'hades'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/health-checker/values.yaml
+++ b/charts/paragon-onprem/charts/health-checker/values.yaml
@@ -97,7 +97,7 @@ fullnameOverride: 'health-checker'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -52,7 +52,7 @@ fullnameOverride: 'hermes'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'release'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-actionkit'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-actions'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: "worker-auditlogs"
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-credentials'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-crons'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-deployments'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-eventlogs'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-proxy'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-triggerkit'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-triggers'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-workflows'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'zeus'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
### Issues Closed

- PARA-21728

### Brief Summary

replace aws s3/grafana iam keys with eks pod identity

### Detailed Summary

AWS enterprise deployments stop provisioning long-lived IAM access keys for S3 consumers and Grafana CloudWatch. Workloads authenticate via EKS Pod Identity (IAM roles + ServiceAccount associations). The `eks-pod-identity-agent` addon is always installed for both legacy managed node groups and Karpenter. Azure/GCP are unchanged and still inject storage credentials.

Cutover depends on monorepo support for ambient AWS credentials when static keys are absent (PARA-23624, PARA-23625, PARA-23626).

### Changes

- Always install `eks-pod-identity-agent` (no longer gated on Karpenter; no Terraform state move)
- Replace S3 IAM user/access keys with a Pod Identity IAM role; keep the same S3/KMS policy statements; export `role_arn` instead of `root_user`/`root_password`
- Point S3 KMS `key_users` at the new role ARN
- Add Pod Identity associations for Paragon S3 consumer ServiceAccounts
- Replace Grafana IAM user/access keys with a Pod Identity role + CloudWatch RO policy and association for the `grafana` ServiceAccount
- Stop injecting / strip `CLOUD_STORAGE_MICROSERVICE_USER`/`PASS` and `MONITOR_GRAFANA_AWS_*` on AWS; stop copying static S3 keys into Managed Sync secrets
- Enable dedicated ServiceAccounts (`serviceAccount.create: true`) on S3 consumer charts
- Update example values and README storage output schema for Pod Identity

### Unrelated Changes

N/A

### Future Work

- PARA-23624 / PARA-23626: monorepo S3 ambient credentials (mirror GCP PARA-13362) — required before production cutover
- PARA-23625: Grafana CloudWatch optional AWS keys / default auth — required before Grafana cutover
- Managed Sync Pod Identity association (out of scope; external chart SA)

### Steps to Test

1. `terraform init -backend=false && terraform validate` in `aws/workspaces/infra` and `aws/workspaces/paragon`
2. On an existing MNG (legacy) AWS workspace: plan should **create** `eks-pod-identity-agent`, S3/Grafana roles, and Pod Identity associations; destroy S3/Grafana IAM users and access keys
3. Confirm plan does not recreate unrelated core addons (vpc-cni, coredns, etc.)
4. After monorepo ambient-cred changes are deployed: verify a consumer pod and Grafana can access S3 / CloudWatch with no static access keys in env

### QA Notes

- Do not fully cut over (remove keys / rely on Pod Identity) until PARA-23624 and PARA-23625 are shipped
- Azure and GCP behavior is intentionally unchanged
- Chart SA creation is cloud-agnostic; Pod Identity wiring is AWS-only via Terraform

### Deployment Notes

- Infra output `storage.value` no longer includes `root_user`/`root_password`; consumers must use `role_arn`
- Applying this will destroy existing S3 and Grafana IAM users/access keys on AWS
- Ensure monorepo ambient credential support is live before applying to production if apps still require `CLOUD_STORAGE_MICROSERVICE_*` / `MONITOR_GRAFANA_AWS_*`

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Apply destroys existing S3 and Grafana IAM users/access keys and changes how all S3 consumer pods and Grafana authenticate; mis-timed rollout or missing monorepo ambient-credential support can break object storage and CloudWatch dashboards until Pod Identity and app changes are aligned.
> 
> **Overview**
> **AWS enterprise deployments** move S3 and Grafana CloudWatch auth from long-lived IAM access keys to **EKS Pod Identity** (IAM roles bound to Kubernetes ServiceAccounts).
> 
> Infra always installs the **eks-pod-identity-agent** add-on (no longer tied to Karpenter). S3 access drops the dedicated IAM user, group, and access keys in favor of a Pod Identity role with the same bucket/KMS permissions; Terraform now exports **`role_arn`** instead of **`root_user`** / **`root_password`**, and the README infra-output schema is updated accordingly.
> 
> The **paragon** workspace wires Pod Identity: a new **`pod-identity`** module associates the infra S3 role with 18 Paragon consumer ServiceAccounts, and Grafana gets its own role plus a **`grafana`** ServiceAccount association for CloudWatch read-only access. Helm/env injection stops setting **`CLOUD_STORAGE_MICROSERVICE_*`** and **`MONITOR_GRAFANA_AWS_*`** on AWS (keys are stripped from customer values too), and Managed Sync secrets no longer auto-fill static S3 keys unless explicitly overridden.
> 
> **Helm charts** for S3 consumer microservices flip **`serviceAccount.create`** to **`true`** so pods run under named ServiceAccounts that match the Terraform associations. Docs in **`charts/example.yaml`** call out Pod Identity for AWS vs legacy key-based config for MinIO/other clouds.
> 
> Production cutover still depends on application support for ambient AWS credentials when static keys are absent (noted in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ebdc5d51d107b188dad916126e534b116623013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->