### PR TITLE
feat(aws): adopt EKS Pod Identity for S3 microservices

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ This will produce an `infra-output.json` file that will generally follow the sch
     "value": {
       "private_bucket": "<private-bucket-name>",
       "public_bucket": "<public-bucket-name>",
-      "root_password": "<iam-password>",
-      "root_user": "<iam-username>"
+      "role_arn": "<iam-role-arn-for-eks-pod-identity>"
     }
   },
   "postgres": {

--- a/aws/workspaces/infra/cluster/eks_addons.tf
+++ b/aws/workspaces/infra/cluster/eks_addons.tf
@@ -68,8 +68,6 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
 }
 
 resource "aws_eks_addon" "eks_pod_identity_agent" {
-  count = var.enable_karpenter ? 1 : 0
-
   cluster_name                = module.eks.cluster_name
   addon_name                  = "eks-pod-identity-agent"
   addon_version               = local.eks_addon_versions["eks-pod-identity-agent"]

--- a/aws/workspaces/infra/outputs.tf
+++ b/aws/workspaces/infra/outputs.tf
@@ -40,13 +40,12 @@ output "auditlogs_bucket" {
 }
 
 output "storage" {
-  description = "Object storage connection info."
+  description = "Object storage connection info. S3 access uses EKS Pod Identity (role_arn); static access keys are no longer provisioned."
   value = {
     public_bucket       = module.storage.s3.public_bucket
     private_bucket      = module.storage.s3.private_bucket
     managed_sync_bucket = module.storage.s3.managed_sync_bucket
-    root_user           = module.storage.s3.access_key_id
-    root_password       = module.storage.s3.access_key_secret
+    role_arn            = module.storage.s3.role_arn
     kms_key_arn         = module.storage.s3.kms_key_arn
   }
   sensitive = true

--- a/aws/workspaces/infra/storage/outputs.tf
+++ b/aws/workspaces/infra/storage/outputs.tf
@@ -1,7 +1,6 @@
 output "s3" {
   value = {
-    access_key_id       = aws_iam_access_key.app.id
-    access_key_secret   = aws_iam_access_key.app.secret
+    role_arn            = aws_iam_role.app.arn
     private_bucket      = aws_s3_bucket.app.bucket
     public_bucket       = aws_s3_bucket.cdn.bucket
     auditlogs_bucket    = aws_s3_bucket.auditlogs.bucket

--- a/aws/workspaces/infra/storage/s3-app.tf
+++ b/aws/workspaces/infra/storage/s3-app.tf
@@ -106,31 +106,34 @@ resource "aws_s3_bucket_policy" "app" {
   policy = data.aws_iam_policy_document.app.json
 }
 
-resource "aws_iam_user" "app" {
-  name = "${var.workspace}-s3-user"
-
-  tags = {
-    Name = "${var.workspace}-s3-user"
+# EKS Pod Identity role for Paragon microservices that access app/cdn/auditlogs S3 buckets.
+# Associations (SA → role) are created in the paragon workspace.
+data "aws_iam_policy_document" "app_assume" {
+  statement {
+    sid = "PodIdentity"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
   }
 }
 
-resource "aws_iam_access_key" "app" {
-  user = aws_iam_user.app.name
+resource "aws_iam_role" "app" {
+  name               = "${var.workspace}-s3"
+  assume_role_policy = data.aws_iam_policy_document.app_assume.json
+
+  tags = {
+    Name = "${var.workspace}-s3"
+  }
 }
 
-resource "aws_iam_group" "app_group" {
-  name = "${var.workspace}-s3-user-group"
-}
-
-resource "aws_iam_group_membership" "app_group_membership" {
-  name  = "${var.workspace}-s3-user-group-membership"
-  group = aws_iam_group.app_group.name
-  users = [aws_iam_user.app.name]
-}
-
-resource "aws_iam_group_policy" "app" {
-  name  = "${var.workspace}-s3-user-group-policy"
-  group = aws_iam_group.app_group.name
+resource "aws_iam_role_policy" "app" {
+  name = "${var.workspace}-s3-policy"
+  role = aws_iam_role.app.id
 
   policy = jsonencode(
     {

--- a/aws/workspaces/infra/storage/s3-kms.tf
+++ b/aws/workspaces/infra/storage/s3-kms.tf
@@ -22,9 +22,8 @@ module "s3_kms_key" {
 
   key_administrators = var.admin_arns
 
-  # the application reads/writes objects via this IAM user, so it must be able to
-  # use the key to encrypt/decrypt objects
-  key_users = [aws_iam_user.app.arn]
+  # Pod Identity role used by Paragon workloads to read/write encrypted objects
+  key_users = [aws_iam_role.app.arn]
 
   computed_aliases = {
     s3 = { name = "s3/${var.workspace}" }

--- a/aws/workspaces/paragon/helm-config/outputs.tf
+++ b/aws/workspaces/paragon/helm-config/outputs.tf
@@ -1,3 +1,7 @@
 output "config" {
-  value = local.managed_sync_secrets
+  value = {
+    for key, value in local.managed_sync_secrets :
+    key => value
+    if value != null
+  }
 }

--- a/aws/workspaces/paragon/helm-config/outputs.tf
+++ b/aws/workspaces/paragon/helm-config/outputs.tf
@@ -1,7 +1,3 @@
 output "config" {
-  value = {
-    for key, value in local.managed_sync_secrets :
-    key => value
-    if value != null
-  }
+  value = local.managed_sync_secrets
 }

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,10 +66,9 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    # TODO(PARA-21728 follow-up): Managed Sync Pod Identity — do not inject static S3 keys on AWS.
-    # Optional override only if explicitly provided in customer helm values.
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
+    # root_user/root_password removed once S3 Pod Identity lands; try() keeps this safe until Managed Sync PR.
+    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_USER"], try(local.storage_output.root_user, null))
+    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_PASS"], try(local.storage_output.root_password, null))
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -90,12 +89,11 @@ locals {
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
+    CLOUD_STORAGE_USER                = local.storage_config.user
+    CLOUD_STORAGE_PASS                = local.storage_config.pass
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
-    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
-    CLOUD_STORAGE_USER = local.storage_config.user
-    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,8 +66,10 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_USER"], local.storage_output.root_user)
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_PASS"], local.storage_output.root_password)
+    # TODO(PARA-21728 follow-up): Managed Sync Pod Identity — do not inject static S3 keys on AWS.
+    # Optional override only if explicitly provided in customer helm values.
+    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
+    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -88,11 +90,12 @@ locals {
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
-    CLOUD_STORAGE_USER                = local.storage_config.user
-    CLOUD_STORAGE_PASS                = local.storage_config.pass
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
+    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
+    CLOUD_STORAGE_USER = local.storage_config.user
+    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,10 +66,6 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    # Managed Sync uses EKS Pod Identity (SA managed-sync-service-account).
-    # Optional override only if explicitly provided in customer helm values.
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -93,9 +89,6 @@ locals {
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
-    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
-    CLOUD_STORAGE_USER = local.storage_config.user
-    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,9 +66,10 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    # root_user/root_password removed once S3 Pod Identity lands; try() keeps this safe until Managed Sync PR.
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_USER"], try(local.storage_output.root_user, null))
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_PASS"], try(local.storage_output.root_password, null))
+    # Managed Sync uses EKS Pod Identity (SA managed-sync-service-account).
+    # Optional override only if explicitly provided in customer helm values.
+    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
+    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -89,11 +90,12 @@ locals {
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
-    CLOUD_STORAGE_USER                = local.storage_config.user
-    CLOUD_STORAGE_PASS                = local.storage_config.pass
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
+    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
+    CLOUD_STORAGE_USER = local.storage_config.user
+    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -86,10 +86,13 @@ module "pod_identity" {
   source = "./pod-identity"
   count  = try(local.storage_output.role_arn, null) != null ? 1 : 0
 
-  cluster_name     = local.cluster_name
-  namespace        = module.helm.namespace_paragon.id
-  s3_role_arn      = local.storage_output.role_arn
-  service_accounts = toset(keys(local.monorepo_microservices))
+  cluster_name = local.cluster_name
+  namespace    = module.helm.namespace_paragon.id
+  s3_role_arn  = local.storage_output.role_arn
+  service_accounts = setunion(
+    toset(keys(local.monorepo_microservices)),
+    var.managed_sync_enabled ? toset(["managed-sync-service-account"]) : toset([]),
+  )
 }
 
 module "monitors" {

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -80,6 +80,36 @@ module "managed_sync_config" {
   microservices    = local.microservices
 }
 
+# EKS Pod Identity: associate Paragon ServiceAccounts with the infra S3 IAM role.
+module "pod_identity" {
+  source = "./pod-identity"
+  count  = try(local.storage_output.role_arn, null) != null ? 1 : 0
+
+  cluster_name = local.cluster_name
+  namespace    = module.helm.namespace_paragon.id
+  s3_role_arn  = local.storage_output.role_arn
+  service_accounts = toset([
+    "api-triggerkit",
+    "cache-replay",
+    "hades",
+    "health-checker",
+    "hermes",
+    "release",
+    "zeus",
+    "worker-actionkit",
+    "worker-actions",
+    "worker-auditlogs",
+    "worker-credentials",
+    "worker-crons",
+    "worker-deployments",
+    "worker-eventlogs",
+    "worker-proxy",
+    "worker-triggerkit",
+    "worker-triggers",
+    "worker-workflows",
+  ])
+}
+
 module "monitors" {
   source = "./monitors"
   count  = var.monitors_enabled ? 1 : 0

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -80,34 +80,16 @@ module "managed_sync_config" {
   microservices    = local.microservices
 }
 
-# EKS Pod Identity: associate Paragon ServiceAccounts with the infra S3 IAM role.
+# EKS Pod Identity: associate every Paragon onprem ServiceAccount with the S3 role.
+# CLOUD_STORAGE_* is injected globally, so associations match that (no curated subset).
 module "pod_identity" {
   source = "./pod-identity"
   count  = try(local.storage_output.role_arn, null) != null ? 1 : 0
 
-  cluster_name = local.cluster_name
-  namespace    = module.helm.namespace_paragon.id
-  s3_role_arn  = local.storage_output.role_arn
-  service_accounts = toset([
-    "api-triggerkit",
-    "cache-replay",
-    "hades",
-    "health-checker",
-    "hermes",
-    "release",
-    "zeus",
-    "worker-actionkit",
-    "worker-actions",
-    "worker-auditlogs",
-    "worker-credentials",
-    "worker-crons",
-    "worker-deployments",
-    "worker-eventlogs",
-    "worker-proxy",
-    "worker-triggerkit",
-    "worker-triggers",
-    "worker-workflows",
-  ])
+  cluster_name     = local.cluster_name
+  namespace        = module.helm.namespace_paragon.id
+  s3_role_arn      = local.storage_output.role_arn
+  service_accounts = toset(keys(local.monorepo_microservices))
 }
 
 module "monitors" {

--- a/aws/workspaces/paragon/pod-identity/associations.tf
+++ b/aws/workspaces/paragon/pod-identity/associations.tf
@@ -1,0 +1,8 @@
+resource "aws_eks_pod_identity_association" "s3" {
+  for_each = var.service_accounts
+
+  cluster_name    = var.cluster_name
+  namespace       = var.namespace
+  service_account = each.value
+  role_arn        = var.s3_role_arn
+}

--- a/aws/workspaces/paragon/pod-identity/outputs.tf
+++ b/aws/workspaces/paragon/pod-identity/outputs.tf
@@ -1,0 +1,7 @@
+output "s3_associations" {
+  description = "Pod Identity associations for S3 access."
+  value = {
+    for name, assoc in aws_eks_pod_identity_association.s3 :
+    name => assoc.association_arn
+  }
+}

--- a/aws/workspaces/paragon/pod-identity/variables.tf
+++ b/aws/workspaces/paragon/pod-identity/variables.tf
@@ -1,0 +1,19 @@
+variable "cluster_name" {
+  description = "EKS cluster name for Pod Identity associations."
+  type        = string
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for Paragon workloads."
+  type        = string
+}
+
+variable "s3_role_arn" {
+  description = "IAM role ARN for S3 access via EKS Pod Identity."
+  type        = string
+}
+
+variable "service_accounts" {
+  description = "Kubernetes ServiceAccount names that should assume the S3 Pod Identity role."
+  type        = set(string)
+}

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -814,6 +814,9 @@ locals {
     "POSTGRES_DATABASE",
     "REDIS_HOST",
     "REDIS_PORT",
+    # AWS uses EKS Pod Identity for S3 — strip static access keys even if present in customer values.
+    "CLOUD_STORAGE_MICROSERVICE_USER",
+    "CLOUD_STORAGE_MICROSERVICE_PASS",
   ]
 
   default_redis_cluster = try(
@@ -989,13 +992,11 @@ locals {
           WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
           WORKFLOW_REDIS_URL             = try("${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}", local.default_redis_url)
 
-          # Cloud Storage configurations
-          CLOUD_STORAGE_MICROSERVICE_PASS = local.storage_output.root_password
-          CLOUD_STORAGE_MICROSERVICE_USER = local.storage_output.root_user
-          CLOUD_STORAGE_PUBLIC_BUCKET     = try(local.storage_output.public_bucket, "${local.workspace}-cdn")
-          CLOUD_STORAGE_SYSTEM_BUCKET     = try(local.storage_output.private_bucket, "${local.workspace}-app")
-          CLOUD_STORAGE_TYPE              = local.cloud_storage_type
-          CLOUD_STORAGE_REGION            = var.aws_region
+          # Cloud Storage configurations (S3 auth via EKS Pod Identity; no static access keys)
+          CLOUD_STORAGE_PUBLIC_BUCKET = try(local.storage_output.public_bucket, "${local.workspace}-cdn")
+          CLOUD_STORAGE_SYSTEM_BUCKET = try(local.storage_output.private_bucket, "${local.workspace}-app")
+          CLOUD_STORAGE_TYPE          = local.cloud_storage_type
+          CLOUD_STORAGE_REGION        = var.aws_region
 
           CLOUD_STORAGE_PUBLIC_URL = coalesce(
             try(local.helm_vars.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),

--- a/charts/example.yaml
+++ b/charts/example.yaml
@@ -293,8 +293,9 @@ secrets:
   ZEUS_POSTGRES_USERNAME: "your-zeus-db-username"
   
   # Cloud Storage
-  CLOUD_STORAGE_MICROSERVICE_PASS: "your-s3-secret-key"
-  CLOUD_STORAGE_MICROSERVICE_USER: "your-s3-access-key"
+  # On AWS, S3 auth uses EKS Pod Identity — do not set CLOUD_STORAGE_MICROSERVICE_USER/PASS.
+  # CLOUD_STORAGE_MICROSERVICE_PASS: "your-s3-secret-key"   # legacy / MinIO only
+  # CLOUD_STORAGE_MICROSERVICE_USER: "your-s3-access-key"   # legacy / MinIO only
   
   # Monitoring
   MONITOR_GRAFANA_AWS_ACCESS_ID: "your-grafana-aws-access-key"

--- a/charts/paragon-onprem/charts/account/values.yaml
+++ b/charts/paragon-onprem/charts/account/values.yaml
@@ -46,7 +46,7 @@ fullnameOverride: 'account'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/api-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/api-triggerkit/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'api-triggerkit'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/cache-replay/values.yaml
+++ b/charts/paragon-onprem/charts/cache-replay/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'cache-replay'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/cerberus/values.yaml
+++ b/charts/paragon-onprem/charts/cerberus/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'cerberus'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/connect/values.yaml
+++ b/charts/paragon-onprem/charts/connect/values.yaml
@@ -46,7 +46,7 @@ fullnameOverride: 'connect'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/dashboard/values.yaml
+++ b/charts/paragon-onprem/charts/dashboard/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'dashboard'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/hades/values.yaml
+++ b/charts/paragon-onprem/charts/hades/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'hades'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/health-checker/values.yaml
+++ b/charts/paragon-onprem/charts/health-checker/values.yaml
@@ -97,7 +97,7 @@ fullnameOverride: 'health-checker'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/hermes/values.yaml
+++ b/charts/paragon-onprem/charts/hermes/values.yaml
@@ -52,7 +52,7 @@ fullnameOverride: 'hermes'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/passport/values.yaml
+++ b/charts/paragon-onprem/charts/passport/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'passport'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/pheme/values.yaml
+++ b/charts/paragon-onprem/charts/pheme/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'pheme'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/release/values.yaml
+++ b/charts/paragon-onprem/charts/release/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'release'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-actionkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actionkit/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-actionkit'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-actions/values.yaml
+++ b/charts/paragon-onprem/charts/worker-actions/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-actions'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-auditlogs/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: "worker-auditlogs"
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-credentials/values.yaml
+++ b/charts/paragon-onprem/charts/worker-credentials/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-credentials'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-crons/values.yaml
+++ b/charts/paragon-onprem/charts/worker-crons/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-crons'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-deployments'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
+++ b/charts/paragon-onprem/charts/worker-eventlogs/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-eventlogs'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-proxy/values.yaml
+++ b/charts/paragon-onprem/charts/worker-proxy/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-proxy'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggerkit/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-triggerkit'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-triggers/values.yaml
+++ b/charts/paragon-onprem/charts/worker-triggers/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-triggers'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/worker-workflows/values.yaml
+++ b/charts/paragon-onprem/charts/worker-workflows/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'worker-workflows'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.

--- a/charts/paragon-onprem/charts/zeus/values.yaml
+++ b/charts/paragon-onprem/charts/zeus/values.yaml
@@ -36,7 +36,7 @@ fullnameOverride: 'zeus'
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
### Issues Closed

- PARA-21728

### Brief Summary

replace aws s3 iam keys with eks pod identity for microservices

### Detailed Summary

AWS enterprise deployments stop provisioning long-lived IAM access keys for S3 consumer microservices. Workloads authenticate via EKS Pod Identity (shared IAM role + ServiceAccount associations). The `eks-pod-identity-agent` addon is always installed for both legacy managed node groups and Karpenter. Grafana and Managed Sync are intentionally out of scope here (separate PRs). Azure/GCP are unchanged.

Cutover depends on monorepo S3 ambient credentials ([PARA-23624](https://useparagon.atlassian.net/browse/PARA-23624) / [PARA-23626](https://useparagon.atlassian.net/browse/PARA-23626)).

### Changes

- Always install `eks-pod-identity-agent` (no longer gated on Karpenter; no Terraform state move)
- Replace S3 IAM user/access keys with a Pod Identity IAM role; keep the same S3/KMS policy statements (including managed-sync bucket perms); export `role_arn` instead of `root_user`/`root_password`
- Point S3 KMS `key_users` at the new role ARN
- Add Pod Identity associations for Paragon S3 consumer ServiceAccounts
- Stop injecting / strip `CLOUD_STORAGE_MICROSERVICE_USER`/`PASS` on AWS for microservices
- Enable dedicated ServiceAccounts (`serviceAccount.create: true`) on S3 consumer charts
- Keep Managed Sync helm-config compatible via `try()` until the Managed Sync follow-up PR
- Update example values and README storage output schema for Pod Identity

### Unrelated Changes

N/A

### Future Work

- Separate PR: Managed Sync Pod Identity + stop injecting `CLOUD_STORAGE_USER`/`PASS` (same ticket PARA-21728)
- Separate PR: Grafana CloudWatch Pod Identity (same ticket PARA-21728)
- PARA-23624 / PARA-23626: monorepo S3 ambient credentials — required before production cutover

### Steps to Test

1. `terraform init -backend=false && terraform validate` in `aws/workspaces/infra` and `aws/workspaces/paragon`
2. On an existing MNG AWS workspace: plan should **create** `eks-pod-identity-agent`, S3 role, and microservice Pod Identity associations; destroy S3 IAM user and access keys
3. Confirm Grafana IAM user/keys and Managed Sync static key wiring are **not** removed by this PR (beyond `try()` compatibility)
4. After monorepo ambient-cred changes: verify a consumer pod can access S3 with no `CLOUD_STORAGE_MICROSERVICE_*` keys in env

### QA Notes

- Do not fully cut over S3 until PARA-23624 is shipped
- Azure and GCP behavior is intentionally unchanged
- Merge order suggestion: this PR → Managed Sync PR → Grafana PR (Grafana can also merge independently)

### Deployment Notes

- Infra output `storage.value` no longer includes `root_user`/`root_password`; consumers must use `role_arn`
- Applying this will destroy existing S3 IAM users/access keys on AWS
- Managed Sync may temporarily lose static keys from storage outputs until the Managed Sync PR lands; keep dual-run / monorepo readiness in mind

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Apply destroys existing S3 IAM users/keys and changes how all microservices authenticate to S3 until monorepo ambient-credential support ships; misaligned SA names or partial rollout could break object storage across the fleet.
> 
> **Overview**
> **AWS microservice S3 access moves from long-lived IAM user keys to EKS Pod Identity**, with infra exporting `role_arn` instead of `root_user`/`root_password` and README/example values updated accordingly.
> 
> In **infra**, the S3 IAM user, access key, and group wiring is replaced by a Pod Identity–assumable IAM role (same bucket/KMS permissions); S3 KMS `key_users` now reference that role. **`eks-pod-identity-agent` is always installed** (no longer gated on Karpenter).
> 
> In **paragon**, a new `pod-identity` module creates `aws_eks_pod_identity_association` resources for monorepo microservice ServiceAccounts (plus managed-sync SA when enabled). Helm no longer injects or allows `CLOUD_STORAGE_MICROSERVICE_USER`/`PASS` on AWS; managed-sync helm-config drops static S3 user/pass wiring. **Paragon-onprem charts flip `serviceAccount.create` to `true`** so pods run under named SAs that match those associations.
> 
> Grafana and Managed Sync static keys are out of scope; production cutover still depends on monorepo ambient S3 credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b09bbfbd247c9a22744174dbcc065c1713f83d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PARA-23624]: https://useparagon.atlassian.net/browse/PARA-23624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PARA-23626]: https://useparagon.atlassian.net/browse/PARA-23626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ