### PR TITLE
feat(aws): adopt EKS Pod Identity for Managed Sync

### DIFF
--- a/aws/workspaces/paragon/helm-config/outputs.tf
+++ b/aws/workspaces/paragon/helm-config/outputs.tf
@@ -1,3 +1,7 @@
 output "config" {
-  value = local.managed_sync_secrets
+  value = {
+    for key, value in local.managed_sync_secrets :
+    key => value
+    if value != null
+  }
 }

--- a/aws/workspaces/paragon/helm-config/outputs.tf
+++ b/aws/workspaces/paragon/helm-config/outputs.tf
@@ -1,7 +1,3 @@
 output "config" {
-  value = {
-    for key, value in local.managed_sync_secrets :
-    key => value
-    if value != null
-  }
+  value = local.managed_sync_secrets
 }

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,10 +66,6 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    # Managed Sync uses EKS Pod Identity (SA managed-sync-service-account).
-    # Optional override only if explicitly provided in customer helm values.
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -93,9 +89,6 @@ locals {
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
-    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
-    CLOUD_STORAGE_USER = local.storage_config.user
-    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -66,9 +66,10 @@ locals {
       managed_sync = coalesce(try(var.base_helm_values.global.env["CLOUD_STORAGE_MANAGED_SYNC_BUCKET"], null), local.storage_output.managed_sync_bucket)
     }
     type = try(var.base_helm_values.global.env["CLOUD_STORAGE_TYPE"], "S3")
-    # root_user/root_password removed once S3 Pod Identity lands; try() keeps this safe until Managed Sync PR.
-    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_USER"], try(local.storage_output.root_user, null))
-    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_MICROSERVICE_PASS"], try(local.storage_output.root_password, null))
+    # Managed Sync uses EKS Pod Identity (SA managed-sync-service-account).
+    # Optional override only if explicitly provided in customer helm values.
+    user = try(var.base_helm_values.global.env["CLOUD_STORAGE_USER"], null)
+    pass = try(var.base_helm_values.global.env["CLOUD_STORAGE_PASS"], null)
     public_url = coalesce(
       try(var.base_helm_values.global.env["CLOUD_STORAGE_PUBLIC_URL"], null),
       local.storage_type == "S3" ? "https://s3.${var.aws_region}.amazonaws.com" : null,
@@ -89,11 +90,12 @@ locals {
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
-    CLOUD_STORAGE_USER                = local.storage_config.user
-    CLOUD_STORAGE_PASS                = local.storage_config.pass
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
+    # Static keys omitted on AWS (Pod Identity). Optional customer overrides only:
+    CLOUD_STORAGE_USER = local.storage_config.user
+    CLOUD_STORAGE_PASS = local.storage_config.pass
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
     MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")

--- a/aws/workspaces/paragon/modules.tf
+++ b/aws/workspaces/paragon/modules.tf
@@ -86,10 +86,13 @@ module "pod_identity" {
   source = "./pod-identity"
   count  = try(local.storage_output.role_arn, null) != null ? 1 : 0
 
-  cluster_name     = local.cluster_name
-  namespace        = module.helm.namespace_paragon.id
-  s3_role_arn      = local.storage_output.role_arn
-  service_accounts = toset(keys(local.monorepo_microservices))
+  cluster_name = local.cluster_name
+  namespace    = module.helm.namespace_paragon.id
+  s3_role_arn  = local.storage_output.role_arn
+  service_accounts = setunion(
+    toset(keys(local.monorepo_microservices)),
+    var.managed_sync_enabled ? toset(["managed-sync-service-account"]) : toset([]),
+  )
 }
 
 module "monitors" {


### PR DESCRIPTION
### Issues Closed

- PARA-21728

### Brief Summary

wire managed sync to eks pod identity for s3

### Detailed Summary

Follow-up to the S3 microservices Pod Identity PR. Managed Sync stops receiving static `CLOUD_STORAGE_USER`/`PASS` from Terraform and instead uses the shared S3 Pod Identity role via the existing `managed-sync-service-account` ServiceAccount. Depends on the S3 role + `eks-pod-identity-agent` from the base branch.

### Changes

- Stop injecting static S3 keys into Managed Sync helm secrets (optional customer overrides only)
- Filter null secret values from Managed Sync config output
- Associate `managed-sync-service-account` with the shared S3 Pod Identity role when `managed_sync_enabled`

### Unrelated Changes

N/A

### Future Work

- Confirm Managed Sync app supports ambient AWS credentials when `CLOUD_STORAGE_USER`/`PASS` are unset (may need a managed-sync / monorepo follow-up)
- Grafana CloudWatch Pod Identity (separate PR, same ticket)

### Steps to Test

1. Base branch `feat/PARA-21728/eks-pod-identity-s3` must be present (or already merged)
2. `terraform validate` in `aws/workspaces/paragon`
3. With `managed_sync_enabled=true`: plan should create Pod Identity association for `managed-sync-service-account` and remove static `CLOUD_STORAGE_USER`/`PASS` from Managed Sync secrets
4. Verify Managed Sync pods can read/write the managed-sync bucket without static keys

### QA Notes

- Stack this PR on top of the S3 microservices Pod Identity PR
- Do not cut over until Managed Sync can use the AWS default credential chain without static keys

### Deployment Notes

- Requires S3 Pod Identity role (`storage.value.role_arn`) from the S3 PR
- Applying removes long-lived S3 keys from Managed Sync secret material

### Screenshots

N/A

Made with [Cursor](https://cursor.com)