### PR TITLE
fix(infra): restore inline NAT routes when Network Firewall is disabled

### DIFF
--- a/aws/workspaces/infra/network/network.tf
+++ b/aws/workspaces/infra/network/network.tf
@@ -93,22 +93,35 @@ resource "aws_nat_gateway" "gw" {
   }
 }
 
-# Create a new route table for the private subnets. Egress route is managed separately.
+# Private route tables. When NFW is disabled, keep the NAT default route inline on the
+# route table (pre-NFW model) so brownfield upgrades do not hit RouteAlreadyExists from a
+# new standalone aws_route. When NFW is enabled, omit the inline route; the network_firewall
+# module owns private → firewall-endpoint routes as aws_route resources.
 resource "aws_route_table" "private" {
   count  = var.az_count
   vpc_id = aws_vpc.app.id
+
+  dynamic "route" {
+    for_each = var.network_firewall_enabled ? [] : [1]
+    content {
+      cidr_block     = "0.0.0.0/0"
+      nat_gateway_id = aws_nat_gateway.gw[count.index].id
+    }
+  }
 
   tags = {
     Name = "${var.workspace}-private-route-table"
   }
 }
 
-# Default path when Network Firewall is disabled: private subnets egress via NAT.
-resource "aws_route" "private_egress" {
-  count                  = var.network_firewall_enabled ? 0 : var.az_count
-  route_table_id         = aws_route_table.private[count.index].id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.gw[count.index].id
+# Drop standalone NAT aws_route from state without destroying the AWS route. Inline
+# route blocks above take over management for the NFW-disabled path.
+removed {
+  from = aws_route.private_egress
+
+  lifecycle {
+    destroy = false
+  }
 }
 
 # Explicitly associate the newly created route tables to the private subnets (so they don't default to the main route table)

--- a/aws/workspaces/infra/network/outputs.tf
+++ b/aws/workspaces/infra/network/outputs.tf
@@ -40,13 +40,13 @@ output "private_subnet_cidrs" {
 
 # Token that only resolves once private egress routing exists:
 # - NFW enabled  -> firewall + private/return/firewall routes (module.network_firewall.routing_ready)
-# - NFW disabled -> the NAT default routes on the private route tables
+# - NFW disabled -> private route tables (inline NAT default routes) + NAT gateways
 # Consumers gate internet-bootstrapping workloads (EKS nodes, bastion) on this value.
 output "egress_ready" {
   description = "Signals private egress routing is configured for both NFW-enabled and NFW-disabled paths."
   value = var.network_firewall.enabled ? (
     module.network_firewall[0].routing_ready
     ) : (
-    join(",", aws_route.private_egress[*].id)
+    join(",", concat(aws_route_table.private[*].id, aws_nat_gateway.gw[*].id))
   )
 }


### PR DESCRIPTION
### Issues Closed

- PARA-23667

### Brief Summary

fix brownfield RouteAlreadyExists when nfw is off

### Detailed Summary

After PARA-21722, brownfield infra applies with network_firewall.enabled = false failed because private 0.0.0.0/0 → NAT was moved from an inline aws_route_table route to a new standalone aws_route.private_egress. Existing workspaces already had that route in AWS, so Terraform create hit RouteAlreadyExists.

This restores the pre-NFW model when NFW is disabled: NAT default routes stay inline on the private route table. Standalone aws_route resources remain only for the NFW-enabled path. Brownfield upgrades with NFW off no longer require terraform import.

### Changes

- Restore inline 0.0.0.0/0 → NAT on aws_route_table.private when network_firewall_enabled is false
- Remove standalone aws_route.private_egress from the NFW-off path via removed { destroy = false }
- Update egress_ready for the NFW-off path to use private route table and NAT gateway IDs

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. Brownfield (NFW off): on an existing workspace with private RTs that already have 0.0.0.0/0 → NAT, check out this branch with network_firewall unset or enabled = false
2. Run terraform plan/apply in aws/workspaces/infra
3. Confirm no RouteAlreadyExists on module.network.aws_route.private_egress
4. Confirm existing private default routes remain and are not destroyed (removed with destroy = false is expected)
5. Greenfield (NFW off): apply from scratch and confirm private → NAT is created via inline route table routes
6. Optional (NFW on): confirm firewall subnets/policy/endpoints/routes are still planned when enabled = true

### QA Notes

- network_firewall.enabled = false must remain a routing no-op for brownfield
- Bastion/EKS access-entry churn in plan (if present) is unrelated and known; focus review on private route tables
- After apply, Terraform will stop managing former aws_route.private_egress addresses; routes stay in AWS and are owned by the route table inline config

### Deployment Notes

- No customer tfvars changes required for the default (NFW off) path
- Ship before or with the next customer upgrade that includes PARA-21722 NFW code
- Branch under test: fix/PARA-21722/brownfield-private-egress-inline

### Screenshots

N/A — infrastructure-only change. Attach terraform plan snippets showing absence of RouteAlreadyExists / private_egress creates if helpful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how private subnet internet egress is declared in Terraform for the default (NFW-off) path; incorrect routing or state handling could affect EKS/bastion bootstrap, though the change is intentionally scoped to match pre-NFW behavior.
> 
> **Overview**
> Fixes **brownfield Terraform applies** when `network_firewall` is off: private `0.0.0.0/0 → NAT` is modeled again as **inline routes** on `aws_route_table.private` instead of a separate `aws_route.private_egress`, avoiding **RouteAlreadyExists** on workspaces that already had those routes in AWS.
> 
> When NFW is disabled, the standalone NAT `aws_route` is dropped from state via **`removed { destroy = false }`** so existing AWS routes are not destroyed; inline blocks take over management. When NFW is enabled, inline NAT routes are omitted and the firewall module still owns private egress routes.
> 
> The **`egress_ready`** output for the NFW-off path now joins private route table and NAT gateway IDs (replacing the removed route resource IDs) so bastion/EKS still wait on a token that reflects routing being in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd10d068b9f86a43964b9b99b57df1588669d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->