### PR TITLE
fix(PARA-24644): Azure KV redis handoff and OpenObserve Blob creds

### DIFF
--- a/azure/workspaces/infra/runtime_secrets.tf
+++ b/azure/workspaces/infra/runtime_secrets.tf
@@ -40,10 +40,22 @@ resource "azurerm_key_vault_secret" "runtime_postgres" {
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }
 
+# Same contract as output.redis / output.redis_managed (and legacy infra-output.json):
+# - coexistence: redis = legacy, redis-managed = AMR
+# - cutover (legacy off): redis = AMR
 resource "azurerm_key_vault_secret" "runtime_redis" {
   name         = "redis"
   key_vault_id = azurerm_key_vault.paragon.id
-  value        = jsonencode(module.redis.redis)
+  value        = jsonencode(var.redis_enabled ? module.redis.redis : module.redis_managed[0].redis)
+
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+}
+
+resource "azurerm_key_vault_secret" "runtime_redis_managed" {
+  name         = "redis-managed"
+  key_vault_id = azurerm_key_vault.paragon.id
+  # Always present so paragon KV handoff can resolve redis_managed (null when AMR disabled).
+  value        = jsonencode(var.redis_managed_enabled ? module.redis_managed[0].redis : null)
 
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }

--- a/azure/workspaces/infra/storage/outputs.tf
+++ b/azure/workspaces/infra/storage/outputs.tf
@@ -1,12 +1,14 @@
 output "blob" {
   value = {
-    name                   = local.storage_account_name
-    access_key             = azurerm_storage_account.blob.primary_access_key
-    private_container      = azurerm_storage_container.app.name
-    public_container       = azurerm_storage_container.cdn.name
-    logs_container         = azurerm_storage_container.logs.name
-    managed_sync_container = var.managed_sync_enabled ? azurerm_storage_container.managed_sync[0].name : null
-    auditlogs_container    = azurerm_storage_container.auditlogs.name
+    name                        = local.storage_account_name
+    # Same account hosts public (cdn) and private containers; runtime_secrets expects this key.
+    public_storage_account_name = local.storage_account_name
+    access_key                  = azurerm_storage_account.blob.primary_access_key
+    private_container           = azurerm_storage_container.app.name
+    public_container            = azurerm_storage_container.cdn.name
+    logs_container              = azurerm_storage_container.logs.name
+    managed_sync_container      = var.managed_sync_enabled ? azurerm_storage_container.managed_sync[0].name : null
+    auditlogs_container         = azurerm_storage_container.auditlogs.name
   }
   sensitive = true
 }

--- a/azure/workspaces/paragon/infra_secrets.tf
+++ b/azure/workspaces/paragon/infra_secrets.tf
@@ -22,6 +22,12 @@ data "azurerm_key_vault_secret" "infra_redis" {
   key_vault_id = data.azurerm_key_vault.paragon.id
 }
 
+data "azurerm_key_vault_secret" "infra_redis_managed" {
+  count        = local.use_legacy_infra_json ? 0 : 1
+  name         = "redis-managed"
+  key_vault_id = data.azurerm_key_vault.paragon.id
+}
+
 data "azurerm_key_vault_secret" "infra_storage" {
   count        = local.use_legacy_infra_json ? 0 : 1
   name         = "storage"
@@ -47,9 +53,11 @@ locals {
           location = data.azurerm_resource_group.infra[0].location
         }
       }
-      postgres = { value = jsondecode(data.azurerm_key_vault_secret.infra_postgres[0].value) }
-      redis    = { value = jsondecode(data.azurerm_key_vault_secret.infra_redis[0].value) }
-      storage  = { value = jsondecode(data.azurerm_key_vault_secret.infra_storage[0].value) }
+      postgres      = { value = jsondecode(data.azurerm_key_vault_secret.infra_postgres[0].value) }
+      redis         = { value = jsondecode(data.azurerm_key_vault_secret.infra_redis[0].value) }
+      # Mirrors infra output redis_managed (null when AMR disabled / secret encodes null).
+      redis_managed = { value = jsondecode(data.azurerm_key_vault_secret.infra_redis_managed[0].value) }
+      storage       = { value = jsondecode(data.azurerm_key_vault_secret.infra_storage[0].value) }
     },
     var.managed_sync_enabled ? {
       kafka = { value = jsondecode(data.azurerm_key_vault_secret.infra_kafka[0].value) }

--- a/azure/workspaces/paragon/moved.tf
+++ b/azure/workspaces/paragon/moved.tf
@@ -1,0 +1,10 @@
+# Preserve OpenObserve random_* state across module.helm → root (ESO refactor).
+moved {
+  from = module.helm.random_string.openobserve_email[0]
+  to   = random_string.openobserve_email[0]
+}
+
+moved {
+  from = module.helm.random_password.openobserve_password[0]
+  to   = random_password.openobserve_password[0]
+}

--- a/azure/workspaces/paragon/openobserve.tf
+++ b/azure/workspaces/paragon/openobserve.tf
@@ -1,10 +1,10 @@
 resource "random_string" "openobserve_email" {
   count = var.openobserve_email == null ? 1 : 0
 
-  length  = 10
+  length  = 12
   lower   = true
   upper   = false
-  numeric = false
+  numeric = true
   special = false
 }
 

--- a/azure/workspaces/paragon/runtime_secrets.tf
+++ b/azure/workspaces/paragon/runtime_secrets.tf
@@ -58,7 +58,9 @@ resource "azurerm_key_vault_secret" "openobserve" {
   name         = local.runtime_secret_names.openobserve
   key_vault_id = data.azurerm_key_vault.paragon.id
   value = jsonencode({
-    ZO_ROOT_USER_EMAIL    = local.openobserve_email
-    ZO_ROOT_USER_PASSWORD = local.openobserve_password
+    ZO_ROOT_USER_EMAIL         = local.openobserve_email
+    ZO_ROOT_USER_PASSWORD      = local.openobserve_password
+    AZURE_STORAGE_ACCOUNT_NAME = local.storage_output.root_user
+    AZURE_STORAGE_ACCOUNT_KEY  = local.storage_output.root_password
   })
 }

--- a/gcp/workspaces/paragon/moved.tf
+++ b/gcp/workspaces/paragon/moved.tf
@@ -1,0 +1,10 @@
+# Preserve OpenObserve random_* state across module.helm → root (ESO refactor).
+moved {
+  from = module.helm.random_string.openobserve_email[0]
+  to   = random_string.openobserve_email[0]
+}
+
+moved {
+  from = module.helm.random_password.openobserve_password[0]
+  to   = random_password.openobserve_password[0]
+}

--- a/gcp/workspaces/paragon/openobserve.tf
+++ b/gcp/workspaces/paragon/openobserve.tf
@@ -1,10 +1,10 @@
 resource "random_string" "openobserve_email" {
   count = var.openobserve_email == null ? 1 : 0
 
-  length  = 10
+  length  = 12
   lower   = true
   upper   = false
-  numeric = false
+  numeric = true
   special = false
 }
 

--- a/scripts/migrate-openobserve-password.sh
+++ b/scripts/migrate-openobserve-password.sh
@@ -32,6 +32,7 @@ HOOP_CONN=""
 HOOP_K8S_CONN=""
 O2_HOST=""
 OLD_PASSWORD=""
+EMAIL_OVERRIDE=""
 DRY_RUN=false
 USE_HOOP=false
 
@@ -65,7 +66,8 @@ Options:
   --hoop NAME            Hoop TCP connection to OpenObserve (e.g. paragon-eu-openobserve). Mutually exclusive with --o2-host.
   --hoop-k8s NAME        Hoop k8s-admin connection to read the secret (e.g. paragon-eu-k8s-admin). Default: {prefix}-k8s-admin from --hoop.
   --o2-host URL          OpenObserve base URL from your local port-forward (e.g. http://127.0.0.1:5080).
-  --old-password PASS    Current OpenObserve password (from 1Password). Required.
+  --old-password PASS    Current OpenObserve PVC password. Required unless secret password already works.
+  --email EMAIL          OpenObserve root email (PVC). Default: ZO_ROOT_USER_EMAIL from --secret.
   --namespace NAME       Kubernetes namespace (default: paragon)
   --org NAME             OpenObserve organization (default: default)
   --secret NAME          Secret with Terraform password (default: openobserve-credentials)
@@ -77,6 +79,19 @@ EOF
 
 log() { echo "${LOG_PREFIX} $*" >&2; }
 die() { echo "${LOG_PREFIX} error: $*" >&2; exit 1; }
+
+print_vault_reminder() {
+  echo "" >&2
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
+  printf '\033[1;33m\033[1m%s\033[0m\n' "⚠️  UPDATE 1PASSWORD / VAULT" >&2
+  echo "" >&2
+  echo "  Save the new OpenObserve credentials in the customer vault." >&2
+  echo "  Email:    ${EMAIL}" >&2
+  echo "  Password: current value in ${SECRET_NAME} (cluster / Terraform)" >&2
+  echo "" >&2
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
+  echo "" >&2
+}
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
@@ -169,10 +184,20 @@ secret_field_hoop() {
   printf '%s' "$b64" | base64 -d
 }
 
+# Basic auth via header — curl -u truncates passwords that contain '#' (and is
+# fragile with other specials). Always base64 the full user:pass pair.
+basic_auth_header() {
+  local user="$1" pass="$2"
+  local token
+  token="$(printf '%s:%s' "$user" "$pass" | base64 | tr -d '\n')"
+  printf 'Authorization: Basic %s' "$token"
+}
+
 auth_status() {
   local user="$1" pass="$2"
   curl -s -o /dev/null -w '%{http_code}' --connect-timeout 10 --max-time 30 \
-    -u "${user}:${pass}" "${O2_HOST}/api/${ORG}/streams?type=logs"
+    -H "$(basic_auth_header "$user" "$pass")" \
+    "${O2_HOST}/api/${ORG}/streams?type=logs"
 }
 
 while [ $# -gt 0 ]; do
@@ -182,6 +207,7 @@ while [ $# -gt 0 ]; do
     --connection) HOOP_CONN="$2"; USE_HOOP=true; shift 2 ;; # alias
     --o2-host|--o2-url|--openobserve-host) O2_HOST="$(normalize_o2_host "$2")"; shift 2 ;;
     --old-password) OLD_PASSWORD="$2"; shift 2 ;;
+    --email|--user|--username) EMAIL_OVERRIDE="$2"; shift 2 ;;
     --namespace) NAMESPACE="$2"; shift 2 ;;
     --org) ORG="$2"; shift 2 ;;
     --secret) SECRET_NAME="$2"; shift 2 ;;
@@ -196,8 +222,6 @@ need_cmd curl
 need_cmd jq
 need_cmd base64
 
-[ -n "$OLD_PASSWORD" ] || die "--old-password is required (legacy password from 1Password)"
-
 if [ "$USE_HOOP" = true ] && [ -n "$O2_HOST" ]; then
   die "use either --hoop or --o2-host, not both"
 fi
@@ -210,8 +234,8 @@ if [ "$USE_HOOP" = true ]; then
   [ -n "$HOOP_CONN" ] || die "--hoop requires a connection name"
   [ -n "$HOOP_K8S_CONN" ] || HOOP_K8S_CONN="$(default_hoop_k8s_conn "$HOOP_CONN")"
   log "mode=hoop o2=${HOOP_CONN} k8s=${HOOP_K8S_CONN}"
-EMAIL="$(secret_field_hoop ZO_ROOT_USER_EMAIL | tr -d '[:space:]')"
-NEW_PASSWORD="$(secret_field_hoop ZO_ROOT_USER_PASSWORD | tr -d '[:space:]')"
+  EMAIL="$(secret_field_hoop ZO_ROOT_USER_EMAIL | tr -d '[:space:]')"
+  NEW_PASSWORD="$(secret_field_hoop ZO_ROOT_USER_PASSWORD | tr -d '[:space:]')"
   start_hoop_proxy
 else
   need_cmd kubectl
@@ -227,17 +251,35 @@ if [ "${#NEW_PASSWORD}" -lt 8 ] || [ "${#NEW_PASSWORD}" -gt 128 ]; then
   die "secret password length ${#NEW_PASSWORD} out of range (8–128); check hoop secret read output"
 fi
 
-if [ "$OLD_PASSWORD" = "$NEW_PASSWORD" ]; then
-  die "secret password equals --old-password; run terraform apply first"
+SECRET_EMAIL="$EMAIL"
+if [ -n "$EMAIL_OVERRIDE" ]; then
+  EMAIL="$EMAIL_OVERRIDE"
+  log "using --email ${EMAIL} (secret has ${SECRET_EMAIL})"
 fi
 
 log "email=${EMAIL}"
 log "new password from secret (${#NEW_PASSWORD} chars)"
 
+# Already synced: secret password works against OO PVC — nothing to do.
+log "checking if secret password already authenticates"
+new_status="$(auth_status "$EMAIL" "$NEW_PASSWORD")"
+if [ "$new_status" = "200" ]; then
+  log "already in sync — OpenObserve accepts password from ${SECRET_NAME}"
+  print_vault_reminder
+  exit 0
+fi
+log "secret password not accepted yet (HTTP ${new_status}) — migration needed"
+
+[ -n "$OLD_PASSWORD" ] || die "--old-password is required (PVC still has the legacy password)"
+
+if [ "$OLD_PASSWORD" = "$NEW_PASSWORD" ]; then
+  die "secret password equals --old-password; OpenObserve rejected both — check --old-password vs ${SECRET_NAME}"
+fi
+
 log "verifying --old-password against OpenObserve API"
 old_status="$(auth_status "$EMAIL" "$OLD_PASSWORD")"
 if [ "$old_status" != "200" ]; then
-  die "--old-password rejected by OpenObserve (HTTP ${old_status}). Check 1Password value."
+  die "--old-password rejected (HTTP ${old_status}). Confirm the value that works against OO."
 fi
 log "old password accepted"
 
@@ -256,7 +298,7 @@ fi
 
 http_code="$(curl -s -o /tmp/o2-migrate-response.json -w '%{http_code}' \
   --connect-timeout 10 --max-time 120 \
-  -u "${EMAIL}:${OLD_PASSWORD}" \
+  -H "$(basic_auth_header "$EMAIL" "$OLD_PASSWORD")" \
   -X PUT \
   -H 'Content-Type: application/json' \
   -d "$PAYLOAD" \
@@ -276,18 +318,4 @@ if [ "$new_status" != "200" ]; then
 fi
 
 log "done — OpenObserve matches ${SECRET_NAME}"
-
-print_vault_reminder() {
-  echo "" >&2
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
-  printf '\033[1;33m\033[1m%s\033[0m\n' "⚠️  UPDATE 1PASSWORD / VAULT" >&2
-  echo "" >&2
-  echo "  Save the new OpenObserve credentials in the customer vault." >&2
-  echo "  Email:    ${EMAIL}" >&2
-  echo "  Password: current value in ${SECRET_NAME} (cluster / Terraform)" >&2
-  echo "" >&2
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
-  echo "" >&2
-}
-
 print_vault_reminder

--- a/scripts/migrate-openobserve-password.sh
+++ b/scripts/migrate-openobserve-password.sh
@@ -3,7 +3,7 @@
 #
 # One-time manual step AFTER terraform apply on existing OpenObserve clusters.
 #
-# Terraform writes the new password to paragon-secrets-openobserve. OpenObserve
+# Terraform writes the new password to openobserve-credentials (ESO). OpenObserve
 # still has the old password in its PVC until this script runs.
 #
 # Two access modes (pick one):
@@ -25,7 +25,7 @@ LOG_PREFIX="[o2-password-migrate]"
 
 NAMESPACE="${NAMESPACE:-paragon}"
 ORG="${ORG:-default}"
-SECRET_NAME="${SECRET_NAME:-paragon-secrets-openobserve}"
+SECRET_NAME="${SECRET_NAME:-openobserve-credentials}"
 O2_PORT="${O2_PORT:-5080}"
 
 HOOP_CONN=""
@@ -41,7 +41,7 @@ usage() {
   cat <<'EOF'
 migrate-openobserve-password.sh
 
-Syncs OpenObserve (PVC) with the new password already in paragon-secrets-openobserve
+Syncs OpenObserve (PVC) with the new password already in openobserve-credentials
 after terraform apply.
 
   1. terraform apply
@@ -68,7 +68,7 @@ Options:
   --old-password PASS    Current OpenObserve password (from 1Password). Required.
   --namespace NAME       Kubernetes namespace (default: paragon)
   --org NAME             OpenObserve organization (default: default)
-  --secret NAME          Secret with Terraform password (default: paragon-secrets-openobserve)
+  --secret NAME          Secret with Terraform password (default: openobserve-credentials)
   --port PORT            Local port for hoop connect proxy only (default: 5080)
   --dry-run              Print actions without calling the API
   -h, --help             Show this help
@@ -151,14 +151,21 @@ secret_field_kubectl() {
 
 secret_field_hoop() {
   local key="$1"
-  local b64 raw
-  log "reading ${key} via hoop connect ${HOOP_K8S_CONN}"
+  local b64 raw err
+  log "reading ${key} via hoop connect ${HOOP_K8S_CONN} (secret ${SECRET_NAME})"
+  err="$(mktemp)"
   raw="$(hoop connect "$HOOP_K8S_CONN" -s -- \
     kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" \
-    -o "jsonpath={.data.${key}}" 2>/dev/null || true)"
+    -o "jsonpath={.data.${key}}" 2>"$err" || true)"
   # kubectl jsonpath is a single base64 line; ignore any hoop banner noise on stdout
   b64="$(printf '%s\n' "$raw" | grep -E '^[A-Za-z0-9+/=]+$' | tail -1 | tr -d '[:space:]')"
-  [ -n "$b64" ] || die "failed to read ${key} from secret (hoop connect ${HOOP_K8S_CONN})"
+  if [ -z "$b64" ]; then
+    log "hoop/kubectl stderr: $(tr '\n' ' ' <"$err" | tr -d '\r')"
+    log "hoop stdout (truncated): $(printf '%s' "$raw" | head -c 200)"
+    rm -f "$err"
+    die "failed to read ${key} from secret ${SECRET_NAME} (hoop connect ${HOOP_K8S_CONN})"
+  fi
+  rm -f "$err"
   printf '%s' "$b64" | base64 -d
 }
 


### PR DESCRIPTION
### Issues Closed

- [PARA-24644](https://useparagon.atlassian.net/browse/PARA-24644)

### Brief Summary

fix azure key vault redis and openobserve handoff

### Detailed Summary

After cutting over to Azure Managed Redis, the Key Vault `redis` secret was still written from the legacy Redis module (empty when `redis_enabled = false`). Paragon reads infra handoff from Key Vault, so plan failed because `cache` was missing. This aligns KV secrets with the same contract as terraform outputs (legacy as default while both exist; AMR takes over `redis` after cutover) and fixes OpenObserve panicking on Azure Blob init when storage account env vars were missing from the ESO-backed OO secret.

### Changes

- **Infra Key Vault `redis`**: write `var.redis_enabled ? module.redis.redis : module.redis_managed[0].redis` (same selector as `output.redis`).
- **Infra Key Vault `redis-managed`**: always write AMR endpoints when managed is enabled, or `null` when disabled, so coexistence / Hoop can resolve `redis_managed` without the legacy JSON file.
- **Paragon infra secrets**: read KV secret `redis-managed` into `infra_vars.redis_managed` alongside `redis`.
- **Storage output**: add `public_storage_account_name` on the blob output so `runtime_secrets` can populate CDN/public account fields without a missing attribute.
- **OpenObserve KV secret (Azure)**: include `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY` in the `openobserve` secret used by ESO → `openobserve-credentials`, so OO no longer panics with `Account must be specified` when `ZO_S3_PROVIDER=azure`.
- **`migrate-openobserve-password.sh`**: default secret name to `openobserve-credentials` (ESO) and improve Hoop error output when the secret read fails.

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. On an Azure customer with Managed Redis cutover (`redis_enabled = false`, `redis_managed_enabled = true`), apply **infra** and confirm KV secrets `redis` and `redis-managed` contain cache/queue/system keys (not `{}`).
2. Apply **paragon** without `infra_json_path`; confirm plan succeeds and Hoop redis connections point at AMR hosts.
3. Confirm KV/k8s `openobserve-credentials` includes `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY`, then restart OpenObserve and verify it stays up (no Azure account panic).
4. Optional: with a rotated OO password, run `./scripts/migrate-openobserve-password.sh` against `openobserve-credentials`.

### QA Notes

- Before first paragon apply after ESO migration: if plan wants to destroy `module.helm.azurerm_key_vault.paragon`, run `terraform state rm 'module.helm.azurerm_key_vault.paragon'` in the **paragon** workspace (infra already owns the vault). Do **not** apply that destroy.
- OpenObserve password migrate script is only needed if terraform rotated `ZO_ROOT_USER_PASSWORD`; it does not fix Blob account config.

### Deployment Notes

- Apply **infra** before **paragon** so `redis-managed` exists in Key Vault.
- No more `terraform output -json > ../paragon/.secure/infra-output.json` for the default handoff path.
- Existing clusters: after OO secret update, wait for ESO refresh or force-sync ExternalSecret, then restart the OpenObserve StatefulSet.

### Screenshots

N/A

[PARA-24644]: https://useparagon.atlassian.net/browse/PARA-24644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes infra→paragon secret contracts and Redis routing at cutover; mis-ordered applies could briefly point workloads at wrong Redis or empty secrets. OpenObserve KV now carries storage account keys—sensitive but required for Blob.
> 
> **Overview**
> Fixes **Azure Managed Redis cutover** and **OpenObserve on Azure Blob** when infra is handed off via Key Vault instead of `infra-output.json`.
> 
> **Redis / Key Vault:** Infra now writes KV `redis` using the same selector as `output.redis` (legacy while both exist, AMR after cutover), and adds a always-present `redis-managed` secret (AMR payload or `null`). Paragon reads `redis-managed` into `infra_vars.redis_managed` so plans no longer fail with missing cache config after legacy Redis is disabled.
> 
> **Storage:** Blob module output gains `public_storage_account_name` so runtime KV storage JSON matches what paragon expects for CDN/public account fields.
> 
> **OpenObserve:** The Azure paragon `openobserve` KV secret (ESO → `openobserve-credentials`) now includes `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY`, fixing OO startup when `ZO_S3_PROVIDER=azure`. Azure/GCP paragon add `moved` blocks for OpenObserve `random_*` resources after the helm→root ESO refactor; auto-generated OO email strings allow digits and are slightly longer.
> 
> **Ops script:** `migrate-openobserve-password.sh` defaults to `openobserve-credentials`, can skip migration when the secret password already works, supports `--email` override, uses Basic auth headers (passwords with `#`), and surfaces clearer Hoop/kubectl read errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59980e8f1812d9abcad26da7622a798c68b5b548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->