### PR TITLE
fix(PARA-24668): remove legacy AWS S3 IAM access key references

### DIFF
--- a/aws/workspaces/infra/app_env.tf
+++ b/aws/workspaces/infra/app_env.tf
@@ -89,8 +89,6 @@ locals {
     WORKFLOW_REDIS_URL             = local.argocd_redis_url.workflow
 
     CLOUD_STORAGE_COMPLIANCE_BUCKET = local.argocd_storage.auditlogs_bucket
-    CLOUD_STORAGE_MICROSERVICE_PASS = local.argocd_storage.access_key_secret
-    CLOUD_STORAGE_MICROSERVICE_USER = local.argocd_storage.access_key_id
     CLOUD_STORAGE_PUBLIC_BUCKET     = local.argocd_storage.public_bucket
     CLOUD_STORAGE_SYSTEM_BUCKET     = local.argocd_storage.private_bucket
     CLOUD_STORAGE_TYPE              = local.argocd_cloud_storage_type

--- a/aws/workspaces/infra/runtime_secrets.tf
+++ b/aws/workspaces/infra/runtime_secrets.tf
@@ -58,8 +58,6 @@ resource "aws_secretsmanager_secret_version" "runtime_storage" {
     managed_sync_bucket = module.storage.s3.managed_sync_bucket
     logs_bucket         = module.storage.s3.logs_bucket
     auditlogs_bucket    = module.storage.s3.auditlogs_bucket
-    root_user           = module.storage.s3.access_key_id
-    root_password       = module.storage.s3.access_key_secret
   })
 }
 

--- a/aws/workspaces/infra/runtime_secrets.tf
+++ b/aws/workspaces/infra/runtime_secrets.tf
@@ -58,6 +58,8 @@ resource "aws_secretsmanager_secret_version" "runtime_storage" {
     managed_sync_bucket = module.storage.s3.managed_sync_bucket
     logs_bucket         = module.storage.s3.logs_bucket
     auditlogs_bucket    = module.storage.s3.auditlogs_bucket
+    role_arn            = module.storage.s3.role_arn
+    kms_key_arn         = module.storage.s3.kms_key_arn
   })
 }
 

--- a/aws/workspaces/paragon/helm/external_secrets.tf
+++ b/aws/workspaces/paragon/helm/external_secrets.tf
@@ -32,6 +32,10 @@ resource "helm_release" "external_secrets" {
     name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
     value = var.eso_role_arn
   }
+
+  # ALB controller registers a cluster-scoped Service mutating webhook; wait
+  # until its pods have endpoints or Service creates fail with no endpoints.
+  depends_on = [helm_release.ingress]
 }
 
 resource "helm_release" "reloader" {
@@ -43,6 +47,8 @@ resource "helm_release" "reloader" {
   create_namespace = false
   atomic           = true
   cleanup_on_fail  = true
+
+  depends_on = [helm_release.ingress]
 }
 
 locals {

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.07.15"
+version="2026.07.23"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-24668

### Brief Summary

remove stale aws s3 iam access key refs

### Detailed Summary

After EKS Pod Identity replaced long-lived S3 IAM access keys, `module.storage.s3` no longer exports `access_key_id` / `access_key_secret`. The AWS infra workspace still referenced those attributes when writing runtime storage secrets and the ArgoCD env secret, which caused `terraform plan` to fail with unsupported attribute errors. This removes those leftover references so AWS S3 auth continues via Pod Identity (`role_arn`) only.

### Changes

- Stop writing `CLOUD_STORAGE_MICROSERVICE_USER` / `PASS` from removed storage IAM access keys into the infra env secret
- Stop embedding `root_user` / `root_password` access-key fields in the runtime storage Secrets Manager payload

### Unrelated Changes

- Fixed potential race condition during external secret creation.

### Future Work

N/A

### Steps to Test

1. In `aws/workspaces/infra`, run `terraform init` (as needed) and `terraform plan`
2. Confirm plan no longer errors on `access_key_id` / `access_key_secret`
3. Confirm storage secret / env outputs still include bucket names and rely on Pod Identity for auth (no static S3 keys)

### QA Notes

N/A

### Deployment Notes

Existing Secrets Manager values may still contain legacy `root_user` / `root_password` or microservice key env vars until the next infra apply refreshes them. Pods should already authenticate to S3 via EKS Pod Identity.

### Screenshots

N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what S3 credentials are published to Secrets Manager and the app env secret; runtime must already use Pod Identity (`role_arn`) or S3 access could break until the next apply refreshes secrets.
> 
> **Overview**
> Fixes **terraform plan** failures after storage stopped exporting long-lived S3 IAM access keys by aligning secrets and env with **EKS Pod Identity** only.
> 
> **Infra env / ArgoCD:** Drops `CLOUD_STORAGE_MICROSERVICE_USER` and `CLOUD_STORAGE_MICROSERVICE_PASS` from the flat env secret built in `app_env.tf`; bucket names, region, and endpoints are unchanged.
> 
> **Runtime storage secret:** The Secrets Manager `runtime_storage` JSON no longer writes `root_user` / `root_password`; it now stores `role_arn` and `kms_key_arn` from `module.storage.s3`.
> 
> **Helm ordering:** `external-secrets` and `reloader` releases in `external_secrets.tf` now `depends_on` `helm_release.ingress` so the ALB mutating webhook has endpoints before Service creation.
> 
> **Release prep:** `prepare.sh` chart version bumped to `2026.07.23`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f79c5e1e06dd581adfa9e6d9380c8346dd702f78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->