### PR TITLE
fix(PARA-24758): restore managed-sync enterprise env and pin OpenObserve email

### DIFF
--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -178,5 +178,6 @@ module "secrets" {
 
   managed_sync_config     = var.managed_sync_enabled ? coalesce(var.paragon_managed_sync_config, {}) : null
   create_openobserve      = true
+  openobserve_email       = var.openobserve_email
   recovery_window_in_days = var.secrets_recovery_window_in_days
 }

--- a/aws/workspaces/infra/secrets/secrets.tf
+++ b/aws/workspaces/infra/secrets/secrets.tf
@@ -99,7 +99,11 @@ resource "aws_secretsmanager_secret_version" "openobserve" {
 
   secret_id = aws_secretsmanager_secret.openobserve[0].id
   secret_string = jsonencode({
-    ZO_ROOT_USER_EMAIL    = "${random_string.openobserve_email[0].result}@useparagon.com"
+    ZO_ROOT_USER_EMAIL = (
+      var.openobserve_email != null
+      ? var.openobserve_email
+      : "${random_string.openobserve_email[0].result}@useparagon.com"
+    )
     ZO_ROOT_USER_PASSWORD = random_password.openobserve_password[0].result
   })
 }

--- a/aws/workspaces/infra/secrets/variables.tf
+++ b/aws/workspaces/infra/secrets/variables.tf
@@ -38,3 +38,9 @@ variable "create_openobserve" {
   type        = bool
   default     = true
 }
+
+variable "openobserve_email" {
+  description = "Optional OpenObserve root user email. When set, used instead of the generated random email."
+  type        = string
+  default     = null
+}

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -480,6 +480,12 @@ variable "paragon_managed_sync_config" {
   default     = null
 }
 
+variable "openobserve_email" {
+  description = "Optional OpenObserve root user email. When set, used instead of the generated random email."
+  type        = string
+  default     = null
+}
+
 variable "secrets_recovery_window_in_days" {
   description = "Secrets Manager deletion recovery window for application secrets (env, docker-cfg, managed-sync, openobserve) and runtime handoff secrets. Set to 0 for immediate deletion so names are free after destroy; use 7–30 in production for undo protection."
   type        = number

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -80,20 +80,26 @@ locals {
   }
 
   managed_sync_secrets = {
-    HOST_ENV  = "AWS_K8"
-    LOG_LEVEL = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
+    HOST_ENV       = "AWS_K8"
+    LOG_LEVEL      = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
     TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")
+
+    PLATFORM_ENV = try(var.base_helm_values.global.env["PLATFORM_ENV"], "enterprise")
+    NODE_ENV     = try(var.base_helm_values.global.env["NODE_ENV"], "production")
+    LICENSE      = try(var.base_helm_values.global.env["LICENSE"], null)
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
     CLOUD_STORAGE_PUBLIC_URL          = local.storage_config.public_url
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
+    CLOUD_STORAGE_REGION              = try(var.base_helm_values.global.env["CLOUD_STORAGE_REGION"], var.aws_region)
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
-    MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
-    PARAGON_PROXY_BASE_URL = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
-    PARAGON_ZEUS_BASE_URL  = try("http://zeus:${var.microservices.zeus.port}", null)
+    MANAGED_SYNC_URL              = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
+    PARAGON_PROXY_BASE_URL        = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
+    PARAGON_ZEUS_BASE_URL         = try("http://zeus:${var.microservices.zeus.port}", null)
+    WORKER_EVENT_LOGS_PRIVATE_URL = try("http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}", null)
 
     MANAGED_SYNC_PRIVATE_KEY     = replace(tls_private_key.managed_sync_signing_key.private_key_pem, "\n", "\\n")
     MANAGED_SYNC_AUTH_PUBLIC_KEY = replace(tls_private_key.managed_sync_signing_key.public_key_pem, "\n", "\\n")

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -105,9 +105,13 @@ locals {
   }
 
   managed_sync_secrets = {
-    HOST_ENV  = "AZURE_K8"
-    LOG_LEVEL = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
+    HOST_ENV       = "AZURE_K8"
+    LOG_LEVEL      = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
     TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")
+
+    PLATFORM_ENV = try(var.base_helm_values.global.env["PLATFORM_ENV"], "enterprise")
+    NODE_ENV     = try(var.base_helm_values.global.env["NODE_ENV"], "production")
+    LICENSE      = try(var.base_helm_values.global.env["LICENSE"], null)
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
@@ -118,9 +122,10 @@ locals {
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
 
     // TODO: make `MANAGED_SYNC_URL` communicate via private DNS instead of open internet
-    MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
-    PARAGON_PROXY_BASE_URL = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
-    PARAGON_ZEUS_BASE_URL  = try("http://zeus:${var.microservices.zeus.port}", null)
+    MANAGED_SYNC_URL              = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
+    PARAGON_PROXY_BASE_URL        = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
+    PARAGON_ZEUS_BASE_URL         = try("http://zeus:${var.microservices.zeus.port}", null)
+    WORKER_EVENT_LOGS_PRIVATE_URL = try("http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}", null)
 
     MANAGED_SYNC_PRIVATE_KEY     = replace(tls_private_key.managed_sync_signing_key.private_key_pem, "\n", "\\n")
     MANAGED_SYNC_AUTH_PUBLIC_KEY = replace(tls_private_key.managed_sync_signing_key.public_key_pem, "\n", "\\n")

--- a/gcp/workspaces/paragon/helm-config/secrets.tf
+++ b/gcp/workspaces/paragon/helm-config/secrets.tf
@@ -91,9 +91,13 @@ locals {
   }
 
   managed_sync_secrets = {
-    HOST_ENV  = "GCP_K8"
-    LOG_LEVEL = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
+    HOST_ENV       = "GCP_K8"
+    LOG_LEVEL      = try(var.base_helm_values.global.env["LOG_LEVEL"], "debug")
     TRIAL_DISABLED = try(var.base_helm_values.global.env["TRIAL_DISABLED"], "true")
+
+    PLATFORM_ENV = try(var.base_helm_values.global.env["PLATFORM_ENV"], "enterprise")
+    NODE_ENV     = try(var.base_helm_values.global.env["NODE_ENV"], "production")
+    LICENSE      = try(var.base_helm_values.global.env["LICENSE"], null)
 
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
@@ -104,9 +108,10 @@ locals {
     CLOUD_STORAGE_PASS                = local.storage_type == "GCP" ? (try(var.gcp_storage_sa_key, null) != null ? base64encode(var.gcp_storage_sa_key) : "") : local.storage_config.pass
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
 
-    MANAGED_SYNC_URL       = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
-    PARAGON_PROXY_BASE_URL = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
-    PARAGON_ZEUS_BASE_URL  = try("http://zeus:${var.microservices["zeus"].port}", null)
+    MANAGED_SYNC_URL              = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
+    PARAGON_PROXY_BASE_URL        = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
+    PARAGON_ZEUS_BASE_URL         = try("http://zeus:${var.microservices["zeus"].port}", null)
+    WORKER_EVENT_LOGS_PRIVATE_URL = try("http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}", null)
 
     MANAGED_SYNC_PRIVATE_KEY     = replace(tls_private_key.managed_sync_signing_key.private_key_pem, "\n", "\\n")
     MANAGED_SYNC_AUTH_PUBLIC_KEY = replace(tls_private_key.managed_sync_signing_key.public_key_pem, "\n", "\\n")


### PR DESCRIPTION
### Issues Closed

- PARA-24758

### Brief Summary

fix managed-sync enterprise boot and openobserve email pin

### Detailed Summary

Managed Sync pods crash because the managed-sync secret overlay never wrote `PLATFORM_ENV` / `LICENSE`, so enterprise token defaults (including `WORKER_EVENT_LOGS_ACCESS_TOKEN`) never resolve. Also adds an optional infra `openobserve_email` so a known OpenObserve login can be pinned without regenerating from `random_string`.

### Changes

- Add `PLATFORM_ENV`, `NODE_ENV`, `LICENSE`, `CLOUD_STORAGE_REGION`, and `WORKER_EVENT_LOGS_PRIVATE_URL` to the managed-sync secret overlay
- Add optional `openobserve_email` infra variable; when set, use it as `ZO_ROOT_USER_EMAIL` instead of the generated random email

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. Apply the paragon workspace with Managed Sync enabled and confirm the managed-sync secret includes `PLATFORM_ENV=enterprise` and `LICENSE`
2. Confirm Managed Sync API pods stay Running (no missing `WORKER_EVENT_LOGS_ACCESS_TOKEN` crash)
3. Set `openobserve_email` in infra tfvars, apply infra, and confirm OpenObserve root email matches the override while password remains generated

### QA Notes

Infra apply with a reduced `paragon_managed_sync_config` still replaces the whole managed-sync secret base; follow with a paragon apply so the overlay restores full keys. Prefer applying paragon first for the Managed Sync boot fix.

### Deployment Notes

- Paragon apply required for Managed Sync secret overlay changes
- Optional: set `openobserve_email` in infra `vars.auto.tfvars` before infra apply if pinning OpenObserve email

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed-sync and OpenObserve secrets that affect pod boot; scope is Terraform secret composition across clouds, not app runtime logic.
> 
> **Overview**
> Restores **enterprise Managed Sync** configuration in the paragon Helm **managed-sync secret overlay** on AWS, Azure, and GCP. The overlay now writes **`PLATFORM_ENV`**, **`NODE_ENV`**, **`LICENSE`**, **`WORKER_EVENT_LOGS_PRIVATE_URL`**, and on AWS **`CLOUD_STORAGE_REGION`** (from global env or region), so enterprise defaults such as **`WORKER_EVENT_LOGS_ACCESS_TOKEN`** can resolve and Managed Sync API pods stop crashing on missing env.
> 
> Adds optional **`openobserve_email`** on AWS infra (workspace → secrets module). When set, **`ZO_ROOT_USER_EMAIL`** in the OpenObserve Secrets Manager secret uses that value instead of the generated `@useparagon.com` address; the password stays randomly generated.
> 
> **Paragon apply** is required for the Managed Sync secret changes; infra apply only needed if pinning OpenObserve email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ae9bd244fc0b8dc344d8bcad687071ce284dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->