### PR TITLE
fix(PARA-24807): point WORKFLOW_REDIS_URL at cache Redis, not managed-sync

### DIFF
--- a/aws/workspaces/infra/app_env.tf
+++ b/aws/workspaces/infra/app_env.tf
@@ -15,15 +15,13 @@ locals {
 
   argocd_default_redis_url = local.argocd_redis_cache != null ? "${local.argocd_redis_cache.host}:${local.argocd_redis_cache.port}" : null
 
-  # Infra ElastiCache exposes cache/queue/system and, when managed_sync_enabled,
-  # managed_sync (the dedicated caching & workflows cluster). Map the workflow role
-  # to managed_sync so WORKFLOW_REDIS_* targets that cluster instead of falling back
-  # to cache. cache/queue/system map to themselves.
+  # Map chart Redis roles to ElastiCache instances. workflow shares cache —
+  # there is no dedicated workflow cluster (see charts/example.yaml).
   argocd_redis_role_source = {
     cache    = "cache"
     queue    = "queue"
     system   = "system"
-    workflow = "managed_sync"
+    workflow = "cache"
   }
 
   argocd_redis_endpoint = {

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -88,6 +88,9 @@ locals {
     NODE_ENV     = try(var.base_helm_values.global.env["NODE_ENV"], "production")
     LICENSE      = try(var.base_helm_values.global.env["LICENSE"], null)
 
+    FEATURE_FLAG_PLATFORM_ENABLED  = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENABLED"], "true")
+    FEATURE_FLAG_PLATFORM_ENDPOINT = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENDPOINT"], "http://flipt:${var.microservices.flipt.port}")
+
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync

--- a/aws/workspaces/paragon/helm-config/secrets.tf
+++ b/aws/workspaces/paragon/helm-config/secrets.tf
@@ -54,6 +54,10 @@ locals {
     cluster_enabled = try(var.base_helm_values.global.env["MANAGED_SYNC_REDIS_CLUSTER_ENABLED"], var.infra_values.redis.value.managed_sync.cluster, var.infra_values.redis.value.cache.cluster, false)
   }
 
+  # Workflow Redis shares cache when there is no dedicated workflow instance (matches monorepo chart).
+  workflow_redis_from_infra = try(var.infra_values.redis.value.workflow, var.infra_values.redis.value.cache, null)
+  workflow_redis_url        = local.workflow_redis_from_infra != null ? "${local.workflow_redis_from_infra.host}:${local.workflow_redis_from_infra.port}" : null
+
   # Backward compatible with infra workspaces that still emit the legacy "minio" output
   # instead of the renamed "storage" output.
   storage_output = try(var.infra_values.storage.value, var.infra_values.minio.value)
@@ -91,6 +95,9 @@ locals {
     FEATURE_FLAG_PLATFORM_ENABLED  = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENABLED"], "true")
     FEATURE_FLAG_PLATFORM_ENDPOINT = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENDPOINT"], "http://flipt:${var.microservices.flipt.port}")
 
+    WORKFLOW_REDIS_URL             = try(var.base_helm_values.global.env["WORKFLOW_REDIS_URL"], local.workflow_redis_url)
+    WORKFLOW_REDIS_CLUSTER_ENABLED = try(var.base_helm_values.global.env["WORKFLOW_REDIS_CLUSTER_ENABLED"], local.workflow_redis_from_infra.cluster, false)
+
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_MANAGED_SYNC_BUCKET = local.storage_config.buckets.managed_sync
@@ -102,7 +109,8 @@ locals {
     MANAGED_SYNC_URL              = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
     PARAGON_PROXY_BASE_URL        = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
     PARAGON_ZEUS_BASE_URL         = try("http://zeus:${var.microservices.zeus.port}", null)
-    WORKER_EVENT_LOGS_PRIVATE_URL = try("http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}", null)
+    WORKER_ACTIONKIT_PRIVATE_URL  = try(var.base_helm_values.global.env["WORKER_ACTIONKIT_PRIVATE_URL"], "http://worker-actionkit:${var.microservices["worker-actionkit"].port}")
+    WORKER_EVENT_LOGS_PRIVATE_URL = try(var.base_helm_values.global.env["WORKER_EVENT_LOGS_PRIVATE_URL"], "http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}")
 
     MANAGED_SYNC_PRIVATE_KEY     = replace(tls_private_key.managed_sync_signing_key.private_key_pem, "\n", "\\n")
     MANAGED_SYNC_AUTH_PUBLIC_KEY = replace(tls_private_key.managed_sync_signing_key.public_key_pem, "\n", "\\n")

--- a/aws/workspaces/paragon/runtime_secrets.tf
+++ b/aws/workspaces/paragon/runtime_secrets.tf
@@ -33,8 +33,8 @@ data "aws_secretsmanager_secret_version" "env" {
 
 resource "aws_secretsmanager_secret_version" "env_paragon_overlay" {
   secret_id = data.aws_secretsmanager_secret.env.id
-  # Infra wins on conflicts so chart-derived redis/postgres wiring (e.g. WORKFLOW_REDIS_*
-  # falling back to cache) cannot clobber infra's managed_sync mapping.
+  # Infra owns the base secret and wins on conflicts; this workspace only overlays
+  # chart-specific keys that infra does not compute.
   secret_string = jsonencode(merge(
     local.helm_secret_values,
     jsondecode(data.aws_secretsmanager_secret_version.env.secret_string)

--- a/aws/workspaces/paragon/variables.tf
+++ b/aws/workspaces/paragon/variables.tf
@@ -1007,14 +1007,9 @@ locals {
           SYSTEM_REDIS_CLUSTER_ENABLED   = try(local.infra_vars.redis.value.system.cluster, local.default_redis_cluster)
           SYSTEM_REDIS_TLS_ENABLED       = try(local.infra_vars.redis.value.system.ssl, local.default_redis_ssl)
           SYSTEM_REDIS_URL               = try("${local.infra_vars.redis.value.system.host}:${local.infra_vars.redis.value.system.port}", local.default_redis_url)
-          # Prefer managed_sync (workflow cluster) when present — matches infra/app_env.tf.
-          WORKFLOW_REDIS_CLUSTER_ENABLED = try(local.infra_vars.redis.value.managed_sync.cluster, local.infra_vars.redis.value.workflow.cluster, local.default_redis_cluster)
-          WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.managed_sync.ssl, local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
-          WORKFLOW_REDIS_URL             = try(
-            "${local.infra_vars.redis.value.managed_sync.host}:${local.infra_vars.redis.value.managed_sync.port}",
-            "${local.infra_vars.redis.value.workflow.host}:${local.infra_vars.redis.value.workflow.port}",
-            local.default_redis_url
-          )
+          WORKFLOW_REDIS_CLUSTER_ENABLED = try(local.infra_vars.redis.value.cache.cluster, local.default_redis_cluster)
+          WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.cache.ssl, local.default_redis_ssl)
+          WORKFLOW_REDIS_URL             = try("${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}", local.default_redis_url)
 
           # Cloud Storage configurations (S3 auth via EKS Pod Identity; no static access keys)
           CLOUD_STORAGE_PUBLIC_BUCKET = try(local.storage_output.public_bucket, "${local.workspace}-cdn")

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -113,6 +113,9 @@ locals {
     NODE_ENV     = try(var.base_helm_values.global.env["NODE_ENV"], "production")
     LICENSE      = try(var.base_helm_values.global.env["LICENSE"], null)
 
+    FEATURE_FLAG_PLATFORM_ENABLED  = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENABLED"], "true")
+    FEATURE_FLAG_PLATFORM_ENDPOINT = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENDPOINT"], "http://flipt:${var.microservices.flipt.port}")
+
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_USER                = local.storage_config.user

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -77,6 +77,13 @@ locals {
   # URL scheme but still requires MANAGED_SYNC_REDIS_TLS_ENABLED to enable TLS in the client.
   managed_sync_redis_url = "${local.redis_config.redis_tls_enabled ? "rediss" : "redis"}://${local.redis_config.password != null ? ":${urlencode(local.redis_config.password)}@" : ""}${local.redis_config.host}:${local.redis_config.port}"
 
+  # Workflow Redis shares cache when there is no dedicated workflow instance (matches monorepo chart).
+  workflow_redis_from_infra = try(var.infra_values.redis.value.workflow, var.infra_values.redis.value.cache, null)
+  workflow_redis_url = try(
+    local.workflow_redis_from_infra.connection_string,
+    local.workflow_redis_from_infra != null ? "${local.workflow_redis_from_infra.host}:${local.workflow_redis_from_infra.port}" : null
+  )
+
   # Backward compatible with infra workspaces that still emit the legacy "minio" output
   # instead of the renamed "storage" output.
   storage_output = try(var.infra_values.storage.value, var.infra_values.minio.value)
@@ -116,6 +123,9 @@ locals {
     FEATURE_FLAG_PLATFORM_ENABLED  = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENABLED"], "true")
     FEATURE_FLAG_PLATFORM_ENDPOINT = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENDPOINT"], "http://flipt:${var.microservices.flipt.port}")
 
+    WORKFLOW_REDIS_URL             = try(var.base_helm_values.global.env["WORKFLOW_REDIS_URL"], local.workflow_redis_url)
+    WORKFLOW_REDIS_CLUSTER_ENABLED = try(var.base_helm_values.global.env["WORKFLOW_REDIS_CLUSTER_ENABLED"], local.workflow_redis_from_infra.cluster, false)
+
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_USER                = local.storage_config.user
@@ -128,7 +138,8 @@ locals {
     MANAGED_SYNC_URL              = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
     PARAGON_PROXY_BASE_URL        = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
     PARAGON_ZEUS_BASE_URL         = try("http://zeus:${var.microservices.zeus.port}", null)
-    WORKER_EVENT_LOGS_PRIVATE_URL = try("http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}", null)
+    WORKER_ACTIONKIT_PRIVATE_URL  = try(var.base_helm_values.global.env["WORKER_ACTIONKIT_PRIVATE_URL"], "http://worker-actionkit:${var.microservices["worker-actionkit"].port}")
+    WORKER_EVENT_LOGS_PRIVATE_URL = try(var.base_helm_values.global.env["WORKER_EVENT_LOGS_PRIVATE_URL"], "http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}")
 
     MANAGED_SYNC_PRIVATE_KEY     = replace(tls_private_key.managed_sync_signing_key.private_key_pem, "\n", "\\n")
     MANAGED_SYNC_AUTH_PUBLIC_KEY = replace(tls_private_key.managed_sync_signing_key.public_key_pem, "\n", "\\n")

--- a/gcp/workspaces/paragon/helm-config/secrets.tf
+++ b/gcp/workspaces/paragon/helm-config/secrets.tf
@@ -49,6 +49,9 @@ locals {
   # Prefer infra Redis when present so TLS (ssl) and URL scheme come from infra (Memorystore → rediss://; else 0x15 error).
   redis_from_infra = try(var.infra_values.redis.value.managed_sync, var.infra_values.redis.value.cache, null)
 
+  # Workflow Redis shares cache when there is no dedicated workflow instance (matches monorepo chart).
+  workflow_redis_from_infra = try(var.infra_values.redis.value.workflow, var.infra_values.redis.value.cache, null)
+
   redis_config = {
     host                 = local.redis_from_infra != null ? local.redis_from_infra.host : try(var.base_helm_values.global.env["REDIS_HOST"], try(var.infra_values.redis.value.managed_sync.host, var.infra_values.redis.value.cache.host))
     port                 = local.redis_from_infra != null ? local.redis_from_infra.port : try(var.base_helm_values.global.env["REDIS_PORT"], try(var.infra_values.redis.value.managed_sync.port, var.infra_values.redis.value.cache.port))
@@ -59,6 +62,10 @@ locals {
   }
 
   managed_sync_redis_url = "${local.redis_config.redis_tls_enabled ? "rediss" : "redis"}://${local.redis_config.password != null ? ":${urlencode(local.redis_config.password)}@" : ""}${local.redis_config.host}:${local.redis_config.port}"
+
+  workflow_redis_url = local.workflow_redis_from_infra != null ? (
+    "${try(local.workflow_redis_from_infra.ssl, false) ? "rediss" : "redis"}://${try(local.workflow_redis_from_infra.password, null) != null ? ":${urlencode(local.workflow_redis_from_infra.password)}@" : ""}${local.workflow_redis_from_infra.host}:${local.workflow_redis_from_infra.port}"
+  ) : null
 
   # Backward compatible with infra workspaces that still emit the legacy "minio" output
   # instead of the renamed "storage" output.
@@ -102,6 +109,9 @@ locals {
     FEATURE_FLAG_PLATFORM_ENABLED  = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENABLED"], "true")
     FEATURE_FLAG_PLATFORM_ENDPOINT = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENDPOINT"], "http://flipt:${var.microservices.flipt.port}")
 
+    WORKFLOW_REDIS_URL             = try(var.base_helm_values.global.env["WORKFLOW_REDIS_URL"], local.workflow_redis_url)
+    WORKFLOW_REDIS_CLUSTER_ENABLED = try(var.base_helm_values.global.env["WORKFLOW_REDIS_CLUSTER_ENABLED"], local.workflow_redis_from_infra.cluster, false)
+
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url
@@ -114,7 +124,8 @@ locals {
     MANAGED_SYNC_URL              = try(var.base_helm_values.global.env["MANAGED_SYNC_URL"], "https://sync.${var.domain}")
     PARAGON_PROXY_BASE_URL        = try("http://worker-proxy:${var.microservices["worker-proxy"].port}", null)
     PARAGON_ZEUS_BASE_URL         = try("http://zeus:${var.microservices["zeus"].port}", null)
-    WORKER_EVENT_LOGS_PRIVATE_URL = try("http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}", null)
+    WORKER_ACTIONKIT_PRIVATE_URL  = try(var.base_helm_values.global.env["WORKER_ACTIONKIT_PRIVATE_URL"], "http://worker-actionkit:${var.microservices["worker-actionkit"].port}")
+    WORKER_EVENT_LOGS_PRIVATE_URL = try(var.base_helm_values.global.env["WORKER_EVENT_LOGS_PRIVATE_URL"], "http://worker-eventlogs:${var.microservices["worker-eventlogs"].port}")
 
     MANAGED_SYNC_PRIVATE_KEY     = replace(tls_private_key.managed_sync_signing_key.private_key_pem, "\n", "\\n")
     MANAGED_SYNC_AUTH_PUBLIC_KEY = replace(tls_private_key.managed_sync_signing_key.public_key_pem, "\n", "\\n")

--- a/gcp/workspaces/paragon/helm-config/secrets.tf
+++ b/gcp/workspaces/paragon/helm-config/secrets.tf
@@ -99,6 +99,9 @@ locals {
     NODE_ENV     = try(var.base_helm_values.global.env["NODE_ENV"], "production")
     LICENSE      = try(var.base_helm_values.global.env["LICENSE"], null)
 
+    FEATURE_FLAG_PLATFORM_ENABLED  = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENABLED"], "true")
+    FEATURE_FLAG_PLATFORM_ENDPOINT = try(var.base_helm_values.global.env["FEATURE_FLAG_PLATFORM_ENDPOINT"], "http://flipt:${var.microservices.flipt.port}")
+
     CLOUD_STORAGE_TYPE                = local.storage_type
     CLOUD_STORAGE_PUBLIC_BUCKET       = local.storage_config.buckets.public
     CLOUD_STORAGE_PRIVATE_URL         = local.storage_config.public_url


### PR DESCRIPTION
### Issues Closed

- PARA-24807
- SEV-1107

### Brief Summary

point workflow redis at cache, not managed-sync

### Detailed Summary

On AWS enterprise installs with managed sync enabled, Terraform mapped the chart `workflow` Redis role to the `managed_sync` ElastiCache cluster. Billing writes keys such as `tasksLimit` to the **cache** cluster, while `worker-deployments` verification reads them via `WORKFLOW_REDIS_URL`. When that URL pointed at `-redis-sync`, deploys failed with `paragonErrorCode 2001` / missing `taskLimit`, which left workflows undeployed and produced trigger/proxy/dynamic-variable 404s on paragon-eu (SEV-1107).

This PR maps `workflow` → `cache` in infra and the paragon workspace so `WORKFLOW_REDIS_*` matches `CACHE_REDIS_*`. Managed sync continues to use its own `MANAGED_SYNC_REDIS_*` / `REDIS_HOST` wiring against the sync cluster.

Separately, managed-sync pods only receive env from `paragon-managed-sync-secrets` (Helm strips `global.env`), so `FEATURE_FLAG_PLATFORM_*` is added to managed-sync secrets on AWS, Azure, and GCP.

### Changes

- Map `argocd_redis_role_source.workflow` from `managed_sync` to `cache` in `aws/workspaces/infra/app_env.tf`
- Resolve `WORKFLOW_REDIS_*` from `redis.value.cache` in `aws/workspaces/paragon/variables.tf`
- Correct the env overlay comment in `aws/workspaces/paragon/runtime_secrets.tf`
- Add `FEATURE_FLAG_PLATFORM_ENABLED` / `FEATURE_FLAG_PLATFORM_ENDPOINT` to managed-sync secrets on AWS, Azure, and GCP

### Unrelated Changes

None

### Future Work

- Consider a guardrail that `WORKFLOW_REDIS_URL` equals `CACHE_REDIS_URL` when no dedicated workflow Redis exists
- Optional non-ESO secret path (`install_external_secrets=false` with restored `kubernetes_secret`) discussed during SEV, not in this PR
- Follow-up capacity work from SEV (HPA behavior damping, restart cron schedule, metrics-server replicas)

### Steps to Test

1. Plan/apply **infra** first, then **paragon**, on an AWS env with managed sync enabled.
2. Confirm Secrets Manager `paragon/<workspace>/env` has `WORKFLOW_REDIS_URL` equal to `CACHE_REDIS_URL` (cache host, not `-redis-sync`).
3. After ESO sync / pod restart, confirm `worker-deployments` (or hermes) env matches.
4. Deploy a test workflow; verify no `DeploymentError` for missing `taskLimit`.
5. Confirm `paragon-managed-sync-secrets` includes `FEATURE_FLAG_PLATFORM_*` and `MANAGED_SYNC_REDIS_URL` still points at the sync cluster.
6. Coordinate with WFE to re-drive workflows stuck in `DEPLOYMENT_FAILED` and confirm hermes / bull-queue metrics recover on EU.

### QA Notes

Primary verification is on AWS (paragon-eu). Azure/GCP change is only the managed-sync feature-flag secret keys; Redis role mapping is AWS-specific.

### Deployment Notes

- Apply order matters: **infra** owns `WORKFLOW_REDIS_URL` in Secrets Manager and wins the overlay merge; apply infra before paragon.
- After apply, ensure ESO has resynced `paragon-secrets` and `paragon-managed-sync-secrets`; restart consumers if pods did not pick up new values.
- WFE may need to re-drive failed workflow deployments after Redis is corrected.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production Redis endpoints for workflow deploy verification; wrong apply order or stale secrets could prolong deployment failures until infra is applied and ESO resyncs.
> 
> **Overview**
> **Workflow Redis** is aligned with the **cache** cluster instead of **managed-sync**, so billing keys like `tasksLimit` and `worker-deployments` reads use the same Redis. On AWS, infra maps the chart `workflow` role to `cache` in `app_env.tf`, and paragon `WORKFLOW_REDIS_*` in `variables.tf` is derived from `redis.value.cache` rather than `managed_sync`.
> 
> **Managed-sync secrets** (AWS, Azure, GCP) now include `WORKFLOW_REDIS_URL` / `WORKFLOW_REDIS_CLUSTER_ENABLED` (workflow → dedicated `workflow` infra output or cache), `FEATURE_FLAG_PLATFORM_ENABLED` / `FEATURE_FLAG_PLATFORM_ENDPOINT` (Flipt), and `WORKER_ACTIONKIT_PRIVATE_URL` plus overridable `WORKER_EVENT_LOGS_PRIVATE_URL`. The AWS env overlay comment in `runtime_secrets.tf` clarifies that infra wins on merge conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bae7231a50de4254b3f8cdb7beba2cc00740fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->