### PR TITLE
feat(PARA-24362): add AWS Marketplace APN tagging for PRM compliance

### DIFF
--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -509,6 +509,8 @@ locals {
       Name        = "paragon-${var.organization}"
       Environment = local.environment
       Creator     = "Terraform"
+      Workspace   = "enterprise-installer"
+      aws-apn-id  = "pc:3elab41fw971izucbsjrfn81o"
     },
     trimspace(var.organization) == "" ? {} : { Organization = var.organization }
   )


### PR DESCRIPTION
### Issues Closed

- [PARA-24362](https://useparagon.atlassian.net/browse/PARA-24362)

### Brief Summary

add aws-apn-id default tags for marketplace prm

### Detailed Summary

AWS is measuring partner infrastructure spend via resource tags for PRM funding and co-sell. This adds the required `aws-apn-id` Marketplace Partner ID tag (and a static `Workspace` tag) to Terraform `default_tags` for the Brevian enterprise installer, so eligible AWS resources created/managed by this workspace pick up the tag automatically.

### Changes

- Add `aws-apn-id = "pc:3elab41fw971izucbsjrfn81o"` to `local.default_tags` in `aws/workspaces/infra/variables.tf`
- Add `Workspace = "enterprise-installer"` to the same default tags map

### Unrelated Changes

None

### Future Work

Roll out the same `aws-apn-id` default tag across remaining environment classifications (QA/staging, production cloud, other single-tenant enterprise workspaces, managed/unmanaged enterprise, and internal support infra) per the phased scope in PARA-24362.

### Steps to Test

1. Review the diff in `aws/workspaces/infra/variables.tf` and confirm `default_tags` includes `aws-apn-id` and `Workspace`
2. Run `terraform plan` in the Brevian infra workspace and confirm tag updates are expected on tagged resources
3. After apply, verify an eligible AWS resource shows `aws-apn-id=pc:3elab41fw971izucbsjrfn81o` in the console/CLI

### QA Notes

N/A — infra tagging change; verify via Terraform plan/apply and AWS resource tags rather than product QA.

### Deployment Notes

Requires a Terraform plan/apply for the Brevian infra workspace so existing resources pick up the new default tags. Do not tag the Marketplace listing ARN.

### Screenshots

N/A — will capture AWS console tag screenshots after apply for ticket verification.


[PARA-24362]: https://useparagon.atlassian.net/browse/PARA-24362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tag-only change on Terraform default_tags; no auth, data, or runtime behavior changes, though apply may update tags on many existing resources.
> 
> **Overview**
> Adds **`Workspace = "enterprise-installer"`** and **`aws-apn-id = "pc:3elab41fw971izucbsjrfn81o"`** to `local.default_tags` in the Brevian enterprise infra workspace.
> 
> Those tags are already wired through the AWS provider **`default_tags`**, so the next Terraform apply should attach them to resources this workspace manages—supporting AWS Marketplace PRM spend attribution without changing application logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518b660889a0e493b8ca49ea74f4a18cdc40b89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->