### PR TITLE
feat: allow configuring managed sync RDS instance class

### DIFF
--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -45,21 +45,22 @@ module "cloudtrail" {
 module "postgres" {
   source = "./postgres"
 
-  workspace                   = local.workspace
-  aws_region                  = var.aws_region
-  rds_instance_class          = var.rds_instance_class
-  rds_gp3_iops                = var.rds_gp3_iops
-  rds_gp3_storage_throughput  = var.rds_gp3_storage_throughput
-  rds_allocated_storage       = var.rds_allocated_storage
-  rds_max_allocated_storage   = var.rds_max_allocated_storage
-  rds_multi_az                = var.rds_multi_az
-  rds_multiple_instances      = var.rds_multiple_instances
-  rds_postgres_version        = var.rds_postgres_version
-  rds_restore_from_snapshot   = var.rds_restore_from_snapshot
-  rds_final_snapshot_enabled  = var.rds_final_snapshot_enabled
-  disable_deletion_protection = var.disable_deletion_protection
-  managed_sync_enabled        = var.managed_sync_enabled
-  migrated_passwords          = var.migrated_passwords
+  workspace                       = local.workspace
+  aws_region                      = var.aws_region
+  rds_instance_class              = var.rds_instance_class
+  rds_managed_sync_instance_class = var.rds_managed_sync_instance_class
+  rds_gp3_iops                    = var.rds_gp3_iops
+  rds_gp3_storage_throughput      = var.rds_gp3_storage_throughput
+  rds_allocated_storage           = var.rds_allocated_storage
+  rds_max_allocated_storage       = var.rds_max_allocated_storage
+  rds_multi_az                    = var.rds_multi_az
+  rds_multiple_instances          = var.rds_multiple_instances
+  rds_postgres_version            = var.rds_postgres_version
+  rds_restore_from_snapshot       = var.rds_restore_from_snapshot
+  rds_final_snapshot_enabled      = var.rds_final_snapshot_enabled
+  disable_deletion_protection     = var.disable_deletion_protection
+  managed_sync_enabled            = var.managed_sync_enabled
+  migrated_passwords              = var.migrated_passwords
 
   vpc                = module.network.vpc
   public_subnet      = module.network.public_subnet

--- a/aws/workspaces/infra/postgres/variables.tf
+++ b/aws/workspaces/infra/postgres/variables.tf
@@ -33,6 +33,11 @@ variable "rds_instance_class" {
   description = "The RDS instance class type used for Postgres."
 }
 
+variable "rds_managed_sync_instance_class" {
+  description = "The RDS instance class type used for the managed sync Postgres instance."
+  type        = string
+}
+
 variable "rds_gp3_iops" {
   description = "gp3 provisioned IOPS for all RDS instances. Null uses size-based baseline (3000 below 400 GiB, 12000 at/above)."
   type        = number
@@ -123,7 +128,7 @@ locals {
     }, var.managed_sync_enabled ? {
     managed_sync = {
       name = "${var.workspace}-managed-sync"
-      size = "db.t4g.small"
+      size = var.rds_managed_sync_instance_class
       db   = "managed_sync"
     }
     } : {}) : {

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -63,6 +63,12 @@ variable "rds_instance_class" {
   default     = "db.t4g.small"
 }
 
+variable "rds_managed_sync_instance_class" {
+  description = "The RDS instance class type used for the managed sync Postgres instance."
+  type        = string
+  default     = "db.t4g.small"
+}
+
 variable "rds_postgres_version" {
   description = "Postgres version for the database."
   type        = string


### PR DESCRIPTION
### Issues Closed

- N/A

### Brief Summary

configurable managed sync rds size

### Detailed Summary

The managed sync Postgres instance class was hardcoded to `db.t4g.small`, so larger sizes applied out of band could not be pinned in tfvars and Terraform would drift them back down. This adds `rds_managed_sync_instance_class` (default still `db.t4g.small`) and wires it through the AWS infra postgres module so operators can set the size per workspace.

### Changes

- Add `rds_managed_sync_instance_class` root variable (default `db.t4g.small`)
- Pass it into the postgres module and use it for the managed sync instance size

### Unrelated Changes

N/A

### Future Work

- Consider per-instance size overrides for other RDS roles if needed

### Steps to Test

1. From `aws/workspaces/infra`: `terraform init -backend=false && terraform validate`
2. Set `rds_managed_sync_instance_class` in tfvars and confirm plan only changes managed sync `instance_class`
3. Apply and verify the RDS instance reaches the configured class

### QA Notes

N/A — infra IaC only

### Deployment Notes

- Set `rds_managed_sync_instance_class` in infra tfvars when managed sync should not use the default `db.t4g.small`
- Changing instance class causes an RDS modify (possible reboot/brief downtime)

### Screenshots

N/A