### PR TITLE
feat: optional custom AWS bastion tags

### DIFF
--- a/aws/workspaces/infra/bastion/server.tf
+++ b/aws/workspaces/infra/bastion/server.tf
@@ -69,6 +69,8 @@ module "bastion" {
   bastion_launch_template_name = substr(local.bastion_name, 0, 22)
   instance_type                = "t3.micro"
 
+  tags = var.bastion_tags
+
   # user data template
   extra_user_data_content = templatefile("${path.module}/../templates/bastion/bastion-startup.tpl.sh", {
     account_id      = var.cloudflare_tunnel_account_id,

--- a/aws/workspaces/infra/bastion/variables.tf
+++ b/aws/workspaces/infra/bastion/variables.tf
@@ -23,6 +23,12 @@ variable "ssh_whitelist" {
   type        = list(string)
 }
 
+variable "bastion_tags" {
+  description = "Optional additional tags applied to bastion resources (e.g. customer SCP-required tags)."
+  type        = map(string)
+  default     = {}
+}
+
 # Cloudflare variables
 variable "cloudflare_api_token" {
   description = "Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Account `Cloudflare Tunnel`, `Access: Organizations, Identity Providers, and Groups`, `Access: Apps and Policies` and Zone `DNS`"

--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -104,6 +104,7 @@ module "bastion" {
   workspace     = local.workspace
   aws_region    = var.aws_region
   ssh_whitelist = local.ssh_whitelist
+  bastion_tags  = var.bastion_tags
 
   cloudflare_api_token           = var.cloudflare_api_token
   cloudflare_tunnel_enabled      = var.cloudflare_tunnel_enabled

--- a/aws/workspaces/infra/variables.tf
+++ b/aws/workspaces/infra/variables.tf
@@ -354,6 +354,12 @@ variable "bastion_enabled" {
   default     = true
 }
 
+variable "bastion_tags" {
+  description = "Optional additional tags applied to bastion resources (e.g. customer SCP-required tags)."
+  type        = map(string)
+  default     = {}
+}
+
 # cloudflare
 variable "cloudflare_api_token" {
   description = "Cloudflare API token created at https://dash.cloudflare.com/profile/api-tokens. Requires Edit permissions on Account `Cloudflare Tunnel`, `Access: Organizations, Identity Providers, and Groups`, `Access: Apps and Policies` and Zone `DNS`"


### PR DESCRIPTION
### Issues Closed

- PARA-25206

### Brief Summary

optional custom tags for aws bastion

### Detailed Summary

Adds an optional `bastion_tags` Terraform variable so additional tags can be applied to bastion resources when required (for example by customer SCPs). Defaults to an empty map so existing workspaces are unchanged unless tags are provided via tfvars.

### Changes

- Add root and bastion-module `bastion_tags` variable (`map(string)`, default `{}`)
- Pass `bastion_tags` through the infra bastion module
- Wire tags into the bastion host module

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. From `aws/workspaces/infra`: `terraform init -backend=false && terraform validate` with `bastion_tags` unset
2. Set `bastion_tags` in tfvars (e.g. a couple of key/value pairs) and confirm `terraform plan` shows those tags on bastion resources
3. Confirm omitting `bastion_tags` produces no bastion tag drift vs current state

### QA Notes

N/A

### Deployment Notes

Customers that need extra bastion tags should set `bastion_tags` in infra tfvars. No change required for others.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tag-only Terraform wiring with a default empty map; no auth, networking, or runtime behavior changes.
> 
> **Overview**
> Adds an optional **`bastion_tags`** Terraform variable (`map(string)`, default `{}`) so workspaces can supply extra tags on bastion resources created by the external `terraform-aws-bastion` module—commonly needed for customer SCP-mandated tags.
> 
> The root infra variable is passed through `modules.tf` into the local bastion module and set as **`tags = var.bastion_tags`** on that module call. Omitting the variable leaves behavior unchanged (no tag drift).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73779e9b0a72ff55ffc8da0702d95b54ee7ceed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->