### PR TITLE
fix(PARA-25248): stop EKS module depends_on from force-replacing cluster IAM policies

### DIFF
--- a/aws/workspaces/infra/cluster/autoscaling.tf
+++ b/aws/workspaces/infra/cluster/autoscaling.tf
@@ -69,8 +69,12 @@ module "cluster_autoscaler" {
     }
   })
 
+  # Only the node groups are listed: module.eks is already implicit via cluster_name and the
+  # OIDC issuer inputs, and every module-level depends_on defers this module's
+  # data.aws_region read to apply time, which makes the Helm values unknown and rewrites the
+  # release on every run. Node group ordering is kept so the autoscaler pod has a node to
+  # schedule onto on a greenfield apply.
   depends_on = [
-    module.eks,
     module.eks_managed_node_group
   ]
 }

--- a/aws/workspaces/infra/cluster/cluster.tf
+++ b/aws/workspaces/infra/cluster/cluster.tf
@@ -77,10 +77,19 @@ module "eks" {
     Name = var.workspace
   }
 
-  depends_on = [
-    aws_iam_role.eks_cluster_admin,
-    terraform_data.egress_ready,
-  ]
+  # NEVER add depends_on here. A module-level depends_on is inherited by the module's
+  # data sources, so `data.aws_partition.current` is deferred to apply time whenever any
+  # upstream object has a pending change. That makes local.iam_role_policy_prefix unknown
+  # at plan time, which makes policy_arn unknown on
+  # aws_iam_role_policy_attachment.this["AmazonEKSClusterPolicy"] and
+  # ["AmazonEKSVPCResourceController"]. policy_arn is ForceNew, so Terraform silently
+  # detaches and re-attaches both managed policies from the live cluster role on an
+  # otherwise unrelated apply, which takes the control plane's node/ENI management offline
+  # and drives every node NotReady (SEV-1130).
+  #
+  # aws_iam_role.eks_cluster_admin is already an implicit dependency via access_entries.
+  # The egress gate belongs on the node groups, which are what actually bootstrap over the
+  # internet; the control plane itself does not need private egress routing.
 }
 
 # Managed outside the EKS module so creation is ordered after the cluster (and the
@@ -176,8 +185,13 @@ module "eks_managed_node_group" {
   enable_monitoring       = true
   block_device_mappings = each.key == "system" && try(each.value.ami_type, null) == "BOTTLEROCKET_x86_64" ? local.bottlerocket_system_block_device_mappings : local.default_block_device_mappings
 
+  # depends_on is safe here only because create_iam_role = false: the data sources this
+  # defers (aws_partition, aws_caller_identity) feed nothing but the module's own node role
+  # policy ARNs, which are not created. Do not enable create_iam_role without first making
+  # these dependencies implicit — see the note on module.eks above.
   depends_on = [
     module.eks,
+    terraform_data.egress_ready,
     aws_iam_role.node_role,
     aws_iam_role_policy_attachment.custom_worker_policy_attachment,
     aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy,

--- a/aws/workspaces/infra/cluster/karpenter.tf
+++ b/aws/workspaces/infra/cluster/karpenter.tf
@@ -7,11 +7,6 @@ module "sqs" {
   tags = {
     ClusterName = var.workspace
   }
-
-  depends_on = [
-    module.eks,
-    module.ebs_kms_key,
-  ]
 }
 
 module "iam" {
@@ -29,10 +24,11 @@ module "iam" {
     ClusterName = var.workspace
   }
 
-  depends_on = [
-    module.eks,
-    module.sqs,
-  ]
+  # No depends_on: this module builds node role policy ARNs from data.aws_partition, so a
+  # module-level depends_on would defer that read to apply time and force Terraform to
+  # detach and re-attach the Karpenter node role's worker policies. cluster_name,
+  # interruption_queue_arn and kms_key_arn already order this after module.eks,
+  # module.sqs and module.ebs_kms_key.
 }
 
 module "karpenter" {

--- a/prepare.sh
+++ b/prepare.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.08.05"
+version="2026.08.10"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-25248

### Brief Summary

prevent terraform from detaching eks cluster iam policies

### Detailed Summary

A module-level `depends_on` on `module.eks` caused Terraform to defer `data.aws_partition.current` to apply time whenever any upstream dependency had a pending change. That made managed policy ARNs unknown at plan time. Because `policy_arn` is ForceNew on `aws_iam_role_policy_attachment`, Terraform silently detached and re-attached `AmazonEKSClusterPolicy` and `AmazonEKSVPCResourceController` from the live cluster role during otherwise unrelated applies. While those policies were missing, the control plane could not manage node ENIs and nodes went NotReady.

The same pattern also deferred `data.aws_region` inside the cluster-autoscaler module (via `depends_on = [module.eks]`), rewriting the Helm release with `(known after apply)` values. Redundant `depends_on` on Karpenter IAM/SQS modules had the same latent risk for node role policy attachments.

This change removes the unsafe module-level dependencies, moves the egress readiness gate onto managed node groups (where it belongs), and documents why `module.eks` must not regain a module-level `depends_on`.

### Changes

- Remove `depends_on` from `module.eks`; keep egress ordering on `module.eks_managed_node_group`
- Drop redundant `depends_on` from Karpenter `module.sqs` and `module.iam` (implicit deps via inputs remain)
- Drop `module.eks` from cluster-autoscaler `depends_on` (already implicit via cluster name / OIDC inputs)
- Add comments documenting the ForceNew policy-ARN failure mode

### Unrelated Changes

- Bump `prepare.sh` chart version to `2026.08.10`

### Future Work

- Prefer implicit dependencies over module-level `depends_on` anywhere a child module builds IAM policy ARNs from `data.aws_partition` / `data.aws_caller_identity`
- Confirm Spacelift-only apply path so caller-ARN injection stays stable without duplicating the Terraform role in `eks_admin_arns`

### Steps to Test

1. `cd aws/workspaces/infra && terraform init -backend=false && terraform validate`
2. On a healthy AWS infra stack, run a plan that includes an unrelated pending change
3. Confirm the plan does **not** propose create/replace/destroy on:
   - `module.cluster.module.eks.aws_iam_role_policy_attachment.this["AmazonEKSClusterPolicy"]`
   - `module.cluster.module.eks.aws_iam_role_policy_attachment.this["AmazonEKSVPCResourceController"]`
4. Confirm cluster-autoscaler Helm values are not `(known after apply)` solely due to deferred region data
5. Apply and verify EKS nodes remain Ready and both managed policies stay attached to the cluster role

### QA Notes

Infrastructure-only change; no application/QA UI verification. Review Terraform plan output carefully before apply on production stacks that may still show recreating the two cluster policy attachments (that is correcting real drift from a prior bad apply).

### Deployment Notes

- No new variables or Spacelift context keys required
- Safe to roll out to all AWS infra stacks
- If a stack still shows `+ create` for the two cluster policy attachments, that restores missing permissions and should be applied

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes EKS Terraform ordering for cluster IAM and Karpenter node policies; incorrect dependency handling can still detach critical managed policies and take nodes NotReady, so plans must be reviewed before apply.
> 
> **Overview**
> Fixes **PARA-25248** by removing module-level `depends_on` that deferred partition/region data reads and made IAM `policy_arn` values unknown at plan time, triggering **ForceNew** detach/reattach of EKS cluster managed policies and node NotReady incidents (SEV-1130).
> 
> **`module.eks`** no longer depends on `aws_iam_role.eks_cluster_admin` or `terraform_data.egress_ready`; comments document why `depends_on` must not return on that module. **`terraform_data.egress_ready`** is added to **`module.eks_managed_node_group`** so nodes wait for egress without affecting cluster-role policy ARNs. **Cluster-autoscaler** drops `module.eks` from `depends_on` (implicit via cluster/OIDC inputs) while keeping node-group ordering. **Karpenter** `module.sqs` and `module.iam` lose redundant `depends_on` for the same latent partition-ARN risk.
> 
> Also bumps **`prepare.sh`** chart version to `2026.08.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa17cfd87d0d47a6005517af15339f765d5e80a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->