### PR TITLE
fix(PARA-25161): clean up failed migration hooks before next upgrade

### DIFF
--- a/charts/paragon-templates/templates/_migration.yaml
+++ b/charts/paragon-templates/templates/_migration.yaml
@@ -13,6 +13,13 @@ Call with: include "migration.standard" (dict "root" $ "imageName" "postgres-zeu
 {{- if $root.Values.podAnnotations -}}
 {{- $podAnnotations = merge $podAnnotations $root.Values.podAnnotations -}}
 {{- end -}}
+{{- $migration := dict "activeDeadlineSeconds" 600 "queryTimeoutMillis" 600000 -}}
+{{- if and $root.Values.global (kindIs "map" $root.Values.global) (hasKey $root.Values.global "migration") (kindIs "map" $root.Values.global.migration) -}}
+{{- $migration = merge (deepCopy $root.Values.global.migration) $migration -}}
+{{- end -}}
+{{- if and (hasKey $root.Values "migration") (kindIs "map" $root.Values.migration) -}}
+{{- $migration = merge (deepCopy $root.Values.migration) $migration -}}
+{{- end -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -21,8 +28,18 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # Failed jobs are kept for debugging and removed by before-hook-creation on the next upgrade.
+  # backoffLimit is left at the Kubernetes default (6) unless overridden via values.migration /
+  # global.migration — useful for transient DB errors; long CREATE INDEX work is bounded by
+  # activeDeadlineSeconds / POSTGRES_QUERY_TIMEOUT_MILLIS instead.
+  {{- if hasKey $migration "backoffLimit" }}
+  backoffLimit: {{ $migration.backoffLimit }}
+  {{- end }}
+  {{- if $migration.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ $migration.activeDeadlineSeconds }}
+  {{- end }}
   template:
     metadata:
       {{- if $podAnnotations }}
@@ -50,6 +67,9 @@ spec:
             {{- toYaml $root.Values.resources | nindent 12 }}
           env:
             {{- include "env.standard" $root | nindent 12 }}
+            # Override after env.standard so migrations can run longer than runtime query limits.
+            - name: POSTGRES_QUERY_TIMEOUT_MILLIS
+              value: {{ $migration.queryTimeoutMillis | quote }}
       restartPolicy: Never
       {{- with $root.Values.nodeSelector }}
       nodeSelector:

--- a/charts/paragon-templates/templates/_migration.yaml
+++ b/charts/paragon-templates/templates/_migration.yaml
@@ -14,10 +14,12 @@ Call with: include "migration.standard" (dict "root" $ "imageName" "postgres-zeu
 {{- $podAnnotations = merge $podAnnotations $root.Values.podAnnotations -}}
 {{- end -}}
 {{- $migration := dict "activeDeadlineSeconds" 600 "queryTimeoutMillis" 600000 -}}
-{{- if and $root.Values.global (kindIs "map" $root.Values.global) (hasKey $root.Values.global "migration") (kindIs "map" $root.Values.global.migration) -}}
+{{- if kindIs "map" $root.Values.global -}}
+{{- if kindIs "map" (get $root.Values.global "migration") -}}
 {{- $migration = merge (deepCopy $root.Values.global.migration) $migration -}}
 {{- end -}}
-{{- if and (hasKey $root.Values "migration") (kindIs "map" $root.Values.migration) -}}
+{{- end -}}
+{{- if kindIs "map" (get $root.Values "migration") -}}
 {{- $migration = merge (deepCopy $root.Values.migration) $migration -}}
 {{- end -}}
 ---


### PR DESCRIPTION
### Issues Closed

- PARA-25161

### Brief Summary

clean up failed migration helm hooks

### Detailed Summary

Failed `pre-install`/`pre-upgrade` migration Jobs were left in the cluster because `helm.sh/hook-delete-policy` was set to only `hook-succeeded`, which overrides Helm's default `before-hook-creation`. After a failed migration (or rollback), the next upgrade tried to recreate a Job with the same name and failed with an already-exists conflict, forcing manual `kubectl delete job` cleanup (SUP-1860).

This change restores `before-hook-creation` so a failed Job is removed automatically at the start of the next upgrade attempt, while still deleting successful hooks immediately. It also caps migration Jobs at 10 minutes and raises `POSTGRES_QUERY_TIMEOUT_MILLIS` to 10 minutes **only on the migration Job**, so long `CREATE INDEX` work can finish without changing runtime query timeouts on Deployments/StatefulSets. `backoffLimit` remains the Kubernetes default (6) so transient DB failures can still retry.

### Changes

- Set `helm.sh/hook-delete-policy` to `before-hook-creation,hook-succeeded` on the shared migration Job template
- Add configurable `activeDeadlineSeconds` defaulting to 600 (10 minutes)
- Override `POSTGRES_QUERY_TIMEOUT_MILLIS` to 600000 on the migration Job only (after `env.standard`)
- Allow overrides via `migration.*` / `global.migration.*` (`activeDeadlineSeconds`, `queryTimeoutMillis`, optional `backoffLimit`)

### Unrelated Changes

None.

### Future Work

- Consider aligning Helm release `timeout` (currently 900s / 15m) more closely with migration deadlines if customers regularly need longer index builds
- Spike follow-up: document customer runbook for inspecting failed migration Job logs before the next upgrade deletes them via `before-hook-creation`

### Steps to Test

1. Render a prepared chart that uses `migration.standard` and confirm the Job annotations include `before-hook-creation,hook-succeeded`, `activeDeadlineSeconds: 600`, and `POSTGRES_QUERY_TIMEOUT_MILLIS=600000`
2. Deploy/upgrade, force a migration Job failure (e.g. bad DB credentials), confirm the failed Job remains for log inspection
3. Re-run the upgrade and confirm Helm deletes the prior Job before creating the new one (no already-exists conflict)
4. Confirm Deployment/StatefulSet env still uses the normal runtime `POSTGRES_QUERY_TIMEOUT_MILLIS` (not 600000)

### QA Notes

N/A — infra/Helm chart change; no product UI.

### Deployment Notes

No customer config changes required. Optional overrides:

```yaml
global:
  migration:
    activeDeadlineSeconds: 600
    queryTimeoutMillis: 600000
    # backoffLimit: 6
```

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-upgrade migration Job behavior for all services using the shared template; misconfigured deadlines or hook cleanup could affect upgrade success or debug visibility of failed migrations.
> 
> **Overview**
> Fixes upgrade failures when a prior migration Helm hook Job failed and blocked the next release with an **already-exists** conflict on `migrations-*`.
> 
> The shared **`migration.standard`** template now sets **`helm.sh/hook-delete-policy`** to **`before-hook-creation,hook-succeeded`** so failed Jobs are removed at the start of the next upgrade while successful hooks are still deleted immediately. Migration Jobs get a **10-minute** cap via **`activeDeadlineSeconds`** (default 600) and a migration-only **`POSTGRES_QUERY_TIMEOUT_MILLIS`** override (600000) after **`env.standard`**, without changing runtime query limits on Deployments/StatefulSets. **`backoffLimit`** stays at the Kubernetes default unless set via **`migration.*`** / **`global.migration.*`** (`activeDeadlineSeconds`, `queryTimeoutMillis`, optional `backoffLimit`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da9cc91cb826ee1e79bac1f24737cff018ab65e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->