### PR TITLE
fix(gcp): GSM cluster handoff and ESO private GKE sync (PARA-25261)

### DIFF
--- a/gcp/workspaces/infra/runtime_secrets.tf
+++ b/gcp/workspaces/infra/runtime_secrets.tf
@@ -44,8 +44,9 @@ resource "google_secret_manager_secret_version" "runtime_storage" {
     managed_sync_bucket = module.storage.storage.managed_sync_bucket
     logs_bucket         = module.storage.storage.logs_bucket
     auditlogs_bucket    = module.storage.storage.auditlogs_bucket
-    microservice_user   = module.storage.storage.minio_microservice_user
-    microservice_pass   = module.storage.storage.minio_microservice_pass
+    # GCS (no MinIO): microservice creds are the same SA key as root.
+    microservice_user   = module.storage.storage.project_id
+    microservice_pass   = module.storage.storage.private_key
     root_user           = module.storage.storage.project_id
     root_password       = module.storage.storage.private_key
     service_account     = module.storage.storage.service_account

--- a/gcp/workspaces/infra/runtime_secrets.tf
+++ b/gcp/workspaces/infra/runtime_secrets.tf
@@ -112,3 +112,20 @@ resource "google_secret_manager_secret_version" "runtime_bastion" {
     private_key = module.bastion[0].connection.private_key
   })
 }
+
+resource "google_secret_manager_secret" "runtime_cluster" {
+  secret_id = "${local.runtime_secret_prefix}-cluster"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "runtime_cluster" {
+  secret = google_secret_manager_secret.runtime_cluster.id
+  secret_data = jsonencode({
+    cluster_name = module.cluster.kubernetes.name
+    location     = var.region
+    k8s_version  = var.k8s_version
+  })
+}

--- a/gcp/workspaces/paragon/helm/eso_sync.tf
+++ b/gcp/workspaces/paragon/helm/eso_sync.tf
@@ -10,7 +10,8 @@ locals {
 }
 
 resource "time_sleep" "wait_for_eso_core_secrets" {
-  create_duration = "90s"
+  # First apply: ESO webhook/controller + GSM sync often exceeds 90s on private GKE.
+  create_duration = "180s"
 
   depends_on = [
     kubectl_manifest.external_secret_paragon,

--- a/gcp/workspaces/paragon/helm/external_secrets.tf
+++ b/gcp/workspaces/paragon/helm/external_secrets.tf
@@ -51,10 +51,13 @@ locals {
     spec = {
       provider = {
         gcpsm = {
+          projectID = var.gcp_project_id
           auth = {
             workloadIdentity = {
-              clusterLocation = var.region
-              clusterName     = var.cluster_name
+              # Required by ESO 0.14 CRD validation (cannot be omitted/null).
+              clusterProjectID = var.gcp_project_id
+              clusterLocation  = var.region
+              clusterName      = var.cluster_name
               serviceAccountRef = {
                 name      = "external-secrets"
                 namespace = kubernetes_namespace_v1.external_secrets.id

--- a/gcp/workspaces/paragon/helm/external_secrets.tf
+++ b/gcp/workspaces/paragon/helm/external_secrets.tf
@@ -47,6 +47,10 @@ locals {
     kind       = "ClusterSecretStore"
     metadata = {
       name = "gcp-secret-manager"
+      annotations = {
+        # Consumes eso_iam_ready so Terraform applies WI/secretAccessor before this manifest.
+        "paragon.useparagon.com/eso-iam-ready" = var.eso_iam_ready
+      }
     }
     spec = {
       provider = {

--- a/gcp/workspaces/paragon/helm/variables.tf
+++ b/gcp/workspaces/paragon/helm/variables.tf
@@ -82,6 +82,11 @@ variable "external_secrets_service_account_email" {
   type        = string
 }
 
+variable "gcp_project_id" {
+  description = "GCP project ID for Secret Manager (ClusterSecretStore provider.gcpsm.projectID)."
+  type        = string
+}
+
 variable "gcp_creds" {
   description = "GCP credentials for logging bucket access."
   type        = string

--- a/gcp/workspaces/paragon/helm/variables.tf
+++ b/gcp/workspaces/paragon/helm/variables.tf
@@ -82,6 +82,11 @@ variable "external_secrets_service_account_email" {
   type        = string
 }
 
+variable "eso_iam_ready" {
+  description = "Opaque token referencing ESO IAM bindings so the ClusterSecretStore waits without module depends_on."
+  type        = string
+}
+
 variable "gcp_project_id" {
   description = "GCP project ID for Secret Manager (ClusterSecretStore provider.gcpsm.projectID)."
   type        = string

--- a/gcp/workspaces/paragon/infra_secrets.tf
+++ b/gcp/workspaces/paragon/infra_secrets.tf
@@ -5,6 +5,7 @@ locals {
     storage       = "${local.workspace}-storage"
     kafka         = "${local.workspace}-kafka"
     redis_ca_cert = "${local.workspace}-redis-ca-cert"
+    cluster       = "${local.workspace}-cluster"
   }
 }
 
@@ -36,16 +37,30 @@ data "google_secret_manager_secret_version" "infra_kafka" {
   version = "latest"
 }
 
+data "google_secret_manager_secret_version" "infra_cluster" {
+  count   = local.use_legacy_infra_json ? 0 : 1
+  project = local.gcp_project_id
+  secret  = local.infra_secret_names.cluster
+  version = "latest"
+}
+
 locals {
+  # Cluster metadata is not sensitive; nonsensitive avoids propagating secret
+  # sensitivity into providers/modules that take a plain cluster name.
+  provider_cluster = local.use_legacy_infra_json ? {} : jsondecode(
+    nonsensitive(data.google_secret_manager_secret_version.infra_cluster[0].secret_data)
+  )
+
   provider_infra_vars = merge(
     {
       workspace        = { value = local.workspace }
-      cluster_name     = { value = local.cluster_name }
+      cluster_name     = { value = try(local.provider_cluster.cluster_name, local.cluster_name) }
       logs_bucket      = { value = local.logs_bucket }
       auditlogs_bucket = { value = local.auditlogs_bucket }
       postgres         = { value = jsondecode(data.google_secret_manager_secret_version.infra_postgres[0].secret_data) }
       redis            = { value = jsondecode(data.google_secret_manager_secret_version.infra_redis[0].secret_data) }
       storage          = { value = jsondecode(data.google_secret_manager_secret_version.infra_storage[0].secret_data) }
+      k8s_version      = { value = try(local.provider_cluster.k8s_version, null) }
     },
     var.managed_sync_enabled ? {
       kafka = { value = jsondecode(data.google_secret_manager_secret_version.infra_kafka[0].secret_data) }

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -55,6 +55,7 @@ module "helm" {
   feature_flags_content                  = local.feature_flags_content
   flipt_options                          = local.flipt_options
   gcp_creds                              = local.gcp_creds
+  gcp_project_id                         = local.gcp_project_id
   helm_values                            = local.helm_values_public
   secrets_revision = sha256(jsonencode({
     env             = google_secret_manager_secret_version.env.name
@@ -87,6 +88,13 @@ module "helm" {
   waf_security_policy_name    = local.waf_active ? module.waf[0].security_policy_name : ""
   waf_logs_sample_rate        = var.waf_logs_sample_rate
   workspace                   = local.workspace
+
+  # ESO must not reconcile until WI + secretAccessor exist; otherwise
+  # ClusterSecretStore stays InvalidProviderConfig / ExternalSecrets never sync.
+  depends_on = [
+    google_project_iam_member.eso_secret_accessor,
+    google_service_account_iam_member.eso_workload_identity,
+  ]
 }
 
 module "hoop" {

--- a/gcp/workspaces/paragon/modules.tf
+++ b/gcp/workspaces/paragon/modules.tf
@@ -52,11 +52,16 @@ module "helm" {
   domain                                 = var.domain
   env_secret_name                        = google_secret_manager_secret.env.secret_id
   external_secrets_service_account_email = google_service_account.eso.email
-  feature_flags_content                  = local.feature_flags_content
-  flipt_options                          = local.flipt_options
-  gcp_creds                              = local.gcp_creds
-  gcp_project_id                         = local.gcp_project_id
-  helm_values                            = local.helm_values_public
+  # Implicit ordering (helm has local providers, so module depends_on is illegal).
+  eso_iam_ready = sha256(jsonencode([
+    google_project_iam_member.eso_secret_accessor.id,
+    google_service_account_iam_member.eso_workload_identity.id,
+  ]))
+  feature_flags_content = local.feature_flags_content
+  flipt_options         = local.flipt_options
+  gcp_creds             = local.gcp_creds
+  gcp_project_id        = local.gcp_project_id
+  helm_values           = local.helm_values_public
   secrets_revision = sha256(jsonencode({
     env             = google_secret_manager_secret_version.env.name
     docker_cfg      = length(google_secret_manager_secret_version.docker_cfg) > 0 ? google_secret_manager_secret_version.docker_cfg[0].name : null
@@ -88,13 +93,6 @@ module "helm" {
   waf_security_policy_name    = local.waf_active ? module.waf[0].security_policy_name : ""
   waf_logs_sample_rate        = var.waf_logs_sample_rate
   workspace                   = local.workspace
-
-  # ESO must not reconcile until WI + secretAccessor exist; otherwise
-  # ClusterSecretStore stays InvalidProviderConfig / ExternalSecrets never sync.
-  depends_on = [
-    google_project_iam_member.eso_secret_accessor,
-    google_service_account_iam_member.eso_workload_identity,
-  ]
 }
 
 module "hoop" {

--- a/gcp/workspaces/paragon/variables.tf
+++ b/gcp/workspaces/paragon/variables.tf
@@ -535,8 +535,9 @@ variable "waf_rate_limit_options" {
   }
 
   validation {
+    # try(): coalesce(null, "") errors because coalesce skips empty strings too.
     condition = !contains(["HTTP_HEADER", "HTTP_COOKIE"], coalesce(var.waf_rate_limit_options.enforce_on_key, "IP")) || (
-      var.waf_rate_limit_options.enforce_on_key_name != null && trimspace(coalesce(var.waf_rate_limit_options.enforce_on_key_name, "")) != ""
+      try(length(trimspace(var.waf_rate_limit_options.enforce_on_key_name)) > 0, false)
     )
     error_message = "waf_rate_limit_options.enforce_on_key_name is required when enforce_on_key is HTTP_HEADER or HTTP_COOKIE."
   }
@@ -682,7 +683,7 @@ variable "waf_preconfigured_rules" {
             coalesce(exclusion.request_uris, []),
             coalesce(exclusion.request_query_params, []),
           ) :
-          field.operator == "EQUALS_ANY" ? field.value == null : (field.value != null && trimspace(coalesce(field.value, "")) != "")
+          field.operator == "EQUALS_ANY" ? field.value == null : try(length(trimspace(field.value)) > 0, false)
         ]
       ]
     ]))
@@ -816,7 +817,7 @@ variable "waf_custom_rules" {
     condition = alltrue([
       for _, rule in var.waf_custom_rules :
       rule.rate_limit == null || !contains(["HTTP_HEADER", "HTTP_COOKIE"], coalesce(rule.rate_limit.enforce_on_key, "IP")) || (
-        rule.rate_limit.enforce_on_key_name != null && trimspace(coalesce(rule.rate_limit.enforce_on_key_name, "")) != ""
+        try(length(trimspace(rule.rate_limit.enforce_on_key_name)) > 0, false)
       )
     ])
     error_message = "waf_custom_rules.rate_limit.enforce_on_key_name is required when enforce_on_key is HTTP_HEADER or HTTP_COOKIE."
@@ -908,8 +909,14 @@ locals {
   # output; null-safe when neither is present.
   storage_output = try(local.infra_vars.storage.value, local.infra_vars.minio.value, {})
 
-  workspace        = nonsensitive(local.use_legacy_infra_json ? try(local.legacy_infra_vars.workspace.value, local.default_workspace) : local.default_workspace)
-  cluster_name     = coalesce(var.cluster_name_override, local.use_legacy_infra_json ? try(local.legacy_infra_vars.cluster_name.value, null) : null, "${local.workspace}-cluster")
+  workspace = nonsensitive(local.use_legacy_infra_json ? try(local.legacy_infra_vars.workspace.value, local.default_workspace) : local.default_workspace)
+  # Prefer infra GSM handoff (actual GKE name may be -private or -cluster).
+  cluster_name = coalesce(
+    var.cluster_name_override,
+    local.use_legacy_infra_json ? try(local.legacy_infra_vars.cluster_name.value, null) : null,
+    try(local.provider_cluster.cluster_name, null),
+    "${local.workspace}-cluster"
+  )
   logs_bucket      = local.use_legacy_infra_json ? try(local.legacy_infra_vars.logs_bucket.value, "${local.workspace}-logs") : "${local.workspace}-logs"
   auditlogs_bucket = local.use_legacy_infra_json ? try(local.legacy_infra_vars.auditlogs_bucket.value, "${local.workspace}-auditlogs") : "${local.workspace}-auditlogs"
 


### PR DESCRIPTION
### Issues Closed

- PARA-25261

### Brief Summary

fix gcp gsm handoff and eso private gke sync

### Detailed Summary

GCP enterprise apply after the Secret Manager + External Secrets migration was failing for several related reasons: storage runtime secrets still referenced removed MinIO fields, paragon assumed a `${workspace}-cluster` GKE name while private-endpoint clusters use `${workspace}-private` (and unlike AWS there was no cluster metadata secret), the ClusterSecretStore lacked `projectID` / correct WI cluster identity, helm `depends_on` is illegal on the legacy helm module, ESO core wait was too short, and WAF validations crashed on `coalesce(null, "")`.

This PR aligns GCP with the AWS-style cluster handoff, hardens ESO store configuration and IAM ordering via an input token, and fixes the validation/wait issues so clean infra→paragon applies can sync Kubernetes secrets.

### Changes

- Map GCS storage microservice creds to `project_id` / `private_key` in infra runtime secrets (no MinIO attributes)
- Publish `${workspace}-cluster` GSM secret from infra (`cluster_name`, `location`, `k8s_version`) and read it in paragon
- Set ClusterSecretStore `projectID` / `clusterProjectID` / real `clusterName`; pass `eso_iam_ready` instead of illegal module `depends_on`
- Increase ESO core secrets wait to 180s
- Fix WAF optional-string validations to use `try(length(trimspace(...)) > 0, false)`

### Unrelated Changes

None

### Future Work

- Document Secret Manager API + installer SA IAM prerequisites in GCP runbooks
- Consider waiting on ExternalSecret Ready condition instead of a fixed sleep
- Ensure EU / other private-GKE workspaces apply infra before paragon so the cluster secret exists

### Steps to Test

1. Apply GCP infra; confirm GSM `${workspace}-cluster` contains the real GKE name (`-private` when public endpoint is disabled).
2. Apply GCP paragon; confirm ClusterSecretStore is Ready and ExternalSecrets reach SecretSynced.
3. Confirm Kubernetes secrets exist: `paragon-secrets`, docker-cfg, openobserve credentials, redis CA.
4. `terraform plan` with default `waf_rate_limit_options = {}` succeeds.
5. Confirm `module.helm` has no `depends_on` and still orders after ESO IAM via `eso_iam_ready`.

### QA Notes

N/A for product QA — infrastructure / installer validation only. Ops should verify Secret Manager API is enabled and the installer SA can create secrets before apply.

### Deployment Notes

- Apply **infra** before **paragon** so the cluster metadata secret exists.
- Per GCP project: enable `secretmanager.googleapis.com` and grant the installer SA Secret Manager create/admin (or equivalent).
- If ExternalSecrets cached failures from an earlier broken store, one-time `force-sync` annotations may still be needed; clean applies should not require it.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect cluster identity, Secret Manager payloads, and ESO/GSM sync ordering on enterprise GKE; mis-ordering infra vs paragon or stale ESO state could still block applies, but changes are targeted fixes rather than broad refactors.
> 
> **Overview**
> Unblocks **infra → paragon** applies on GCP after the Secret Manager / External Secrets migration by fixing storage handoff, cluster naming, ESO configuration, and Terraform validation edge cases.
> 
> **Infra runtime secrets:** Storage microservice credentials now use GCS **project_id** / **private_key** instead of removed MinIO fields. A new **`${workspace}-cluster`** GSM secret publishes **cluster_name**, **location**, and **k8s_version** from the live GKE module.
> 
> **Paragon handoff:** Paragon reads that cluster secret and prefers the real GKE name (e.g. **`-private`**) over the default **`${workspace}-cluster`** guess. **`k8s_version`** is threaded through infra vars; cluster metadata is decoded with **`nonsensitive`** so sensitivity does not break downstream providers.
> 
> **External Secrets:** **ClusterSecretStore** gains **`projectID`**, **`clusterProjectID`**, and correct workload-identity cluster fields for ESO 0.14. **`eso_iam_ready`** (hash of ESO IAM bindings) and an annotation on the store replace illegal **`depends_on`** on the helm module. Core secret sync wait increases from **90s → 180s** for private GKE first applies.
> 
> **WAF variables:** Optional string checks use **`try(length(trimspace(...)) > 0, false)`** so **`coalesce(null, "")`** no longer errors during **`terraform plan`** with empty defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756c595b70d19376d0afa157a64dce19691b4379. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->