### PR TITLE
fix(PARA-25285): make nsg_malicious_ips conditional type-stable

### DIFF
--- a/azure/workspaces/infra/network/nsg.tf
+++ b/azure/workspaces/infra/network/nsg.tf
@@ -11,37 +11,42 @@
 
 locals {
   # Shared baseline applied to both NSGs (keeps deny/allow posture in one place).
+  # Use for/if (not ternary ? [...] : []) so Terraform does not have to unify a
+  # 2-object tuple with [] — the two deny objects put list(string) on different
+  # attributes (source vs destination prefixes), which fails type unification.
   nsg_baseline_rules = concat(
-    length(var.nsg_malicious_ips) > 0 ? [
-      {
-        name                         = "DenyMaliciousIpsInbound"
-        priority                     = 1000
-        direction                    = "Inbound"
-        access                       = "Deny"
-        protocol                     = "*"
-        source_port_range            = "*"
-        destination_port_range       = "*"
-        destination_port_ranges      = null
-        source_address_prefix        = null
-        source_address_prefixes      = var.nsg_malicious_ips
-        destination_address_prefix   = "*"
-        destination_address_prefixes = null
-      },
-      {
-        name                         = "DenyMaliciousIpsOutbound"
-        priority                     = 1100
-        direction                    = "Outbound"
-        access                       = "Deny"
-        protocol                     = "*"
-        source_port_range            = "*"
-        destination_port_range       = "*"
-        destination_port_ranges      = null
-        source_address_prefix        = "*"
-        source_address_prefixes      = null
-        destination_address_prefix   = null
-        destination_address_prefixes = var.nsg_malicious_ips
-      },
-    ] : [],
+    [
+      for rule in [
+        {
+          name                         = "DenyMaliciousIpsInbound"
+          priority                     = 1000
+          direction                    = "Inbound"
+          access                       = "Deny"
+          protocol                     = "*"
+          source_port_range            = "*"
+          destination_port_range       = "*"
+          destination_port_ranges      = null
+          source_address_prefix        = null
+          source_address_prefixes      = var.nsg_malicious_ips
+          destination_address_prefix   = "*"
+          destination_address_prefixes = null
+        },
+        {
+          name                         = "DenyMaliciousIpsOutbound"
+          priority                     = 1100
+          direction                    = "Outbound"
+          access                       = "Deny"
+          protocol                     = "*"
+          source_port_range            = "*"
+          destination_port_range       = "*"
+          destination_port_ranges      = null
+          source_address_prefix        = "*"
+          source_address_prefixes      = null
+          destination_address_prefix   = null
+          destination_address_prefixes = var.nsg_malicious_ips
+        },
+      ] : rule if length(var.nsg_malicious_ips) > 0
+    ],
     [
       {
         name                         = "DenyPort22Inbound"


### PR DESCRIPTION
### Issues Closed

- PARA-25285

### Brief Summary

fix azure nsg denylist terraform plan type error

### Detailed Summary

`terraform plan` failed with "Inconsistent conditional result types" when `nsg_malicious_ips` was non-empty, so the documented NSG denylist could not be used. The ternary that optionally added DenyMaliciousIps rules tried to unify a 2-object tuple (list prefixes on different attributes) with `[]`. Replaced it with a `for`/`if` comprehension so both empty and non-empty lists plan cleanly.

### Changes

- Update `nsg_baseline_rules` in Azure infra NSG config to filter DenyMaliciousIps inbound/outbound rules with `for`/`if` instead of a ternary

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. In `azure/workspaces/infra`, run `terraform plan` with `nsg_malicious_ips = []` and confirm it succeeds (no DenyMaliciousIps rules).
2. Run `terraform plan` with `nsg_malicious_ips = ["1.2.3.4"]` and confirm it succeeds.
3. Confirm the plan includes DenyMaliciousIpsInbound (`source_address_prefixes = ["1.2.3.4"]`) and DenyMaliciousIpsOutbound (`destination_address_prefixes = ["1.2.3.4"]`).

### QA Notes

Infra-only Terraform change; no application/UI surface. No customer-facing QA beyond plan verification above.

### Deployment Notes

N/A — config-compatible; empty denylist behavior unchanged. Non-empty denylist now plans/applies instead of erroring.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Terraform expression rewrite in NSG baseline locals; intended deny-rule semantics are unchanged, and empty denylist behavior stays the same.
> 
> **Overview**
> Fixes `terraform plan` failing with **Inconsistent conditional result types** when `nsg_malicious_ips` is non-empty, so the optional NSG denylist can actually be used.
> 
> In `nsg.tf`, replaces the ternary that optionally added `DenyMaliciousIpsInbound`/`Outbound` rules with a `for`/`if` comprehension. That avoids unifying a 2-object tuple (list prefixes on different attributes) with `[]`. Empty denylist behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e626bf35464d5f82b516164b2a34ed7b70ff5b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->