### PR TITLE
fix(PARA-22735): default Azure AMR cache cluster_enabled=false

### DIFF
--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -62,13 +62,13 @@ One map drives every instance (`for_each` in `./redis-managed`). Globals stay fi
 Built-in default map (used when `redis_managed_instances` is null):
 
 ```hcl
-cache        = { sku = "Balanced_B10", ha_enabled = true,  cluster_enabled = true }
+cache        = { sku = "Balanced_B10", ha_enabled = true,  cluster_enabled = false }
 queue        = { sku = "Balanced_B3",  ha_enabled = true,  cluster_enabled = false }
 system       = { sku = "Balanced_B3",  ha_enabled = true,  cluster_enabled = false }
 managed-sync = { sku = "Balanced_B10", ha_enabled = true,  cluster_enabled = false }
 ```
 
-`managed-sync` uses `cluster_enabled = false` (NoCluster policy). Bull/ioredis over a private endpoint cannot use OSS cluster slot discovery (internal shard addresses such as `10.0.16.x:8501` are not reachable with TLS), and a non-cluster client against OSSCluster receives `MOVED` redirects. Use NoCluster for the dedicated managed-sync instance; keep OSSCluster on `cache` when the monorepo client supports it.
+`managed-sync` uses `cluster_enabled = false` (NoCluster policy). Bull/ioredis over a private endpoint cannot use OSS cluster slot discovery (internal shard addresses such as `10.0.16.x:8501` are not reachable with TLS), and a non-cluster client against OSSCluster receives `MOVED` redirects. Use NoCluster for cache and managed-sync by default. OSSCluster on private endpoint + TLS breaks ioredis slot discovery (`ClusterAllFailedError`); override `cluster_enabled = true` only when the client and network path support it.
 
 Greenfield example:
 

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -536,7 +536,7 @@ locals {
     cache = {
       sku                   = "Balanced_B10"
       ha_enabled            = true
-      cluster_enabled       = true
+      cluster_enabled       = false
       persistence_mode      = null
       persistence_frequency = null
     }


### PR DESCRIPTION
### Issues Closed

- https://useparagon.atlassian.net/browse/PARA-22735

### Brief Summary

default azure managed redis cache to nocluster

### Detailed Summary

Change the default Azure Managed Redis `cache` instance `cluster_enabled` from `true` to `false` (NoCluster). Bull/ioredis over a private endpoint with TLS cannot discover OSS cluster shard addresses, which leads to client failures. Align the cache default with queue, system, and managed-sync, and document why NoCluster is the safe default.

### Changes

- Set the built-in default `cache.cluster_enabled` to `false` in Azure infra locals
- Update the Azure infra README default map and guidance to treat NoCluster as the safe default for cache and managed-sync

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

- [ ] `terraform plan` with `redis_managed_enabled=true` and defaults shows cache `cluster_enabled=false`
- [ ] Existing override `redis_managed_instances = { cache = { cluster_enabled = true } }` still wins

### QA Notes

This changes the default for new or non-overridden `cache` managed Redis only. Explicit `redis_managed_instances` overrides continue to take precedence. Existing deployments that already provisioned OSSCluster are not automatically reconfigured unless Terraform would recreate or update that setting.

### Deployment Notes

No new variables. Default clustering policy for the Azure Managed Redis `cache` instance is now NoCluster; set `cluster_enabled = true` via `redis_managed_instances` when clustering is intentionally required.

### Screenshots

N/A