### PR TITLE
fix(PARA-22734): nonsensitive dns_enabled for Cloudflare-off plans

### DIFF
--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -341,7 +341,7 @@ locals {
   legacy_infra_vars     = local.use_legacy_infra_json ? jsondecode(var.infra_json != null ? var.infra_json : file(local.infra_json_path)) : null
   workspace             = nonsensitive(local.use_legacy_infra_json ? try(local.legacy_infra_vars.workspace.value, "paragon-${var.organization}-${local.hash}") : "paragon-${var.organization}-${local.hash}")
 
-  dns_enabled = var.ingress_scheme != "internal" && var.cloudflare_api_token != null && var.cloudflare_zone_id != null
+  dns_enabled = nonsensitive(var.ingress_scheme != "internal" && var.cloudflare_api_token != null && var.cloudflare_zone_id != null)
 
   resource_group_name = local.use_legacy_infra_json ? try(local.legacy_infra_vars.resource_group.value.name, "${local.workspace}-resources") : "${local.workspace}-resources"
   cluster_name        = local.use_legacy_infra_json ? try(local.legacy_infra_vars.cluster_name.value, "${local.workspace}-cluster") : "${local.workspace}-cluster"

--- a/gcp/workspaces/paragon/variables.tf
+++ b/gcp/workspaces/paragon/variables.tf
@@ -894,7 +894,7 @@ locals {
     creator      = "terraform"
   }
 
-  dns_enabled = var.ingress_scheme != "internal" && var.cloudflare_api_token != null && var.cloudflare_zone_id != null
+  dns_enabled = nonsensitive(var.ingress_scheme != "internal" && var.cloudflare_api_token != null && var.cloudflare_zone_id != null)
 
   # Cloud Armor backend policies only apply to the external Application Load Balancer.
   waf_active = var.waf_enabled && var.ingress_scheme != "internal"


### PR DESCRIPTION
### Issues Closed

- https://useparagon.atlassian.net/browse/PARA-22734

### Brief Summary

nonsensitive dns_enabled for cloudflare-off plans

### Detailed Summary

Wrap `local.dns_enabled` in `nonsensitive()` for Azure and GCP paragon workspaces so Terraform plan succeeds when Cloudflare is not configured. Referencing sensitive Cloudflare inputs made the boolean sensitive and broke `for_each` in the DNS module even when DNS was disabled.

### Changes

- Wrap `local.dns_enabled` with `nonsensitive()` in the Azure paragon workspace
- Wrap `local.dns_enabled` with `nonsensitive()` in the GCP paragon workspace

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

- [ ] `terraform plan` with null Cloudflare token/zone succeeds
- [ ] Enabling Cloudflare still creates DNS records as before

### QA Notes

DNS enablement logic is unchanged. Cloudflare credentials remain sensitive at the module input level; only the derived enablement boolean is marked nonsensitive so disabled plans can proceed.

### Deployment Notes

N/A — Terraform-only local change; no new variables or config required.

### Screenshots

N/A