### PR TITLE
fix(PARA-24515): prefix Azure Redis URLs with rediss:// when TLS is on

### DIFF
--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -79,6 +79,7 @@ locals {
 
   # Workflow Redis shares cache when there is no dedicated workflow instance (matches monorepo chart).
   # Rebuild from host/password/port with urlencode — same as managed_sync_redis_url / GCP.
+  # Omit userinfo when connection_string is passwordless (Premium auth disabled).
   workflow_redis_from_infra = try(var.infra_values.redis.value.workflow, var.infra_values.redis.value.cache, null)
   workflow_redis_url = local.workflow_redis_from_infra == null ? null : (
     startswith(try(local.workflow_redis_from_infra.connection_string, ""), "redis://") || startswith(try(local.workflow_redis_from_infra.connection_string, ""), "rediss://")
@@ -86,7 +87,11 @@ locals {
     : format(
       "%s://%s%s:%s",
       contains(["true", "1", "yes"], lower(tostring(try(local.workflow_redis_from_infra.ssl, true)))) ? "rediss" : "redis",
-      try(local.workflow_redis_from_infra.password, null) != null ? ":${urlencode(local.workflow_redis_from_infra.password)}@" : "",
+      (
+        try(local.workflow_redis_from_infra.password, null) != null && strcontains(try(local.workflow_redis_from_infra.connection_string, "@"), "@")
+        ? ":${urlencode(local.workflow_redis_from_infra.password)}@"
+        : ""
+      ),
       local.workflow_redis_from_infra.host,
       local.workflow_redis_from_infra.port
     )

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -78,15 +78,18 @@ locals {
   managed_sync_redis_url = "${local.redis_config.redis_tls_enabled ? "rediss" : "redis"}://${local.redis_config.password != null ? ":${urlencode(local.redis_config.password)}@" : ""}${local.redis_config.host}:${local.redis_config.port}"
 
   # Workflow Redis shares cache when there is no dedicated workflow instance (matches monorepo chart).
+  # Rebuild from host/password/port with urlencode — same as managed_sync_redis_url / GCP.
   workflow_redis_from_infra = try(var.infra_values.redis.value.workflow, var.infra_values.redis.value.cache, null)
-  workflow_redis_connection = try(
-    local.workflow_redis_from_infra.connection_string,
-    local.workflow_redis_from_infra != null ? "${local.workflow_redis_from_infra.host}:${local.workflow_redis_from_infra.port}" : null
-  )
-  workflow_redis_url = local.workflow_redis_connection == null ? null : (
-    startswith(local.workflow_redis_connection, "redis://") || startswith(local.workflow_redis_connection, "rediss://")
-    ? local.workflow_redis_connection
-    : format("%s://%s", try(local.workflow_redis_from_infra.ssl, true) ? "rediss" : "redis", local.workflow_redis_connection)
+  workflow_redis_url = local.workflow_redis_from_infra == null ? null : (
+    startswith(try(local.workflow_redis_from_infra.connection_string, ""), "redis://") || startswith(try(local.workflow_redis_from_infra.connection_string, ""), "rediss://")
+    ? local.workflow_redis_from_infra.connection_string
+    : format(
+      "%s://%s%s:%s",
+      contains(["true", "1", "yes"], lower(tostring(try(local.workflow_redis_from_infra.ssl, true)))) ? "rediss" : "redis",
+      try(local.workflow_redis_from_infra.password, null) != null ? ":${urlencode(local.workflow_redis_from_infra.password)}@" : "",
+      local.workflow_redis_from_infra.host,
+      local.workflow_redis_from_infra.port
+    )
   )
 
   # Backward compatible with infra workspaces that still emit the legacy "minio" output

--- a/azure/workspaces/paragon/helm-config/secrets.tf
+++ b/azure/workspaces/paragon/helm-config/secrets.tf
@@ -79,9 +79,14 @@ locals {
 
   # Workflow Redis shares cache when there is no dedicated workflow instance (matches monorepo chart).
   workflow_redis_from_infra = try(var.infra_values.redis.value.workflow, var.infra_values.redis.value.cache, null)
-  workflow_redis_url = try(
+  workflow_redis_connection = try(
     local.workflow_redis_from_infra.connection_string,
     local.workflow_redis_from_infra != null ? "${local.workflow_redis_from_infra.host}:${local.workflow_redis_from_infra.port}" : null
+  )
+  workflow_redis_url = local.workflow_redis_connection == null ? null : (
+    startswith(local.workflow_redis_connection, "redis://") || startswith(local.workflow_redis_connection, "rediss://")
+    ? local.workflow_redis_connection
+    : format("%s://%s", try(local.workflow_redis_from_infra.ssl, true) ? "rediss" : "redis", local.workflow_redis_connection)
   )
 
   # Backward compatible with infra workspaces that still emit the legacy "minio" output

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -603,31 +603,41 @@ locals {
     "true"
   )
 
-  # Azure connection_string is host:port with no scheme; clients need redis:// or rediss:// for TLS.
-  default_redis_url_raw = try(
-    local.helm_vars.global.env["REDIS_URL"],
-    "${local.helm_vars.global.env["REDIS_HOST"]}:${local.helm_vars.global.env["REDIS_PORT"]}",
-    local.infra_vars.redis.value.cache.connection_string,
-    "${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
-  )
-
-  default_redis_url = (
-    startswith(local.default_redis_url_raw, "redis://") || startswith(local.default_redis_url_raw, "rediss://")
-    ? local.default_redis_url_raw
-    : format(
-      "%s://%s",
-      contains(["true", "1", "yes"], lower(tostring(local.default_redis_ssl))) ? "rediss" : "redis",
-      local.default_redis_url_raw
-    )
-  )
-
+  # Rebuild scheme-prefixed Redis URLs from host/password/port (same as GCP).
+  # Do not prefix Azure connection_string: classic Cache keys are unencoded
+  # (:password@host:port), and Managed Redis already urlencodes the password in
+  # connection_string — encoding the whole string would double-encode (%3D → %253D).
   redis_instance_urls = {
     for name, r in try(local.infra_vars.redis.value, {}) : name => (
       startswith(try(r.connection_string, ""), "redis://") || startswith(try(r.connection_string, ""), "rediss://")
       ? r.connection_string
-      : format("%s://%s", try(r.ssl, true) ? "rediss" : "redis", try(r.connection_string, "${r.host}:${r.port}"))
+      : format(
+        "%s://%s%s:%s",
+        contains(["true", "1", "yes"], lower(tostring(try(r.ssl, true)))) ? "rediss" : "redis",
+        try(r.password, null) != null ? ":${urlencode(r.password)}@" : "",
+        r.host,
+        r.port
+      )
     )
   }
+
+  # Prefer an explicitly schemed helm REDIS_URL; otherwise use rebuilt cache URL.
+  default_redis_url = (
+    try(
+      startswith(local.helm_vars.global.env["REDIS_URL"], "redis://") || startswith(local.helm_vars.global.env["REDIS_URL"], "rediss://"),
+      false
+    )
+    ? local.helm_vars.global.env["REDIS_URL"]
+    : try(
+      local.redis_instance_urls["cache"],
+      format(
+        "%s://%s:%s",
+        contains(["true", "1", "yes"], lower(tostring(local.default_redis_ssl))) ? "rediss" : "redis",
+        local.helm_vars.global.env["REDIS_HOST"],
+        local.helm_vars.global.env["REDIS_PORT"]
+      )
+    )
+  )
 
   helm_values = merge(local.helm_vars, {
     global = merge(local.helm_vars.global, {

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -610,6 +610,15 @@ locals {
     "${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
   )
 
+  # Build redis:// or rediss:// URLs (Azure connection_string has no scheme; clients need it for TLS).
+  redis_instance_urls = {
+    for name, r in try(local.infra_vars.redis.value, {}) : name => (
+      startswith(try(r.connection_string, ""), "redis://") || startswith(try(r.connection_string, ""), "rediss://")
+      ? r.connection_string
+      : format("%s://%s", try(r.ssl, true) ? "rediss" : "redis", try(r.connection_string, "${r.host}:${r.port}"))
+    )
+  }
+
   helm_values = merge(local.helm_vars, {
     global = merge(local.helm_vars.global, {
       env = merge({
@@ -747,20 +756,20 @@ locals {
         ZEUS_POSTGRES_DATABASE          = try(local.infra_vars.postgres.value.zeus.database, local.infra_vars.postgres.value.paragon.database)
 
         # Redis configurations
-        REDIS_URL = local.default_redis_url
+        REDIS_URL = try(local.redis_instance_urls["cache"], local.default_redis_url)
 
         CACHE_REDIS_CLUSTER_ENABLED    = try(local.infra_vars.redis.value.cache.cluster, local.default_redis_cluster)
         CACHE_REDIS_TLS_ENABLED        = try(local.infra_vars.redis.value.cache.ssl, local.default_redis_ssl)
-        CACHE_REDIS_URL                = try(local.infra_vars.redis.value.cache.connection_string, local.default_redis_url)
+        CACHE_REDIS_URL                = try(local.redis_instance_urls["cache"], local.default_redis_url)
         QUEUE_REDIS_CLUSTER_ENABLED    = try(local.infra_vars.redis.value.queue.cluster, local.default_redis_cluster)
         QUEUE_REDIS_TLS_ENABLED        = try(local.infra_vars.redis.value.queue.ssl, local.default_redis_ssl)
-        QUEUE_REDIS_URL                = try(local.infra_vars.redis.value.queue.connection_string, local.default_redis_url)
+        QUEUE_REDIS_URL                = try(local.redis_instance_urls["queue"], local.default_redis_url)
         SYSTEM_REDIS_CLUSTER_ENABLED   = try(local.infra_vars.redis.value.system.cluster, local.default_redis_cluster)
         SYSTEM_REDIS_TLS_ENABLED       = try(local.infra_vars.redis.value.system.ssl, local.default_redis_ssl)
-        SYSTEM_REDIS_URL               = try(local.infra_vars.redis.value.system.connection_string, local.default_redis_url)
+        SYSTEM_REDIS_URL               = try(local.redis_instance_urls["system"], local.default_redis_url)
         WORKFLOW_REDIS_CLUSTER_ENABLED = try(local.infra_vars.redis.value.workflow.cluster, local.default_redis_cluster)
         WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
-        WORKFLOW_REDIS_URL             = try(local.infra_vars.redis.value.workflow.connection_string, local.default_redis_url)
+        WORKFLOW_REDIS_URL             = try(local.redis_instance_urls["workflow"], local.default_redis_url)
 
         # Cloud Storage configurations
         CLOUD_STORAGE_MICROSERVICE_PASS = local.storage_output.root_password

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -603,14 +603,24 @@ locals {
     "true"
   )
 
-  default_redis_url = try(
+  # Azure connection_string is host:port with no scheme; clients need redis:// or rediss:// for TLS.
+  default_redis_url_raw = try(
     local.helm_vars.global.env["REDIS_URL"],
     "${local.helm_vars.global.env["REDIS_HOST"]}:${local.helm_vars.global.env["REDIS_PORT"]}",
     local.infra_vars.redis.value.cache.connection_string,
     "${local.infra_vars.redis.value.cache.host}:${local.infra_vars.redis.value.cache.port}"
   )
 
-  # Build redis:// or rediss:// URLs (Azure connection_string has no scheme; clients need it for TLS).
+  default_redis_url = (
+    startswith(local.default_redis_url_raw, "redis://") || startswith(local.default_redis_url_raw, "rediss://")
+    ? local.default_redis_url_raw
+    : format(
+      "%s://%s",
+      contains(["true", "1", "yes"], lower(tostring(local.default_redis_ssl))) ? "rediss" : "redis",
+      local.default_redis_url_raw
+    )
+  )
+
   redis_instance_urls = {
     for name, r in try(local.infra_vars.redis.value, {}) : name => (
       startswith(try(r.connection_string, ""), "redis://") || startswith(try(r.connection_string, ""), "rediss://")
@@ -769,7 +779,8 @@ locals {
         SYSTEM_REDIS_URL               = try(local.redis_instance_urls["system"], local.default_redis_url)
         WORKFLOW_REDIS_CLUSTER_ENABLED = try(local.infra_vars.redis.value.workflow.cluster, local.default_redis_cluster)
         WORKFLOW_REDIS_TLS_ENABLED     = try(local.infra_vars.redis.value.workflow.ssl, local.default_redis_ssl)
-        WORKFLOW_REDIS_URL             = try(local.redis_instance_urls["workflow"], local.default_redis_url)
+        # No dedicated workflow Redis on Azure — fall back to cache (matches secrets.tf / monorepo chart).
+        WORKFLOW_REDIS_URL = try(local.redis_instance_urls["workflow"], local.redis_instance_urls["cache"], local.default_redis_url)
 
         # Cloud Storage configurations
         CLOUD_STORAGE_MICROSERVICE_PASS = local.storage_output.root_password

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -607,6 +607,9 @@ locals {
   # Do not prefix Azure connection_string: classic Cache keys are unencoded
   # (:password@host:port), and Managed Redis already urlencodes the password in
   # connection_string — encoding the whole string would double-encode (%3D → %253D).
+  # Premium Cache with authentication_enabled=false emits passwordless
+  # connection_string (host:port) while still exporting primary_access_key as
+  # password — only include userinfo when connection_string has "@" (or is absent).
   redis_instance_urls = {
     for name, r in try(local.infra_vars.redis.value, {}) : name => (
       startswith(try(r.connection_string, ""), "redis://") || startswith(try(r.connection_string, ""), "rediss://")
@@ -614,7 +617,11 @@ locals {
       : format(
         "%s://%s%s:%s",
         contains(["true", "1", "yes"], lower(tostring(try(r.ssl, true)))) ? "rediss" : "redis",
-        try(r.password, null) != null ? ":${urlencode(r.password)}@" : "",
+        (
+          try(r.password, null) != null && strcontains(try(r.connection_string, "@"), "@")
+          ? ":${urlencode(r.password)}@"
+          : ""
+        ),
         r.host,
         r.port
       )


### PR DESCRIPTION
### Issues Closed

- https://useparagon.atlassian.net/browse/PARA-24515

### Brief Summary

prefix azure redis urls with rediss when tls on

### Detailed Summary

Build scheme-prefixed Redis URLs (`rediss://` when TLS/ssl is enabled, otherwise `redis://`) for Azure paragon env vars, matching GCP behavior. Azure infra `connection_string` values lack a scheme, and clients need it to select TLS correctly. Also apply the same prefixing to `WORKFLOW_REDIS_URL` used by managed-sync secrets.

### Changes

- Add `redis_instance_urls` local that prefixes Redis connection strings based on each instance `ssl` flag
- Wire `REDIS_URL`, `CACHE_REDIS_URL`, `QUEUE_REDIS_URL`, `SYSTEM_REDIS_URL`, and `WORKFLOW_REDIS_URL` through the new map
- Apply the same scheme-prefixing logic to managed-sync `WORKFLOW_REDIS_URL` in helm-config secrets
- Leave connection strings that already include `redis://` or `rediss://` unchanged

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

- [ ] Inspect planned/rendered `CACHE_REDIS_URL` / `WORKFLOW_REDIS_URL` values start with `rediss://` when Redis SSL is true
- [ ] Confirm `*_REDIS_TLS_ENABLED` remains true alongside `rediss://`
- [ ] Values that already include a scheme are left unchanged

### QA Notes

Incorrect Redis URL schemes can break connectivity until the paragon workspace is reapplied. Verify TLS-enabled instances get `rediss://` and that existing scheme-prefixed values are not double-prefixed.

### Deployment Notes

Requires applying the Azure paragon workspace so Helm/env secrets pick up the updated Redis URL values.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Terraform-derived Redis URL env values; incorrect schemes or encoding can break Redis connectivity until the paragon workspace is reapplied, but there is no change to application auth or security logic.
> 
> **Overview**
> Azure paragon Terraform now **builds scheme-prefixed Redis URLs** (`rediss://` when TLS/ssl is on, otherwise `redis://`) for Helm env vars, aligning with GCP instead of passing through unschemed Azure `connection_string` values.
> 
> A new `redis_instance_urls` map in `variables.tf` rebuilds URLs per infra Redis instance from host, port, and password (with `urlencode` on the password only when the connection string indicates auth). Strings that already start with `redis://` or `rediss://` are left unchanged to avoid double-encoding Managed Redis passwords. `REDIS_URL`, `CACHE_REDIS_URL`, `QUEUE_REDIS_URL`, `SYSTEM_REDIS_URL`, and `WORKFLOW_REDIS_URL` are wired through this map; **workflow** falls back to **cache** when Azure has no dedicated workflow Redis.
> 
> Managed-sync `WORKFLOW_REDIS_URL` in `helm-config/secrets.tf` uses the same rebuild logic (including passwordless Premium Cache when auth is disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be1b5b583d056b23bfd7c9de9fdce24793450a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->