### PR TITLE
fix(PARA-25199): raise worker-deployments CPU request to 400m

### DIFF
--- a/charts/paragon-onprem/charts/worker-deployments/values.yaml
+++ b/charts/paragon-onprem/charts/worker-deployments/values.yaml
@@ -18,7 +18,7 @@ resources:
   limits:
     memory: 1024Mi
   requests:
-    cpu: 200m
+    cpu: 400m
     memory: 1024Mi
 
 autoscaling:


### PR DESCRIPTION
### Issues Closed

- https://useparagon.atlassian.net/browse/PARA-25199

### Brief Summary

raise worker-deployments cpu request to 400m

### Detailed Summary

Raise the default `worker-deployments` Helm CPU request from 200m to 400m so HPA CPU utilization better reflects real load. With HPA targeting 75% CPU, a very low request inflates reported utilization relative to actual usage. The new value sits within the SEV-1073 target range (300–500m).

### Changes

- Increase `worker-deployments` default CPU request from 200m to 400m

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

- [ ] Confirm chart default `resources.requests.cpu` is `400m`
- [ ] After upgrade, HPA CPU % for worker-deployments is no longer inflated by tiny requests
- [ ] Rolling update completes without unexpected downtime

### QA Notes

Memory requests/limits and autoscaling settings are unchanged. Expect a rolling update of worker-deployments pods when the chart is upgraded; scheduling footprint increases slightly due to the higher CPU request.

### Deployment Notes

Takes effect on the next Helm upgrade that includes the updated `paragon-onprem` / `worker-deployments` chart values.

### Screenshots

N/A