### PR TITLE
feat(PARA-25300): opt-in Azure CanNotDelete locks for Postgres

### DIFF
--- a/azure/workspaces/infra/modules.tf
+++ b/azure/workspaces/infra/modules.tf
@@ -37,13 +37,14 @@ module "bastion" {
 module "postgres" {
   source = "./postgres"
 
-  instances        = local.postgres_instances
-  postgres_version = var.postgres_version
-  resource_group   = module.network.resource_group
-  tags             = local.default_tags
-  virtual_network  = module.network.virtual_network
-  private_subnet   = module.network.postgres_subnet
-  workspace        = local.workspace
+  instances                          = local.postgres_instances
+  postgres_management_lock_enabled   = var.postgres_management_lock_enabled
+  postgres_version                   = var.postgres_version
+  resource_group                     = module.network.resource_group
+  tags                               = local.default_tags
+  virtual_network                    = module.network.virtual_network
+  private_subnet                     = module.network.postgres_subnet
+  workspace                          = local.workspace
 }
 
 module "redis" {

--- a/azure/workspaces/infra/postgres/postgres.tf
+++ b/azure/workspaces/infra/postgres/postgres.tf
@@ -79,3 +79,13 @@ resource "azurerm_postgresql_flexible_server_database" "paragon" {
 
   depends_on = [azurerm_postgresql_flexible_server_configuration.extensions]
 }
+
+
+resource "azurerm_management_lock" "postgres" {
+  for_each = var.postgres_management_lock_enabled ? local.postgres_instances : {}
+
+  name       = "${each.value.name}-can-not-delete"
+  scope      = azurerm_postgresql_flexible_server.postgres[each.key].id
+  lock_level = "CanNotDelete"
+  notes      = "Protect Postgres Flexible Server from accidental deletion."
+}

--- a/azure/workspaces/infra/postgres/variables.tf
+++ b/azure/workspaces/infra/postgres/variables.tf
@@ -39,6 +39,12 @@ variable "postgres_port" {
   default     = "5432"
 }
 
+variable "postgres_management_lock_enabled" {
+  description = "When true, apply Azure CanNotDelete management locks on Postgres Flexible Servers."
+  type        = bool
+  default     = false
+}
+
 locals {
   postgres_db_names = {
     cerberus     = "cerberus"

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -155,6 +155,12 @@ variable "postgres_version" {
   default     = "14"
 }
 
+variable "postgres_management_lock_enabled" {
+  description = "When true, apply Azure CanNotDelete management locks on Postgres Flexible Servers (opt-in)."
+  type        = bool
+  default     = false
+}
+
 variable "postgres_multiple_instances" {
   description = "Whether or not to create multiple Postgres instances. Used for higher volume installations."
   type        = bool


### PR DESCRIPTION
### Issues Closed

- https://useparagon.atlassian.net/browse/PARA-25300

### Brief Summary

opt-in azure cannotdelete locks for postgres

### Detailed Summary

Add an opt-in `postgres_management_lock_enabled` flag (default `false`) that applies Azure `CanNotDelete` management locks on each deployed Postgres Flexible Server. When enabled, accidental Terraform or portal deletes are blocked until the lock is removed.

### Changes

- Add `postgres_management_lock_enabled` variable on the Azure infra workspace (default `false`)
- Pass the flag into the postgres module
- Create `azurerm_management_lock` resources with `CanNotDelete` for each Flexible Server when enabled

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

- [ ] Default plan creates no management locks
- [ ] With `postgres_management_lock_enabled = true`, locks are created on each Flexible Server
- [ ] Destroy/replace of a locked server is blocked until the lock is removed

### QA Notes

Locks change destroy/replace workflows when enabled. Default remains off so existing plans should be unchanged. If locks are enabled in an environment, intentional teardowns require removing the management lock first.

### Deployment Notes

New optional Azure infra variable: `postgres_management_lock_enabled` (default `false`). Enable explicitly per environment when deletion protection is desired.

### Screenshots

N/A