### PR TITLE
fix: treat blank docker creds as unset

### DIFF
--- a/aws/workspaces/infra/modules.tf
+++ b/aws/workspaces/infra/modules.tf
@@ -155,6 +155,16 @@ module "cluster" {
   private_subnet_ids = module.network.private_subnet[*].id
 }
 
+locals {
+  docker_username = trimspace(coalesce(var.docker_username, ""))
+  docker_password = trimspace(coalesce(var.docker_password, ""))
+
+  # Blank credentials produce a well-formed but unusable pull secret
+  # (auth = base64(":")), which fails image pulls with insufficient_scope
+  # instead of failing the apply, so blank is treated the same as unset.
+  docker_credentials_set = local.docker_username != "" && local.docker_password != ""
+}
+
 module "secrets" {
   source = "./secrets"
 
@@ -162,20 +172,17 @@ module "secrets" {
   organization = var.organization
   env_config   = local.env_config
 
-  docker_config = (
-    var.docker_username != null &&
-    var.docker_password != null
-    ) ? jsonencode({
-      dockerconfigjson = jsonencode({
-        auths = {
-          (coalesce(var.docker_registry_server, "docker.io")) = {
-            username = var.docker_username
-            password = var.docker_password
-            email    = var.docker_email
-            auth     = base64encode("${var.docker_username}:${var.docker_password}")
-          }
+  docker_config = local.docker_credentials_set ? jsonencode({
+    dockerconfigjson = jsonencode({
+      auths = {
+        (coalesce(var.docker_registry_server, "docker.io")) = {
+          username = local.docker_username
+          password = local.docker_password
+          email    = coalesce(var.docker_email, "")
+          auth     = base64encode("${local.docker_username}:${local.docker_password}")
         }
-      })
+      }
+    })
   }) : null
 
   managed_sync_config     = var.managed_sync_enabled ? coalesce(var.paragon_managed_sync_config, {}) : null

--- a/aws/workspaces/paragon/helm/helm.tf
+++ b/aws/workspaces/paragon/helm/helm.tf
@@ -1,6 +1,14 @@
 locals {
   version = var.helm_values.global.env["VERSION"]
 
+  docker_username = trimspace(coalesce(var.docker_username, ""))
+  docker_password = trimspace(coalesce(var.docker_password, ""))
+
+  # Blank credentials produce a well-formed but unusable pull secret
+  # (auth = base64(":")), which fails image pulls with insufficient_scope
+  # instead of failing the apply, so blank is treated the same as unset.
+  docker_credentials_set = local.docker_username != "" && local.docker_password != ""
+
   helm_values_yaml = yamlencode(nonsensitive(var.helm_values))
 
   subchart_values = yamlencode({
@@ -220,8 +228,7 @@ resource "kubernetes_secret" "docker_login" {
   count = (
     var.create_docker_pull_secret &&
     !var.install_external_secrets &&
-    var.docker_username != null &&
-    var.docker_password != null
+    local.docker_credentials_set
   ) ? 1 : 0
 
   metadata {
@@ -235,10 +242,10 @@ resource "kubernetes_secret" "docker_login" {
     ".dockerconfigjson" = jsonencode({
       auths = {
         "${var.docker_registry_server}" = {
-          "username" = var.docker_username
-          "password" = var.docker_password
-          "email"    = var.docker_email
-          "auth"     = base64encode("${var.docker_username}:${var.docker_password}")
+          "username" = local.docker_username
+          "password" = local.docker_password
+          "email"    = coalesce(var.docker_email, "")
+          "auth"     = base64encode("${local.docker_username}:${local.docker_password}")
         }
       }
     })

--- a/aws/workspaces/paragon/runtime_secrets.tf
+++ b/aws/workspaces/paragon/runtime_secrets.tf
@@ -8,19 +8,22 @@ locals {
     managed_sync = "paragon/${local.workspace}/managed-sync"
     openobserve  = "paragon/${local.workspace}/openobserve"
   }
-  runtime_docker_cfg_enabled = var.docker_username != null && var.docker_password != null
-  runtime_docker_cfg_json = jsonencode({
-    dockerconfigjson = jsonencode({
-      auths = {
-        (var.docker_registry_server) = {
-          username = var.docker_username
-          password = var.docker_password
-          email    = var.docker_email
-          auth     = base64encode("${var.docker_username}:${var.docker_password}")
-        }
-      }
-    })
-  })
+  runtime_docker_username = trimspace(coalesce(var.docker_username, ""))
+  runtime_docker_password = trimspace(coalesce(var.docker_password, ""))
+
+  # Blank credentials produce a well-formed but unusable pull secret
+  # (auth = base64(":")), which fails image pulls with insufficient_scope
+  # instead of failing the apply, so blank is treated the same as unset.
+  runtime_docker_cfg_enabled = local.runtime_docker_username != "" && local.runtime_docker_password != ""
+
+  runtime_docker_cfg_paragon_auths = local.runtime_docker_cfg_enabled ? {
+    (var.docker_registry_server) = {
+      username = local.runtime_docker_username
+      password = local.runtime_docker_password
+      email    = coalesce(var.docker_email, "")
+      auth     = base64encode("${local.runtime_docker_username}:${local.runtime_docker_password}")
+    }
+  } : {}
 }
 
 data "aws_secretsmanager_secret" "env" {
@@ -57,15 +60,29 @@ data "aws_secretsmanager_secret_version" "docker_cfg" {
 }
 
 locals {
-  runtime_docker_cfg_from_infra = try(
-    keys(jsondecode(jsondecode(data.aws_secretsmanager_secret_version.docker_cfg.secret_string).dockerconfigjson).auths),
-    []
+  runtime_docker_cfg_base_auths = try(
+    jsondecode(jsondecode(data.aws_secretsmanager_secret_version.docker_cfg.secret_string).dockerconfigjson).auths,
+    {}
   )
-  runtime_docker_cfg_has_infra_auths = length(local.runtime_docker_cfg_from_infra) > 0
-  runtime_docker_cfg_needs_paragon_overlay = (
-    local.runtime_docker_cfg_enabled &&
-    !local.runtime_docker_cfg_has_infra_auths
-  )
+  # An entry missing a username or password cannot pull images, so it does not
+  # count as populated and must not suppress this workspace's credentials.
+  runtime_docker_cfg_usable_base_auths = {
+    for registry, auth in local.runtime_docker_cfg_base_auths : registry => auth
+    if trimspace(try(auth.username, "")) != "" && trimspace(try(auth.password, "")) != ""
+  }
+  runtime_docker_cfg_has_infra_auths = length(keys(local.runtime_docker_cfg_usable_base_auths)) > 0
+
+  # Other registries infra may own are preserved; this workspace only owns the
+  # entry for its own registry.
+  runtime_docker_cfg_json = jsonencode({
+    dockerconfigjson = jsonencode({
+      auths = merge(
+        local.runtime_docker_cfg_usable_base_auths,
+        local.runtime_docker_cfg_paragon_auths
+      )
+    })
+  })
+
   # Sync into the cluster only when Terraform should create the pull secret.
   # create_docker_pull_secret=false is the Artifactory/proxy path where a
   # customer-pre-provisioned secret is referenced via helm imagePullSecrets.
@@ -75,8 +92,11 @@ locals {
   )
 }
 
+# count must not depend on the auths this resource writes: gating it on the
+# current secret value made the overlay delete itself on the following plan,
+# reverting AWSCURRENT to the infra base version with nothing to repopulate it.
 resource "aws_secretsmanager_secret_version" "docker_cfg_paragon_overlay" {
-  count = local.runtime_docker_cfg_needs_paragon_overlay ? 1 : 0
+  count = local.runtime_docker_cfg_enabled ? 1 : 0
 
   secret_id     = data.aws_secretsmanager_secret.docker_cfg.id
   secret_string = local.runtime_docker_cfg_json
@@ -115,7 +135,7 @@ locals {
   runtime_docker_cfg_secret_name   = local.runtime_docker_cfg_sync_enabled ? data.aws_secretsmanager_secret.docker_cfg.name : null
   runtime_openobserve_secret_name  = data.aws_secretsmanager_secret.openobserve.name
   runtime_managed_sync_secret_name = var.managed_sync_enabled ? data.aws_secretsmanager_secret.managed_sync[0].name : null
-  runtime_docker_cfg_version_id = local.runtime_docker_cfg_needs_paragon_overlay ? (
+  runtime_docker_cfg_version_id = local.runtime_docker_cfg_enabled ? (
     aws_secretsmanager_secret_version.docker_cfg_paragon_overlay[0].version_id
   ) : data.aws_secretsmanager_secret_version.docker_cfg.version_id
 }

--- a/prepare.sh
+++ b/prepare.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.08.10"
+version="2026.08.17"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-25382

### Brief Summary

fix blank docker pull secret handling

### Detailed Summary

Blank `TF_VAR_docker_username` / `TF_VAR_docker_password` were treated as set because AWS gates only checked `!= null`. That wrote a well-formed but unusable dockerconfigjson (`auth: "Og=="`) into Secrets Manager, which External Secrets synced into the cluster and broke private image pulls.

A second defect made recovery impossible: the paragon overlay secret version decided its own `count` by reading the secret it wrote. After a blank overlay landed, the next plan saw an `auths` key, concluded infra already owned credentials, destroyed the overlay, and reverted `AWSCURRENT` to the empty infra base — even when real credentials were present in Spacelift context.

This change treats blank credentials as unset, makes overlay `count` depend only on whether this workspace has credentials, and merges usable base auths with this workspace's registry entry.

### Changes

- Treat empty/whitespace docker username and password as unset in AWS infra secrets, paragon runtime overlay, and non-ESO `kubernetes_secret.docker_login`
- Stop gating `docker_cfg_paragon_overlay` on the secret value it writes; keep overlay when credentials are present
- Merge usable infra auths with this workspace's registry entry so other registries are preserved without the self-delete loop
- Bump prepare chart version stamp to `2026.08.17`

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. Confirm `TF_VAR_docker_username`, `TF_VAR_docker_password`, and `TF_VAR_docker_email` are non-empty on the affected AWS stacks.
2. Apply the AWS paragon workspace with this branch (local-preview or tracked run after merge).
3. Verify Secrets Manager `paragon/<workspace>/docker-cfg` `AWSCURRENT` has non-empty username/password (not `auth: "Og=="`).
4. Force ESO refresh if needed: `kubectl -n paragon annotate externalsecret docker-cfg force-sync="$(date +%s)" --overwrite`
5. Confirm the Kubernetes secret has usable credentials: `kubectl -n paragon get secret docker-cfg -o jsonpath='{.data\.dockerconfigjson}' | base64 -d`
6. Confirm previously failing pods pull successfully (no `ErrImagePull` / `insufficient_scope`).
7. Re-plan the paragon stack and confirm it does not destroy `docker_cfg_paragon_overlay` while credentials remain set.
8. Negative check: with blank docker username/password, confirm Terraform skips writing blank auths.

### QA Notes

AWS-only behavior change. Azure/GCP do not use this overlay pattern. Prefer validating against an AWS enterprise stack that uses ESO-backed docker-cfg.

### Deployment Notes

After applying, if the in-cluster secret is still stale, force an ExternalSecret sync (ESO docker refresh interval is 1h). No Spacelift context schema changes are required beyond ensuring docker credentials are non-empty where used.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Secrets Manager and cluster pull-secret behavior for AWS ESO paths; misconfiguration could still block image pulls until credentials are fixed and ESO syncs.
> 
> **Overview**
> Fixes **blank or whitespace-only** `TF_VAR_docker_username` / `TF_VAR_docker_password` being treated as set (only `!= null` was checked), which wrote unusable dockerconfigjson (`auth` for `:`) into Secrets Manager and broke private image pulls via ESO.
> 
> **Infra secrets**, **paragon runtime overlay**, and **non-ESO** `kubernetes_secret.docker_login` now trim/coalesce credentials and only write when both username and password are non-empty.
> 
> The **paragon `docker_cfg` overlay** no longer gates `count` on whether the secret already has `auths` (that caused the overlay to delete itself on the next plan and revert `AWSCURRENT` to an empty infra base). Overlay `count` depends only on whether this workspace has credentials. **Usable** base auths (non-blank username/password) are merged with this workspace’s registry entry so other registries stay intact.
> 
> `prepare.sh` chart version stamp bumps to **2026.08.17**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cb2c279e5681b29f4d4c4fbf31bad0575094fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->