### PR TITLE
fix(logging): fluent-bit startupProbe for DaemonSet cold starts (PARA-25197)

### DIFF
--- a/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
+++ b/charts/paragon-logging/charts/fluent-bit/templates/_pod.tpl
@@ -81,6 +81,10 @@ containers:
     lifecycle:
       {{- toYaml . | nindent 6 }}
   {{- end }}
+    {{- with .Values.startupProbe }}
+    startupProbe:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     livenessProbe:
       {{- toYaml .Values.livenessProbe | nindent 6 }}
     readinessProbe:

--- a/charts/paragon-logging/charts/fluent-bit/values.yaml
+++ b/charts/paragon-logging/charts/fluent-bit/values.yaml
@@ -186,11 +186,20 @@ lifecycle: {}
 #     exec:
 #       command: ["/bin/sh", "-c", "sleep 20"]
 
+# kubelet holds liveness/readiness until startup succeeds (cold start on node join).
+startupProbe:
+  httpGet:
+    path: /api/v1/health
+    port: http
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 18
+
 livenessProbe:
   httpGet:
     path: /
     port: http
-  initialDelaySeconds: 45
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3
@@ -199,7 +208,7 @@ readinessProbe:
   httpGet:
     path: /api/v1/health
     port: http
-  initialDelaySeconds: 30
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 3


### PR DESCRIPTION
### Issues Closed

- PARA-25197

### Brief Summary

fluent-bit startup probe for daemonset cold starts

### Detailed Summary

fluent-bit runs as a DaemonSet. On node join and scale-out, new pods do a cold start (config load, plugins, buffer warmup). Without a startupProbe, liveness and readiness can fail during that window and kubelet restarts the container.

This change adds an HTTP startupProbe on `/api/v1/health` with an ~3 minute allowance (`failureThreshold` 18 × `periodSeconds` 10). Kubelet does not run liveness or readiness until startup succeeds, so `initialDelaySeconds` on those probes is set to 0.

This does not change fluent-bit CPU or memory. Restart-alert grace in Better Stack / Grafana is out of scope; without that tune, scale-out can still page on expected restart counters.

### Changes

- Add `startupProbe` to the fluent-bit subchart values (HTTP `/api/v1/health`, ~3 min window)
- Render `startupProbe` from `_pod.tpl` when set
- Set liveness and readiness `initialDelaySeconds` to 0 (paths remain `/` and `/api/v1/health`)

### Unrelated Changes

None.

### Future Work

Tune the fluent-bit restart/readiness alert (Better Stack / Grafana) with extra grace on node-join / DaemonSet rollout so scale-out does not page on transient restarts.

Confirm no cluster `helm_values` fully override fluent-bit probe objects (Helm replaces the map, so a stale override would drop the new startupProbe).

### Steps to Test

- Cordon/uncordon a node or add a node
- Confirm the new fluent-bit pod becomes Ready without premature restarts
- `kubectl get pod -o yaml` on the DaemonSet: `startupProbe` present; liveness/readiness `initialDelaySeconds` is 0
- Confirm restart alerts do not fire during the startup window (only fully verifiable after the alert-side tune)

### QA Notes

No product/UI change. Logging chart only.

### Deployment Notes

Ships with the logging chart. No tfvars change required unless a workspace already overrides `fluent-bit.livenessProbe` / `readinessProbe` / `startupProbe` in `helm_values`.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm probe defaults only; no auth or data-path changes. Residual risk is stale helm_values fully overriding probe maps and dropping startupProbe.
> 
> **Overview**
> Stops kubelet from killing fluent-bit during DaemonSet cold starts (node join / scale-out) by adding an HTTP `startupProbe` on `/api/v1/health` (~3 minutes: 18 failures × 10s). Liveness and readiness stay gated until startup succeeds.
> 
> `initialDelaySeconds` on liveness and readiness is set to **0** (paths unchanged). Probe is optional in `_pod.tpl` (`{{- with .Values.startupProbe }}`). Helm map overrides of probe objects can still drop the new probe if a workspace fully replaces those values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 721c24fb0ed718b7c1be8aba6bb42a5a7a4fe542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->