### PR TITLE
feat: optional Azure Postgres and Redis in infra

### DIFF
--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -33,14 +33,14 @@ At least one must be `true`. Existing customers keep defaults (`redis_enabled = 
 | Output | When | Contents |
 |--------|------|----------|
 | `redis` | `redis_enabled = true` (even if managed is also enabled) | Legacy BSP endpoints — **unchanged contract for paragon** |
-| `redis` | `redis_enabled = false`, `redis_managed_enabled = true` | Managed Redis endpoints (post-cutover) |
+| `redis` | `redis_enabled = false` | `null` (legacy cache and `redis` secret are not created) |
 | `redis_managed` | `redis_managed_enabled = true` | Managed Redis endpoints for trial `kubectl` patching |
 
 ### Customer migration tfvars sequence
 
 1. **Baseline:** `redis_enabled = true`, `redis_managed_enabled = false`
 2. **Parallel deploy:** `redis_enabled = true`, `redis_managed_enabled = true` → apply creates Managed Redis; legacy keeps running; use `terraform output -json redis_managed` for new endpoints
-3. **After validation:** `redis_enabled = false`, `redis_managed_enabled = true` → apply destroys legacy; `output redis` switches to managed
+3. **After validation:** `redis_enabled = false`, `redis_managed_enabled = true` → apply destroys legacy cache and the `redis` secret; paragon reads `redis-managed`
 
 ### Azure Managed Redis tuning (all regions)
 

--- a/azure/workspaces/infra/README.md
+++ b/azure/workspaces/infra/README.md
@@ -26,7 +26,7 @@ Two optional backends can run independently or **in parallel** during customer m
 | `redis_enabled` | `true` | `./redis` (`azurerm_redis_cache`) | 6 |
 | `redis_managed_enabled` | `false` | `./redis-managed` (`azurerm_managed_redis`) | 7.4 (service default) |
 
-At least one must be `true`. Existing customers keep defaults (`redis_enabled = true`, `redis_managed_enabled = false`) for a no-op plan on Redis.
+Either flag may be `false`. If both are `false`, this workspace does not create Redis and does not write the `redis` or `redis-managed` Key Vault secrets; the paragon workspace then expects a customer-provided `redis` or `redis-managed` secret. Existing customers keep defaults (`redis_enabled = true`, `redis_managed_enabled = false`) for a no-op plan on Redis.
 
 ### Outputs during migration
 
@@ -231,6 +231,7 @@ nsg_malicious_ips = [
 | [azurerm_key_vault_secret.runtime_kafka](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.runtime_postgres](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.runtime_redis](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.runtime_redis_managed](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.runtime_storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
@@ -280,6 +281,7 @@ nsg_malicious_ips = [
 | <a name="input_organization"></a> [organization](#input\_organization) | Name of organization to include in resource names. | `string` | n/a | yes |
 | <a name="input_postgres_base_sku_name"></a> [postgres\_base\_sku\_name](#input\_postgres\_base\_sku\_name) | PostgreSQL SKU for secondary instances. Use GP\_Standard\_D2ads\_v5 for HA support. SKU availability may vary by Azure region. | `string` | `"B_Standard_B2s"` | no |
 | <a name="input_postgres_instances"></a> [postgres\_instances](#input\_postgres\_instances) | Per-instance PostgreSQL overrides. Each key is a logical name (cerberus, eventlogs, hermes, triggerkit, zeus, managed\_sync, paragon).<br/>Both sku and redundant must be set on each entry you include. Omitted keys use built-in defaults (no HA). Null uses defaults for all instances. | <pre>map(object({<br/>    sku       = string<br/>    redundant = bool<br/>  }))</pre> | `null` | no |
+| <a name="input_postgres_management_lock_enabled"></a> [postgres\_management\_lock\_enabled](#input\_postgres\_management\_lock\_enabled) | When true, apply Azure CanNotDelete management locks on Postgres Flexible Servers (opt-in). | `bool` | `false` | no |
 | <a name="input_postgres_multiple_instances"></a> [postgres\_multiple\_instances](#input\_postgres\_multiple\_instances) | Whether or not to create multiple Postgres instances. Used for higher volume installations. | `bool` | `true` | no |
 | <a name="input_postgres_sku_name"></a> [postgres\_sku\_name](#input\_postgres\_sku\_name) | PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`) | `string` | `"GP_Standard_D2ds_v5"` | no |
 | <a name="input_postgres_version"></a> [postgres\_version](#input\_postgres\_version) | PostgreSQL version (14, 15 or 16) | `string` | `"14"` | no |
@@ -310,7 +312,7 @@ nsg_malicious_ips = [
 | <a name="output_kafka"></a> [kafka](#output\_kafka) | Connection info for Kafka (Event Hubs for Kafka). |
 | <a name="output_logs_container"></a> [logs\_container](#output\_logs\_container) | The bucket used to store system logs. |
 | <a name="output_postgres"></a> [postgres](#output\_postgres) | Connection info for Postgres. |
-| <a name="output_redis"></a> [redis](#output\_redis) | Primary Redis connection info for the paragon workspace. During migration (both modules enabled), returns legacy endpoints until redis\_enabled is set to false. |
+| <a name="output_redis"></a> [redis](#output\_redis) | Connection info for installer-managed Azure Cache for Redis. Null when redis\_enabled is false. |
 | <a name="output_redis_managed"></a> [redis\_managed](#output\_redis\_managed) | Azure Managed Redis 7.4 endpoints (null when redis\_managed\_enabled is false). Use during migration for kubectl trial routing while output redis still points at legacy. |
 | <a name="output_redis_managed_export_storage"></a> [redis\_managed\_export\_storage](#output\_redis\_managed\_export\_storage) | Blob storage for on-demand Azure Managed Redis RDB export (null when disabled or legacy Redis). |
 | <a name="output_resource_group"></a> [resource\_group](#output\_resource\_group) | Resource Group that infrastructure was deployed to. |

--- a/azure/workspaces/infra/modules.tf
+++ b/azure/workspaces/infra/modules.tf
@@ -35,16 +35,17 @@ module "bastion" {
 }
 
 module "postgres" {
+  count  = var.postgres_enabled ? 1 : 0
   source = "./postgres"
 
-  instances                          = local.postgres_instances
-  postgres_management_lock_enabled   = var.postgres_management_lock_enabled
-  postgres_version                   = var.postgres_version
-  resource_group                     = module.network.resource_group
-  tags                               = local.default_tags
-  virtual_network                    = module.network.virtual_network
-  private_subnet                     = module.network.postgres_subnet
-  workspace                          = local.workspace
+  instances                        = local.postgres_instances
+  postgres_management_lock_enabled = var.postgres_management_lock_enabled
+  postgres_version                 = var.postgres_version
+  resource_group                   = module.network.resource_group
+  tags                             = local.default_tags
+  virtual_network                  = module.network.virtual_network
+  private_subnet                   = module.network.postgres_subnet
+  workspace                        = local.workspace
 }
 
 module "redis" {

--- a/azure/workspaces/infra/moved.tf
+++ b/azure/workspaces/infra/moved.tf
@@ -2,3 +2,23 @@ moved {
   from = module.bastion
   to   = module.bastion[0]
 }
+
+moved {
+  from = module.postgres
+  to   = module.postgres[0]
+}
+
+moved {
+  from = azurerm_key_vault_secret.runtime_postgres
+  to   = azurerm_key_vault_secret.runtime_postgres[0]
+}
+
+moved {
+  from = azurerm_key_vault_secret.runtime_redis
+  to   = azurerm_key_vault_secret.runtime_redis[0]
+}
+
+moved {
+  from = azurerm_key_vault_secret.runtime_redis_managed
+  to   = azurerm_key_vault_secret.runtime_redis_managed[0]
+}

--- a/azure/workspaces/infra/outputs.tf
+++ b/azure/workspaces/infra/outputs.tf
@@ -14,7 +14,7 @@ output "bastion" {
 
 output "postgres" {
   description = "Connection info for Postgres."
-  value       = module.postgres.postgres
+  value       = local.postgres_runtime
   sensitive   = true
 }
 
@@ -43,8 +43,8 @@ output "storage" {
 }
 
 output "redis" {
-  description = "Primary Redis connection info for the paragon workspace. During migration (both modules enabled), returns legacy endpoints until redis_enabled is set to false."
-  value       = var.redis_enabled ? module.redis.redis : module.redis_managed[0].redis
+  description = "Connection info for installer-managed Azure Cache for Redis. Null when redis_enabled is false."
+  value       = local.redis_runtime
   sensitive   = true
 }
 

--- a/azure/workspaces/infra/runtime_secrets.tf
+++ b/azure/workspaces/infra/runtime_secrets.tf
@@ -5,6 +5,9 @@ locals {
   # a hyphen. Truncating local.workspace to 24 chars can leave a trailing hyphen,
   # so strip any trailing hyphens after truncation.
   key_vault_name = replace(substr(local.workspace, 0, 24), "/-+$/", "")
+
+  postgres_runtime = var.postgres_enabled ? module.postgres[0].postgres : null
+  redis_runtime    = var.redis_enabled ? module.redis.redis : null
 }
 
 resource "azurerm_key_vault" "paragon" {
@@ -33,29 +36,35 @@ resource "azurerm_key_vault_access_policy" "terraform" {
 }
 
 resource "azurerm_key_vault_secret" "runtime_postgres" {
+  count = var.postgres_enabled ? 1 : 0
+
   name         = "postgres"
   key_vault_id = azurerm_key_vault.paragon.id
-  value        = jsonencode(module.postgres.postgres)
+  value        = jsonencode(local.postgres_runtime)
 
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }
 
 # Same contract as output.redis / output.redis_managed (and legacy infra-output.json):
-# - coexistence: redis = legacy, redis-managed = AMR
-# - cutover (legacy off): redis = AMR
+# - redis: Azure Cache for Redis when redis_enabled
+# - redis-managed: Azure Managed Redis when redis_managed_enabled
+# - coexistence: both secrets present; cutover: disable redis_enabled to remove the redis secret
 resource "azurerm_key_vault_secret" "runtime_redis" {
+  count = var.redis_enabled ? 1 : 0
+
   name         = "redis"
   key_vault_id = azurerm_key_vault.paragon.id
-  value        = jsonencode(var.redis_enabled ? module.redis.redis : module.redis_managed[0].redis)
+  value        = jsonencode(local.redis_runtime)
 
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }
 
 resource "azurerm_key_vault_secret" "runtime_redis_managed" {
+  count = var.redis_managed_enabled ? 1 : 0
+
   name         = "redis-managed"
   key_vault_id = azurerm_key_vault.paragon.id
-  # Always present so paragon KV handoff can resolve redis_managed (null when AMR disabled).
-  value        = jsonencode(var.redis_managed_enabled ? module.redis_managed[0].redis : null)
+  value        = jsonencode(module.redis_managed[0].redis)
 
   depends_on = [azurerm_key_vault_access_policy.terraform]
 }

--- a/azure/workspaces/infra/variables.tf
+++ b/azure/workspaces/infra/variables.tf
@@ -137,6 +137,13 @@ variable "cloudflare_tunnel_email_domain" {
 }
 
 # postgres
+# terraform-docs-ignore
+variable "postgres_enabled" {
+  description = "When false, skip creating Azure PostgreSQL Flexible Servers."
+  type        = bool
+  default     = true
+}
+
 variable "postgres_sku_name" {
   description = "PostgreSQL SKU name (e.g. `B_Standard_B2s` or `GP_Standard_D2ds_v5`)"
   type        = string
@@ -243,11 +250,6 @@ variable "redis_managed_enabled" {
   description = "Deploy Azure Managed Redis (Redis 7.4). When false, the redis-managed module is not created. May be true alongside redis_enabled during customer migration (both modules run in parallel)."
   type        = bool
   default     = false
-
-  validation {
-    condition     = var.redis_enabled || var.redis_managed_enabled
-    error_message = "At least one of redis_enabled or redis_managed_enabled must be true."
-  }
 }
 
 variable "redis_managed_instances" {

--- a/azure/workspaces/paragon/infra_secrets.tf
+++ b/azure/workspaces/paragon/infra_secrets.tf
@@ -10,6 +10,15 @@ data "azurerm_key_vault" "paragon" {
   resource_group_name = local.resource_group_name
 }
 
+data "azurerm_key_vault_secrets" "infra" {
+  count        = local.use_legacy_infra_json ? 0 : 1
+  key_vault_id = data.azurerm_key_vault.paragon.id
+}
+
+locals {
+  infra_secret_names = local.use_legacy_infra_json ? toset([]) : toset(data.azurerm_key_vault_secrets.infra[0].names)
+}
+
 data "azurerm_key_vault_secret" "infra_postgres" {
   count        = local.use_legacy_infra_json ? 0 : 1
   name         = "postgres"
@@ -17,13 +26,13 @@ data "azurerm_key_vault_secret" "infra_postgres" {
 }
 
 data "azurerm_key_vault_secret" "infra_redis" {
-  count        = local.use_legacy_infra_json ? 0 : 1
+  count        = local.use_legacy_infra_json ? 0 : (contains(local.infra_secret_names, "redis") ? 1 : 0)
   name         = "redis"
   key_vault_id = data.azurerm_key_vault.paragon.id
 }
 
 data "azurerm_key_vault_secret" "infra_redis_managed" {
-  count        = local.use_legacy_infra_json ? 0 : 1
+  count        = local.use_legacy_infra_json ? 0 : (contains(local.infra_secret_names, "redis-managed") ? 1 : 0)
   name         = "redis-managed"
   key_vault_id = data.azurerm_key_vault.paragon.id
 }
@@ -53,11 +62,22 @@ locals {
           location = data.azurerm_resource_group.infra[0].location
         }
       }
-      postgres      = { value = jsondecode(data.azurerm_key_vault_secret.infra_postgres[0].value) }
-      redis         = { value = jsondecode(data.azurerm_key_vault_secret.infra_redis[0].value) }
-      # Mirrors infra output redis_managed (null when AMR disabled / secret encodes null).
-      redis_managed = { value = jsondecode(data.azurerm_key_vault_secret.infra_redis_managed[0].value) }
-      storage       = { value = jsondecode(data.azurerm_key_vault_secret.infra_storage[0].value) }
+      postgres = { value = jsondecode(data.azurerm_key_vault_secret.infra_postgres[0].value) }
+      redis = {
+        value = (
+          length(data.azurerm_key_vault_secret.infra_redis) > 0
+          ? jsondecode(data.azurerm_key_vault_secret.infra_redis[0].value)
+          : (
+            length(data.azurerm_key_vault_secret.infra_redis_managed) > 0
+            ? jsondecode(data.azurerm_key_vault_secret.infra_redis_managed[0].value)
+            : null
+          )
+        )
+      }
+      redis_managed = {
+        value = length(data.azurerm_key_vault_secret.infra_redis_managed) > 0 ? jsondecode(data.azurerm_key_vault_secret.infra_redis_managed[0].value) : null
+      }
+      storage = { value = jsondecode(data.azurerm_key_vault_secret.infra_storage[0].value) }
     },
     var.managed_sync_enabled ? {
       kafka = { value = jsondecode(data.azurerm_key_vault_secret.infra_kafka[0].value) }

--- a/azure/workspaces/paragon/infra_secrets.tf
+++ b/azure/workspaces/paragon/infra_secrets.tf
@@ -64,15 +64,7 @@ locals {
       }
       postgres = { value = jsondecode(data.azurerm_key_vault_secret.infra_postgres[0].value) }
       redis = {
-        value = (
-          length(data.azurerm_key_vault_secret.infra_redis) > 0
-          ? jsondecode(data.azurerm_key_vault_secret.infra_redis[0].value)
-          : (
-            length(data.azurerm_key_vault_secret.infra_redis_managed) > 0
-            ? jsondecode(data.azurerm_key_vault_secret.infra_redis_managed[0].value)
-            : null
-          )
-        )
+        value = length(data.azurerm_key_vault_secret.infra_redis) > 0 ? jsondecode(data.azurerm_key_vault_secret.infra_redis[0].value) : null
       }
       redis_managed = {
         value = length(data.azurerm_key_vault_secret.infra_redis_managed) > 0 ? jsondecode(data.azurerm_key_vault_secret.infra_redis_managed[0].value) : null
@@ -84,5 +76,16 @@ locals {
     } : {}
   )
 
-  infra_vars = local.use_legacy_infra_json ? local.legacy_infra_vars : local.provider_infra_vars
+  # Helm still reads infra_vars.redis. After AMR cutover, installer Redis is
+  # gone (output redis / Key Vault `redis` are null) while redis_managed is set.
+  # Apply the same fallback for Key Vault and legacy infra_json.
+  infra_vars_source = local.use_legacy_infra_json ? local.legacy_infra_vars : local.provider_infra_vars
+  redis_from_infra = (
+    try(local.infra_vars_source.redis.value.cache.host, "") != ""
+    ? local.infra_vars_source.redis.value
+    : try(local.infra_vars_source.redis_managed.value, null)
+  )
+  infra_vars = merge(local.infra_vars_source, {
+    redis = { value = local.redis_from_infra }
+  })
 }

--- a/azure/workspaces/paragon/runtime_secrets.tf
+++ b/azure/workspaces/paragon/runtime_secrets.tf
@@ -23,7 +23,7 @@ resource "azurerm_key_vault_secret" "env" {
     }
     precondition {
       condition     = try(local.infra_vars.redis.value.cache.host, "") != ""
-      error_message = "Key Vault has neither a usable `redis` nor `redis-managed` secret with a cache.host. Create one of those secrets (same JSON shape as installer-managed Redis) before applying this workspace."
+      error_message = "Neither `redis` nor `redis-managed` has a usable cache.host. Provide one via Key Vault or infra_json (same JSON shape as installer-managed Redis) before applying this workspace."
     }
   }
 }

--- a/azure/workspaces/paragon/runtime_secrets.tf
+++ b/azure/workspaces/paragon/runtime_secrets.tf
@@ -21,6 +21,10 @@ resource "azurerm_key_vault_secret" "env" {
       condition     = length(local.helm_secret_values) > 0
       error_message = "Paragon env secret would be empty after chart secretKeys split. Confirm prepare.sh charts and infra-backed helm_values contain postgres/redis credentials."
     }
+    precondition {
+      condition     = try(local.infra_vars.redis.value.cache.host, "") != ""
+      error_message = "Key Vault has neither a usable `redis` nor `redis-managed` secret with a cache.host. Create one of those secrets (same JSON shape as installer-managed Redis) before applying this workspace."
+    }
   }
 }
 

--- a/azure/workspaces/paragon/variables.tf
+++ b/azure/workspaces/paragon/variables.tf
@@ -611,7 +611,7 @@ locals {
   # connection_string (host:port) while still exporting primary_access_key as
   # password — only include userinfo when connection_string has "@" (or is absent).
   redis_instance_urls = {
-    for name, r in try(local.infra_vars.redis.value, {}) : name => (
+    for name, r in coalesce(local.infra_vars.redis.value, {}) : name => (
       startswith(try(r.connection_string, ""), "redis://") || startswith(try(r.connection_string, ""), "rediss://")
       ? r.connection_string
       : format(

--- a/prepare.sh
+++ b/prepare.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # version of charts, must be semver and doesn't have to match Paragon appVersion
-version="2026.08.18"
+version="2026.08.24"
 
 # defaults
 provider="aws"


### PR DESCRIPTION
### Issues Closed

- PARA-25318

### Brief Summary

make azure postgres and redis optional

### Detailed Summary

Azure infra can skip creating PostgreSQL Flexible Server and Redis so a customer can run their own stores (for example geo-replicated endpoints). Connection details stay in Key Vault as `postgres` and `redis` (and `redis-managed` when Azure Managed Redis is used) so the paragon workspace still bakes Helm env from those secrets.

Defaults are unchanged: Postgres and legacy Redis still deploy. `postgres_enabled` is omitted from terraform-docs. Paragon fails with a clear error if neither Redis secret has a `cache.host`.

### Changes

- Add `postgres_enabled` (default true) and skip the Postgres module and `postgres` Key Vault secret when false
- Allow both `redis_enabled` and `redis_managed_enabled` to be false; each Redis Key Vault secret is created only when its flag is on
- Move existing module/secret addresses so default installs do not recreate resources
- Paragon reads Redis secrets if present and falls back from `redis` to `redis-managed`; require a usable `cache.host` before writing `env`
- Bump `prepare.sh` chart version to 2026.08.24

### Unrelated Changes

N/A

### Future Work

N/A

### Steps to Test

1. Default plan (`postgres_enabled` unset, `redis_enabled = true`): no destroy/recreate of Postgres or legacy Redis besides the one-time destroy of the unused `redis-managed` secret (previously JSON `null`) on existing stacks.
2. New workspace with `postgres_enabled = false`, `redis_enabled = false`, `redis_managed_enabled = false`: no Postgres/Redis resources; Key Vault still created.
3. Create `postgres` and `redis` secrets in that vault (JSON shape matching installer outputs, including `cache.host`), then apply paragon; confirm Helm env and ESO `paragon-secrets` receive the values.
4. Apply paragon without Redis secrets and confirm the `env` precondition error about `cache.host`.
5. AMR cutover (`redis_enabled = false`, `redis_managed_enabled = true`): legacy Redis and the `redis` secret are removed; paragon uses `redis-managed`.

### QA Notes

N/A

### Deployment Notes

Existing Azure infra applies will destroy the `redis-managed` Key Vault secret when Azure Managed Redis is off (it was always written as `null`). Soft-deleted names can be recovered or purged if they need to be recreated. If Postgres/Redis flags are turned off after those resources exist, Terraform will destroy the corresponding resources and secrets.

Customer-managed stores: set the flags on the infra stack, write `postgres`/`redis` before the first paragon apply. Fast failover still requires updating those secrets and `env` (see internal runbook); the next paragon apply rebuilds `env` from `postgres`/`redis`.

### Screenshots

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Terraform state addresses, Key Vault secret lifecycle (including destroying the old null `redis-managed` secret on existing stacks), and how Helm gets Redis credentials—misconfiguration can break paragon apply or cutover if secrets are missing.
> 
> **Overview**
> Azure **infra** can now skip provisioning PostgreSQL Flexible Server and Redis so customers can bring their own endpoints (e.g. geo-replicated stores). **`postgres_enabled`** (default `true`) gates the Postgres module and the `postgres` Key Vault secret; **`redis_enabled`** / **`redis_managed_enabled`** can both be `false`, in which case neither Redis stack nor the matching secrets are created.
> 
> **Redis contract changes:** `output redis` and the `redis` secret only reflect legacy Azure Cache for Redis—no longer aliasing Managed Redis after cutover. Each of `redis` and `redis-managed` secrets is created only when its flag is on (replacing the always-present `redis-managed` secret that encoded `null`). **`moved`** blocks keep default installs from recreating Postgres/Redis modules and secrets when switching to `count`.
> 
> **Paragon** lists Key Vault secret names and reads `redis` / `redis-managed` only if present, merges **`redis_managed` into `infra_vars.redis`** when legacy `cache.host` is empty (AMR cutover and customer secrets), adds a lifecycle **precondition** on the `env` secret requiring a usable `cache.host`, and uses **`coalesce`** for Redis URL building when values are null. Docs and **`prepare.sh`** chart version bump to **2026.08.24**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b227a8846a3047dc582f39909f3aca150f9a34e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->